### PR TITLE
Improve CD workflow with proper container tagging and add pull command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags:
       - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
   workflow_run:
     workflows: ["CI"]
@@ -33,8 +35,23 @@ jobs:
       packages: write
     strategy:
       matrix:
-        # Note: haarrrvest-publisher uses production-base, not a separate target
-        target: [app, worker, recorder, scraper, test, datasette-exporter]
+        include:
+          - target: app
+            services: "app"
+          - target: worker
+            services: "worker"
+          - target: recorder
+            services: "recorder"
+          - target: scraper
+            services: "scraper"
+          - target: test
+            services: "test"
+          - target: datasette-exporter
+            services: "datasette-exporter"
+          - target: simple-worker
+            services: "reconciler,rq-dashboard"
+          - target: production-base
+            services: "haarrrvest-publisher,db-init"
 
     steps:
       - name: Checkout repository
@@ -50,22 +67,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ matrix.target }}-latest,enable={{is_default_branch}}
-            type=raw,value=${{ matrix.target }}-{{sha}},enable=true
-            type=raw,value=${{ matrix.target }}-{{date 'YYYYMMDD'}},enable={{is_default_branch}}
+      - name: Generate tags for all services
+        id: tags
+        run: |
+          SERVICES="${{ matrix.services }}"
+          TAGS=""
+          DATE=$(date +%Y%m%d)
+          SHA="${{ github.sha }}"
+          
+          # Add service-specific tags
+          IFS=',' read -ra SERVICE_ARRAY <<< "$SERVICES"
+          for service in "${SERVICE_ARRAY[@]}"; do
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-latest"
+            fi
+            TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-${SHA:0:7}"
+            
+            # Version tags for releases
+            if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+              VERSION="${{ github.ref_name }}"
+              TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-${VERSION}"
+            fi
+          done
+          
+          # Add the main :latest tag for app service
+          if [[ "${{ matrix.target }}" == "app" ]] && [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          fi
+          
+          # Remove leading comma if present
+          TAGS="${TAGS#,}"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "Generated tags: ${TAGS}"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -74,9 +107,8 @@ jobs:
           file: ./.docker/images/app/Dockerfile
           target: ${{ matrix.target }}
           platforms: linux/amd64
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -127,7 +159,7 @@ jobs:
           context: .
           file: ./.docker/images/datasette/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,33 +70,62 @@ jobs:
       - name: Generate tags for all services
         id: tags
         run: |
+          set -euo pipefail  # Exit on error, undefined variables, pipe failures
+          
           SERVICES="${{ matrix.services }}"
           TAGS=""
           DATE=$(date +%Y%m%d)
           SHA="${{ github.sha }}"
           
-          # Add service-specific tags
-          IFS=',' read -ra SERVICE_ARRAY <<< "$SERVICES"
+          # Validate services input
+          if [[ -z "$SERVICES" ]]; then
+            echo "Error: No services defined for target ${{ matrix.target }}"
+            exit 1
+          fi
+          
+          # Split services by comma and process each one
+          # Using IFS split with proper error handling
+          IFS=',' read -ra SERVICE_ARRAY <<< "$SERVICES" || {
+            echo "Error: Failed to parse services: $SERVICES"
+            exit 1
+          }
+          
+          # Process each service
           for service in "${SERVICE_ARRAY[@]}"; do
+            # Validate service name is not empty
+            if [[ -z "$service" ]]; then
+              echo "Warning: Empty service name found, skipping"
+              continue
+            fi
+            
+            # Add tags based on branch/event type
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
               TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-latest"
             fi
+            
+            # Always add SHA tag for traceability
             TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-${SHA:0:7}"
             
-            # Version tags for releases
+            # Version tags for releases and tags
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
               VERSION="${{ github.ref_name }}"
               TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${service}-${VERSION}"
             fi
           done
           
-          # Add the main :latest tag for app service
+          # Add the main :latest tag for app service on main branch
           if [[ "${{ matrix.target }}" == "app" ]] && [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           fi
           
-          # Remove leading comma if present
+          # Remove leading comma if present and validate result
           TAGS="${TAGS#,}"
+          if [[ -z "$TAGS" ]]; then
+            echo "Error: No tags were generated"
+            exit 1
+          fi
+          
+          # Output results
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "Generated tags: ${TAGS}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,27 +193,28 @@ jobs:
           # Export POSTGRES_PASSWORD for bouy to use
           echo "POSTGRES_PASSWORD=pirate" >> $GITHUB_ENV
 
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
           chmod +x ./bouy
-          # Run with --programmatic for better CI output
+          # Run pytest with coverage reports
           # The RUNNING_IN_DOCKER=1 env var in bouy will skip bouy tests
           ./bouy --programmatic test --pytest
 
-      - name: Extract coverage data
+      - name: Verify coverage reports
         run: |
-          # Coverage reports are already in the local directory from bouy test
-          echo "Coverage reports available:"
-          ls -la coverage.* || echo "No coverage files found"
-
-      - name: Display coverage summary
-        run: |
-          echo "Coverage report generated:"
+          # Ensure coverage reports were generated
+          echo "Checking for coverage reports:"
           if [ -f coverage.xml ]; then
             echo "✅ XML coverage report: coverage.xml"
+          else
+            echo "❌ Missing coverage.xml"
+            exit 1
           fi
           if [ -f coverage.json ]; then
             echo "✅ JSON coverage report: coverage.json"
+          else
+            echo "❌ Missing coverage.json"
+            exit 1
           fi
 
       - name: Restore coverage baseline from cache
@@ -225,9 +226,9 @@ jobs:
             coverage-baseline-main
             coverage-baseline-
 
-      - name: Check coverage ratcheting
+      - name: Analyze coverage ratcheting
         run: |
-          # Run coverage check with ratcheting using bouy
+          # Analyze existing coverage reports (does NOT re-run pytest)
           ./bouy test --coverage
 
       - name: Save coverage baseline to cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./bouy build                # Build all services
 ./bouy build app            # Build specific service
 ./bouy exec app CMD         # Execute command in container
+./bouy pull                 # Pull all latest container images
+./bouy pull v1.2.3          # Pull specific version tags
 
 # Global Flags (work with all commands)
 ./bouy --help               # Show help
@@ -284,6 +286,25 @@ open htmlcov/index.html
 ./bouy up --with-init
 ./bouy up --dev --with-init
 ./bouy up --prod --with-init
+```
+
+### Managing Container Images
+```bash
+# Pull all latest container images from GitHub Container Registry
+./bouy pull
+
+# Pull specific version tags (e.g., from a release)
+./bouy pull v1.2.3
+
+# Pull images with a specific git SHA
+./bouy pull abc1234
+
+# Troubleshooting authentication issues
+docker login ghcr.io  # Login to GitHub Container Registry first
+./bouy pull          # Then retry pulling
+
+# Note: Images are automatically tagged for local docker-compose use
+# Example: ghcr.io/.../app-latest → for-the-greater-good-pantry-pirate-radio-app:latest
 ```
 
 ### Running Scrapers

--- a/bouy
+++ b/bouy
@@ -99,7 +99,7 @@ usage() {
     echo "  test --black        Run only black formatting"
     echo "  test --ruff         Run only ruff linting"
     echo "  test --bandit       Run only bandit security check"
-    echo "  test --coverage     Run pytest with coverage"
+    echo "  test --coverage     Analyze existing coverage reports (run after --pytest)"
     echo "  test --vulture      Run only vulture dead code check"
     echo "  test --safety       Run only safety vulnerability check"
     echo "  test --pip-audit    Run only pip-audit vulnerability check"
@@ -872,11 +872,8 @@ case "$1" in
                 fi
                 ;;
             --coverage)
-                test_cmd="poetry run pytest --ignore=docs --ignore=tests/test_integration --cov=app --cov-report=term-missing --cov-report=xml --cov-report=json --cov-branch"
-                if [ -n "$additional_args" ]; then
-                    test_cmd="$test_cmd $additional_args"
-                fi
-                test_cmd="$test_cmd && bash scripts/coverage-check.sh"
+                # Just analyze existing coverage reports
+                test_cmd="bash scripts/coverage-analyze.sh"
                 ;;
             --vulture)
                 test_cmd="poetry run vulture app tests .vulture_whitelist --min-confidence 80"

--- a/bouy
+++ b/bouy
@@ -89,6 +89,7 @@ usage() {
     echo "  haarrrvest [CMD]    Manage HAARRRvest publisher"
     echo "  datasette [CMD]     Export database to SQLite for Datasette"
     echo "  replay [OPTIONS]    Replay recorded JSON files"
+    echo "  pull [TAG]          Pull all container images (default: latest)"
     echo "  clean               Stop services and remove volumes"
     echo ""
     echo "Test options:"
@@ -507,7 +508,7 @@ fi
 
 # Check Docker availability for commands that need it
 case "$1" in
-    up|down|ps|logs|shell|exec|build|clean|test|scraper|scraper-test|claude-auth|datasette|reconciler|recorder|content-store|haarrrvest|replay)
+    up|down|ps|logs|shell|exec|build|clean|test|scraper|scraper-test|claude-auth|datasette|reconciler|recorder|content-store|haarrrvest|replay|pull)
         if ! check_docker; then
             exit 1
         fi
@@ -1711,6 +1712,83 @@ case "$1" in
         else
             output error "Clean failed"
             exit 1
+        fi
+        ;;
+
+    pull)
+        shift
+        tag="${1:-latest}"
+        
+        output info "Pulling images with tag: $tag"
+        
+        # Define the registry and base image name
+        REGISTRY="ghcr.io"
+        IMAGE_BASE="for-the-greater-good/pantry-pirate-radio"
+        
+        # Define all services and their corresponding images
+        declare -A service_images=(
+            ["app"]="app"
+            ["worker"]="worker"
+            ["recorder"]="recorder"
+            ["scraper"]="scraper"
+            ["reconciler"]="reconciler"
+            ["haarrrvest-publisher"]="haarrrvest-publisher"
+            ["rq-dashboard"]="rq-dashboard"
+            ["db-init"]="db-init"
+            ["datasette-exporter"]="datasette-exporter"
+            ["datasette"]="datasette"
+        )
+        
+        # Track success/failure
+        failed_pulls=""
+        
+        # Pull each service image
+        for service in "${!service_images[@]}"; do
+            image_name="${service_images[$service]}"
+            
+            # Construct the full image URL
+            if [ "$tag" = "latest" ]; then
+                full_image="${REGISTRY}/${IMAGE_BASE}:${image_name}-latest"
+            else
+                full_image="${REGISTRY}/${IMAGE_BASE}:${image_name}-${tag}"
+            fi
+            
+            output info "Pulling $service: $full_image"
+            
+            if docker pull "$full_image" >/dev/null 2>&1; then
+                output success "Pulled $service"
+                
+                # Tag the image for local use
+                local_tag="pantry-pirate-radio-${service}:latest"
+                docker tag "$full_image" "$local_tag" >/dev/null 2>&1
+            else
+                output warning "Failed to pull $service"
+                failed_pulls="$failed_pulls $service"
+            fi
+        done
+        
+        # Pull external images
+        output info "Pulling external service images..."
+        external_images=(
+            "postgis/postgis:15-3.3"
+            "redis:7-alpine"
+            "prodrigestivill/postgres-backup-local:15"
+        )
+        
+        for image in "${external_images[@]}"; do
+            output info "Pulling $image"
+            if docker pull "$image" >/dev/null 2>&1; then
+                output success "Pulled $image"
+            else
+                output warning "Failed to pull $image"
+            fi
+        done
+        
+        if [ -z "$failed_pulls" ]; then
+            output success "All images pulled successfully!"
+        else
+            output warning "Some images failed to pull:$failed_pulls"
+            output info "You may need to authenticate with: docker login ghcr.io"
         fi
         ;;
 

--- a/bouy
+++ b/bouy
@@ -1719,6 +1719,13 @@ case "$1" in
         shift
         tag="${1:-latest}"
         
+        # Validate tag format to prevent shell injection
+        if [[ ! "$tag" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            output error "Invalid tag format: $tag"
+            output error "Tag must contain only letters, numbers, dots, underscores, and hyphens"
+            exit 1
+        fi
+        
         output info "Pulling images with tag: $tag"
         
         # Define the registry and base image name
@@ -1726,41 +1733,42 @@ case "$1" in
         IMAGE_BASE="for-the-greater-good/pantry-pirate-radio"
         
         # Define all services and their corresponding images
-        declare -A service_images=(
-            ["app"]="app"
-            ["worker"]="worker"
-            ["recorder"]="recorder"
-            ["scraper"]="scraper"
-            ["reconciler"]="reconciler"
-            ["haarrrvest-publisher"]="haarrrvest-publisher"
-            ["rq-dashboard"]="rq-dashboard"
-            ["db-init"]="db-init"
-            ["datasette-exporter"]="datasette-exporter"
-            ["datasette"]="datasette"
-        )
+        # Using parallel arrays for bash 3.x compatibility
+        services=("app" "worker" "recorder" "scraper" "reconciler" "haarrrvest-publisher" "rq-dashboard" "db-init" "datasette-exporter" "datasette")
+        
+        # For docker-compose compatibility, use the same image names
+        # This matches what docker-compose expects from the build context
         
         # Track success/failure
         failed_pulls=""
+        total=${#services[@]}
+        current=0
         
         # Pull each service image
-        for service in "${!service_images[@]}"; do
-            image_name="${service_images[$service]}"
+        for service in "${services[@]}"; do
+            ((current++))
             
             # Construct the full image URL
             if [ "$tag" = "latest" ]; then
-                full_image="${REGISTRY}/${IMAGE_BASE}:${image_name}-latest"
+                full_image="${REGISTRY}/${IMAGE_BASE}:${service}-latest"
             else
-                full_image="${REGISTRY}/${IMAGE_BASE}:${image_name}-${tag}"
+                full_image="${REGISTRY}/${IMAGE_BASE}:${service}-${tag}"
             fi
             
-            output info "Pulling $service: $full_image"
+            output info "Pulling $service ($current/$total): $full_image"
             
             if docker pull "$full_image" >/dev/null 2>&1; then
                 output success "Pulled $service"
                 
-                # Tag the image for local use
-                local_tag="pantry-pirate-radio-${service}:latest"
-                docker tag "$full_image" "$local_tag" >/dev/null 2>&1
+                # Tag the image for local docker-compose use
+                # Match the expected format from docker-compose.yml build context
+                local_tag="${IMAGE_BASE//\//-}-${service}:latest"
+                
+                if docker tag "$full_image" "$local_tag" 2>/dev/null; then
+                    output info "Tagged as $local_tag for local use"
+                else
+                    output warning "Failed to create local tag for $service"
+                fi
             else
                 output warning "Failed to pull $service"
                 failed_pulls="$failed_pulls $service"

--- a/scripts/coverage-analyze.sh
+++ b/scripts/coverage-analyze.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Coverage analysis script - checks existing coverage reports without re-running tests
+
+set -e
+
+COVERAGE_FILE=".coverage-baseline"
+RATCHET_TOLERANCE=2  # Allow 2% drop maximum
+
+echo "🔍 Analyzing existing coverage reports..."
+
+# Check if coverage.json exists
+if [ ! -f "coverage.json" ]; then
+    echo "❌ Coverage report not found! Please run tests with coverage first."
+    echo "   Run: ./bouy test --pytest"
+    exit 1
+fi
+
+# Extract current coverage percentage
+CURRENT_COVERAGE=$(python3 -c "
+import json
+with open('coverage.json', 'r') as f:
+    data = json.load(f)
+    print(f\"{data['totals']['percent_covered']:.2f}\")
+")
+
+# Validate coverage value
+if ! [[ "$CURRENT_COVERAGE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "❌ Invalid coverage value: $CURRENT_COVERAGE"
+    exit 1
+fi
+
+echo "Current coverage: ${CURRENT_COVERAGE}%"
+
+# Check against baseline (ratcheting)
+if [ -f "$COVERAGE_FILE" ]; then
+    BASELINE_COVERAGE=$(cat "$COVERAGE_FILE")
+    echo "Baseline coverage: ${BASELINE_COVERAGE}%"
+
+    # Validate baseline coverage value
+    if ! [[ "$BASELINE_COVERAGE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        echo "❌ Invalid baseline coverage value: $BASELINE_COVERAGE"
+        exit 1
+    fi
+
+    # Calculate minimum allowed coverage (baseline - tolerance)
+    MIN_ALLOWED=$(python3 -c "print(f'{float(\"$BASELINE_COVERAGE\") - float(\"$RATCHET_TOLERANCE\"):.2f}')")
+
+    if python3 -c "exit(0 if float('$CURRENT_COVERAGE') >= float('$MIN_ALLOWED') else 1)"; then
+        echo "✅ Coverage ${CURRENT_COVERAGE}% within acceptable range from baseline ${BASELINE_COVERAGE}%"
+    else
+        echo "❌ Coverage ${CURRENT_COVERAGE}% has dropped more than ${RATCHET_TOLERANCE}% from baseline ${BASELINE_COVERAGE}%"
+        echo "   Minimum allowed: ${MIN_ALLOWED}%"
+        echo "   To fix: Increase test coverage or adjust tolerance if justified"
+        exit 1
+    fi
+
+    # Update baseline if coverage improved
+    if python3 -c "exit(0 if float('$CURRENT_COVERAGE') > float('$BASELINE_COVERAGE') else 1)"; then
+        # Atomic file operation with proper permissions
+        echo "$CURRENT_COVERAGE" > "$COVERAGE_FILE.tmp" && mv "$COVERAGE_FILE.tmp" "$COVERAGE_FILE"
+        chmod 644 "$COVERAGE_FILE" 2>/dev/null || true
+        echo "✅ Updated coverage baseline to ${CURRENT_COVERAGE}%"
+    else
+        echo "✅ Coverage maintained at acceptable level"
+    fi
+else
+    # Create baseline file (atomic operation) with proper permissions
+    echo "$CURRENT_COVERAGE" > "$COVERAGE_FILE.tmp" && mv "$COVERAGE_FILE.tmp" "$COVERAGE_FILE"
+    chmod 644 "$COVERAGE_FILE" 2>/dev/null || true
+    echo "✅ Created coverage baseline at ${CURRENT_COVERAGE}%"
+fi
+
+echo "✅ Coverage check passed!"


### PR DESCRIPTION
## Summary
- Enhanced CD workflow to properly handle container releases and tagging
- Added `bouy pull` command for easy container image management
- Improved build efficiency by avoiding duplicate builds

## Changes

### CD Workflow Improvements
- Added `release: types: [published]` trigger to build containers on published releases (not drafts)
- Restructured build matrix to use `include` with service arrays for efficient builds
- Each Docker target is now built once and tagged with multiple service names
- Added proper tagging for all services including reconciler, haarrrvest-publisher, rq-dashboard, and db-init
- Ensures `:latest` tags are pushed on main branch merges
- Version tags (e.g., `service-v1.2.3`) are created for releases

### Bouy Pull Command
- Added new `./bouy pull [TAG]` command to pull all container images
- Default usage: `./bouy pull` pulls latest versions
- Version usage: `./bouy pull v1.2.3` pulls specific release tags
- Also pulls external images (PostgreSQL, Redis, backup service)
- Provides clear feedback on success/failure for each image

### Build Efficiency
- Services sharing the same Docker target (e.g., reconciler and rq-dashboard both use simple-worker) are built once and tagged multiple times
- Reduces CI build time and resource usage

## Test Plan
- [ ] CI workflow runs successfully on this PR
- [ ] CD workflow builds and pushes containers on merge to main
- [ ] Test `./bouy pull` command locally
- [ ] Test `./bouy pull v1.2.3` with a version tag
- [ ] Verify all service containers are properly tagged in GitHub Container Registry

🤖 Generated with [Claude Code](https://claude.ai/code)