### PR TITLE
fix: correct env file paths in Docker compose configuration

### DIFF
--- a/.docker/compose/base.yml
+++ b/.docker/compose/base.yml
@@ -7,7 +7,7 @@ services:
       target: app
     ports:
       - "8000:8000"
-    env_file: .env
+    env_file: ../../.env
     # All environment variables are loaded from .env file
     # Override specific values as needed for your environment
     depends_on:
@@ -24,7 +24,7 @@ services:
     command: rq worker llm
     ports:
       - "8080-8089:8080"  # Claude health check port range for scaling
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Worker-specific overrides
       - CLAUDE_HEALTH_SERVER=true
@@ -44,7 +44,7 @@ services:
       context: ../..
       dockerfile: .docker/images/app/Dockerfile
       target: recorder
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Recorder-specific paths
       - OUTPUT_DIR=/app/outputs
@@ -65,7 +65,7 @@ services:
       dockerfile: .docker/images/app/Dockerfile
       target: scraper
     command: tail -f /dev/null  # Keep container running
-    env_file: .env
+    env_file: ../../.env
     # All environment variables are loaded from .env file
     depends_on:
       db:
@@ -82,7 +82,7 @@ services:
       dockerfile: .docker/images/app/Dockerfile
       target: simple-worker
     command: rq worker reconciler
-    env_file: .env
+    env_file: ../../.env
     # All environment variables are loaded from .env file
     depends_on:
       db:
@@ -96,7 +96,7 @@ services:
       dockerfile: .docker/images/app/Dockerfile
       target: production-base
     command: python -m app.haarrrvest_publisher.service
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Publisher-specific paths and defaults
       - OUTPUT_DIR=/app/outputs
@@ -121,7 +121,7 @@ services:
 
   db:
     image: postgis/postgis:15-3.3
-    env_file: .env
+    env_file: ../../.env
     # Database credentials loaded from .env file
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -140,7 +140,7 @@ services:
       dockerfile: .docker/images/app/Dockerfile
       target: production-base
     command: /app/scripts/init-database.sh
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Database connection overrides for init
       - POSTGRES_HOST=db
@@ -184,7 +184,7 @@ services:
     command: rq-dashboard -H cache
     ports:
       - "9181:9181"
-    env_file: .env
+    env_file: ../../.env
     # Redis URL loaded from .env file
     depends_on:
       - cache
@@ -194,7 +194,7 @@ services:
       context: ../..
       dockerfile: .docker/images/app/Dockerfile
       target: datasette-exporter
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Datasette exporter specific settings
       - OUTPUT_DIR=/data
@@ -223,7 +223,7 @@ services:
 
   db-backup:
     image: prodrigestivill/postgres-backup-local:15
-    env_file: .env
+    env_file: ../../.env
     environment:
       # Backup specific configuration
       - POSTGRES_HOST=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,0 @@
-.docker/compose/base.yml


### PR DESCRIPTION
## Summary
- Fixes "env file not found" error when running `bouy` commands
- Updates Docker Compose configuration to use correct relative paths for `.env` file
- Removes problematic `docker-compose.yml` symlink

## Problem
When running `./bouy up`, Docker Compose was looking for the `.env` file in the wrong location (`/Users/bryanmoran/code/.env` instead of the project root). This was caused by:
1. The `env_file` directive in `base.yml` using `.env` instead of a relative path
2. The `docker-compose.yml` symlink causing path resolution issues

## Solution
1. Updated all `env_file: .env` references in `base.yml` to `env_file: ../../.env` 
2. Removed the `docker-compose.yml` symlink (bouy correctly finds `.docker/compose/base.yml` without it)

## Test Plan
- [x] Run `./bouy ps` - should list services without errors
- [x] Run `./bouy up app` - should start app service without "env file not found" error
- [x] Run `./bouy down` - should stop services cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)