### PR TITLE
Fix rq-dashboard deprecated options and add dashboard navigation

### DIFF
--- a/.docker/compose/base.yml
+++ b/.docker/compose/base.yml
@@ -202,7 +202,7 @@ services:
       context: ../..
       dockerfile: .docker/images/app/Dockerfile
       target: simple-worker
-    command: rq-dashboard -H cache
+    command: rq-dashboard -u redis://cache:6379
     ports:
       - "9181:9181"
     env_file: ../../.env

--- a/.docker/compose/docker-compose.prod.yml
+++ b/.docker/compose/docker-compose.prod.yml
@@ -93,7 +93,7 @@ services:
 
   rq-dashboard:
     image: ${DOCKER_REGISTRY:-ghcr.io/for-the-greater-good/pantry-pirate-radio}:worker-${DOCKER_TAG:-latest}
-    command: rq-dashboard -H cache
+    command: rq-dashboard -u redis://cache:6379
     # NO PORTS EXPOSED - access via SSH tunnel: ssh -L 9181:rq-dashboard:9181 user@server
     env_file: .env
     environment:

--- a/app/content_store/dashboard.py
+++ b/app/content_store/dashboard.py
@@ -135,6 +135,39 @@ DASHBOARD_TEMPLATE = """
             background-color: #10b981;
             transition: width 0.3s ease;
         }
+        nav {
+            background-color: #1f2937;
+            padding: 10px 0;
+            margin: -20px -20px 20px -20px;
+        }
+        nav ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            gap: 20px;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+        nav li {
+            display: inline;
+        }
+        nav a {
+            color: #9ca3af;
+            text-decoration: none;
+            padding: 5px 10px;
+            border-radius: 4px;
+            transition: all 0.2s;
+        }
+        nav a:hover {
+            color: white;
+            background-color: #374151;
+        }
+        nav a.active {
+            color: white;
+            background-color: #2563eb;
+        }
     </style>
     <script>
         function refreshData() {
@@ -180,6 +213,13 @@ DASHBOARD_TEMPLATE = """
     </script>
 </head>
 <body>
+    <nav>
+        <ul>
+            <li><a href="#" class="active">Content Store</a></li>
+            <li><a href="http://localhost:9181" target="_blank">RQ Dashboard</a></li>
+            <li><a href="http://localhost:8000/docs" target="_blank">API Docs</a></li>
+        </ul>
+    </nav>
     <div class="container">
         <h1>Content Store Dashboard</h1>
 

--- a/tests/test_llm/test_geocoding_integration.py
+++ b/tests/test_llm/test_geocoding_integration.py
@@ -356,7 +356,6 @@ class TestEndToEndGeographicValidation:
             usage={"prompt_tokens": 100, "completion_tokens": 200, "total_tokens": 300},
         )
 
-
         job = LLMJob(
             id="test-job-123",
             prompt="Test prompt",
@@ -461,7 +460,6 @@ class TestEndToEndGeographicValidation:
             model="test-model",
             usage={"prompt_tokens": 50, "completion_tokens": 100, "total_tokens": 150},
         )
-
 
         job = LLMJob(
             id="test-job-456",


### PR DESCRIPTION
## Summary
- Fixed deprecation warning in rq-dashboard by updating to modern syntax
- Added navigation links between monitoring dashboards for better UX
- Resolved the error message: "You are using deprecated options, pay attention to --help or readme.md to update your settings\!"

## Changes
- Updated rq-dashboard command from `-H cache` to `-u redis://cache:6379` in both Docker Compose files
- Added navigation bar to Content Store Dashboard with links to RQ Dashboard and API Docs
- Improved integration between the monitoring tools

## Test plan
- [x] Started services with `./bouy up`
- [x] Verified rq-dashboard runs without deprecation warnings
- [x] Confirmed navigation links work in Content Store Dashboard
- [x] Tested that both dashboards are accessible and functional

🤖 Generated with [Claude Code](https://claude.ai/code)