### PR TITLE
feat: stricter confidence scoring — build-up model with 90 cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -664,7 +664,8 @@ routing is entirely infrastructure (CDK env var override for `SQS_QUEUE_URL`).
 - **HAARRRvest Publisher**: Syncs processed data to public repository
 
 #### Data Validation Pipeline
-- **Confidence Scoring**: Evaluates data quality on 0-100 scale
+- **Confidence Scoring**: Build-up model — scraped data starts at base 60, earns bonuses for completeness. Capped at 90 for scraped data; only human corrections (Tightbeam) reach 91-100.
+- **Source Corroboration**: Locations confirmed by multiple scrapers receive +5 (2 sources) or +10 (3+ sources) bonus, applied during reconciliation.
 - **Enrichment**: Enhances incomplete data using geocoding services
 - **Rejection**: Filters out test data and low-quality records
 - **Caching**: Redis-based caching for performance optimization
@@ -790,11 +791,12 @@ Plugin CDK stacks are discovered automatically from `plugin.yml` → `infra.stac
 ## Recent Updates and Features
 
 ### Data Validation Pipeline (Latest - Issues #362-#369)
-- **Confidence Scoring System**: All locations scored 0-100 for quality assessment
+- **Confidence Scoring System**: Build-up model — base score of 60, bonuses for data completeness (address +5, description +3, geocoder quality +5, phone/hours/website +3 each). Hard cap at 90 for scraped data; 100 reserved for human corrections via Tightbeam.
+- **Source Corroboration**: Multi-scraper confirmation boosts scores (+5 for 2 sources, +10 for 3+), applied during reconciliation merge.
 - **Automated Data Enrichment**: Enhances incomplete data using geocoding services
 - **Quality Rejection**: Automatically rejects test addresses and placeholder data
 - **Redis-Based Service**: Distributed validation with caching for performance
-- **Configurable Thresholds**: Customizable rejection threshold (default: 30)
+- **Configurable Thresholds**: Customizable rejection threshold (default: 10)
 
 ### Geocoding Improvements
 - **0,0 Coordinate Detection**: Automatic detection and correction of invalid (0,0) coordinates

--- a/app/reconciler/location_creator.py
+++ b/app/reconciler/location_creator.py
@@ -507,9 +507,26 @@ class LocationCreator(BaseReconciler):
                 )
                 self.db.commit()
 
+            # Fetch current confidence score for source corroboration
+            current_score_query = text(
+                "SELECT confidence_score FROM location WHERE id = :id"
+            )
+            current_score_result = self.db.execute(
+                current_score_query, {"id": location_id}
+            )
+            current_score_row = current_score_result.first()
+            current_confidence = current_score_row[0] if current_score_row else None
+
             # Merge source records to update canonical record
             merge_strategy = MergeStrategy(self.db)
-            merge_strategy.merge_location(location_id)
+            updated_score = merge_strategy.merge_location(
+                location_id, current_confidence
+            )
+            if updated_score is not None:
+                self.logger.info(
+                    f"Source corroboration bonus applied: "
+                    f"score={updated_score} for location {location_id}"
+                )
 
         return location_id, is_new
 

--- a/app/reconciler/merge_strategy.py
+++ b/app/reconciler/merge_strategy.py
@@ -133,11 +133,17 @@ class MergeStrategy(BaseReconciler):
                 )
                 return {}
 
-    def merge_location(self, location_id: str) -> None:
+    def merge_location(
+        self, location_id: str, current_confidence_score: int | None = None
+    ) -> int | None:
         """Merge source-specific location records into a canonical record.
 
         Args:
             location_id: ID of the canonical location
+            current_confidence_score: Current confidence score for source corroboration
+
+        Returns:
+            Updated confidence score if source bonus applied, None otherwise
         """
         # Get all source records for this location
         query = text(
@@ -162,7 +168,7 @@ class MergeStrategy(BaseReconciler):
 
         if not rows:
             self.logger.warning(f"No source records found for location {location_id}")
-            return
+            return None
 
         # Debug logging to understand what we're getting
         self.logger.debug(f"Query returned {len(rows)} rows for location {location_id}")
@@ -218,16 +224,34 @@ class MergeStrategy(BaseReconciler):
 
             if not fallback_row:
                 self.logger.error(f"Could not find location with ID {location_id}")
-                return
+                return None
 
             # Use the location record as is - no merging needed
             self.logger.info(
                 f"Using existing location record for {location_id} without merging"
             )
-            return
+            return None
 
         # Apply merging strategy to create canonical record
         merged_data = self._merge_location_data(valid_records)
+
+        # Source corroboration: count distinct scrapers and apply bonus
+        updated_score = None
+        if current_confidence_score is not None:
+            distinct_scrapers = len(
+                set(r.get("scraper_id") for r in valid_records if r.get("scraper_id"))
+            )
+            if distinct_scrapers > 1:
+                from app.validator.scoring import ConfidenceScorer
+
+                scorer = ConfidenceScorer()
+                updated_score = scorer.apply_source_corroboration(
+                    current_confidence_score, distinct_scrapers
+                )
+                self.logger.info(
+                    f"Source corroboration: {distinct_scrapers} scrapers, "
+                    f"score {current_confidence_score} -> {updated_score}"
+                )
 
         # Update canonical record
         update_query = text(
@@ -238,7 +262,14 @@ class MergeStrategy(BaseReconciler):
             description = :description,
             latitude = :latitude,
             longitude = :longitude,
-            is_canonical = TRUE
+            is_canonical = TRUE,
+            confidence_score = COALESCE(:confidence_score, confidence_score),
+            validation_status = CASE
+                WHEN :confidence_score IS NOT NULL AND :confidence_score >= 80 THEN 'verified'
+                WHEN :confidence_score IS NOT NULL AND :confidence_score >= 10 THEN 'needs_review'
+                WHEN :confidence_score IS NOT NULL THEN 'rejected'
+                ELSE validation_status
+            END
         WHERE id = :id
         """
         )
@@ -251,6 +282,7 @@ class MergeStrategy(BaseReconciler):
                 "description": merged_data["description"],
                 "latitude": merged_data["latitude"],
                 "longitude": merged_data["longitude"],
+                "confidence_score": updated_score,
             },
         )
         self.db.commit()
@@ -258,6 +290,8 @@ class MergeStrategy(BaseReconciler):
         self.logger.info(
             f"Merged {len(valid_records)} source records for location {location_id}"
         )
+
+        return updated_score
 
     def _merge_location_data(
         self, source_records: list[dict[str, Any]]

--- a/app/validator/job_processor.py
+++ b/app/validator/job_processor.py
@@ -573,6 +573,12 @@ class ValidationProcessor:
             location_scores = []
             total_locations = len(data[locations_key])
 
+            # Collect service-level signals for scoring annotations
+            # These are transient metadata (underscore-prefixed), NOT HSDS fields
+            services = data.get("service", data.get("services", []))
+            phones = data.get("phone", data.get("phones", []))
+            schedules = data.get("schedule", data.get("schedules", []))
+
             for location in data[locations_key]:
                 # Handle locations that couldn't be enriched due to service failure
                 if location.get("enrichment_failed"):
@@ -592,6 +598,17 @@ class ValidationProcessor:
                         f"confidence={confidence_score}, status=needs_review (enrichment failed)"
                     )
                     continue
+
+                # Annotate location with service-level richness signals
+                location["_has_phone"] = bool(phones) or any(
+                    s.get("phones") or s.get("phone") for s in services
+                )
+                location["_has_schedule"] = bool(schedules) or any(
+                    s.get("schedules") or s.get("schedule") for s in services
+                )
+                location["_has_website"] = any(s.get("url") for s in services) or bool(
+                    location.get("url")
+                )
 
                 # Run validation rules
                 validation_results = validator.validate_location(location)

--- a/app/validator/scoring.py
+++ b/app/validator/scoring.py
@@ -1,13 +1,26 @@
-"""Confidence scoring for validated location data."""
+"""Confidence scoring for validated location data — build-up model.
+
+Scraped data starts at a base score and earns points for quality signals.
+Hard cap of 90 for scraped data; only human corrections (Tightbeam) reach 91-100.
+"""
 
 import logging
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
+# Scoring constants
+BASE_SCORE = 60
+SCRAPED_DATA_CAP = 90
+
 
 class ConfidenceScorer:
-    """Calculate confidence scores for location data after validation."""
+    """Calculate confidence scores for location data after validation.
+
+    Uses a build-up model: scraped data starts at BASE_SCORE (60) and earns
+    points for completeness, geocoding quality, and service-level richness.
+    Penalties still apply for quality issues. Score capped at SCRAPED_DATA_CAP (90).
+    """
 
     def __init__(self, config: Dict[str, Any] = None):
         """Initialize the confidence scorer.
@@ -28,107 +41,115 @@ class ConfidenceScorer:
     ) -> int:
         """Calculate confidence score based on validation results.
 
-        This method assumes geocoding enrichment has already been performed.
-        Missing coordinates after enrichment results in immediate rejection (score 0).
+        Uses a build-up model: start at base score (60) and add bonuses
+        for data quality signals. Penalize for issues. Cap at 90.
 
         Args:
             location: Location data dictionary
             validation_results: Results from validation rules
 
         Returns:
-            Confidence score from 0-100
+            Confidence score from 0-90 (scraped data cap)
         """
         # CRITICAL FAILURES - Return immediately
 
         # No coordinates after enrichment = automatic rejection
         if not validation_results.get("has_coordinates", False):
             logger.debug(
-                f"Location {location.get('name', 'unknown')}: No coordinates after enrichment, score=0"
+                f"Location {location.get('name', 'unknown')}: "
+                "No coordinates after enrichment, score=0"
             )
             return 0
 
         # 0,0 or near-zero coordinates = automatic rejection
         if validation_results.get("is_zero_coordinates", False):
             logger.debug(
-                f"Location {location.get('name', 'unknown')}: Zero/near-zero coordinates, score=0"
+                f"Location {location.get('name', 'unknown')}: "
+                "Zero/near-zero coordinates, score=0"
             )
             return 0
 
         # Outside US bounds = almost reject (score 5)
         if not validation_results.get("within_us_bounds", False):
             logger.debug(
-                f"Location {location.get('name', 'unknown')}: Outside US bounds, score=5"
+                f"Location {location.get('name', 'unknown')}: "
+                "Outside US bounds, score=5"
             )
             return 5
 
         # Test data detected = almost reject (score 5)
         if validation_results.get("is_test_data", False):
             logger.debug(
-                f"Location {location.get('name', 'unknown')}: Test data detected, score=5"
+                f"Location {location.get('name', 'unknown')}: "
+                "Test data detected, score=5"
             )
             return 5
 
-        # Start with perfect score and deduct for issues
-        score = 100
+        # BUILD-UP MODEL: Start at base and earn points
+        score = BASE_SCORE
 
-        # MAJOR DEDUCTIONS
+        # COMPLETENESS BONUSES
 
-        # Placeholder address (-75 points)
-        if validation_results.get("has_placeholder_address", False):
-            score -= 75
-            logger.debug(
-                f"Location {location.get('name', 'unknown')}: Placeholder address detected, -75 points"
-            )
+        # Full address: street + city + state + postal code (+5)
+        if self._has_full_address(location):
+            score += 5
 
-        # Wrong state (-20 points)
-        if not validation_results.get("within_state_bounds", True):
-            score -= 20
-            logger.debug(
-                f"Location {location.get('name', 'unknown')}: Outside claimed state bounds, -20 points"
-            )
+        # Meaningful description (+3)
+        if self._has_meaningful_description(location):
+            score += 3
 
-        # GEOCODING QUALITY DEDUCTIONS
+        # GEOCODING QUALITY
 
         geocoding_source = location.get("geocoding_source", "").lower()
         geocoding_confidence = validation_results.get("geocoding_confidence", "unknown")
 
-        # Census geocoder is less reliable (-10 points)
-        if geocoding_source == "census":
-            score -= 10
-            logger.debug(
-                f"Location {location.get('name', 'unknown')}: Census geocoder used, -10 points"
-            )
-
-        # Fallback geocoding (state centroid, etc.) (-15 points)
-        if (
-            geocoding_source in ["state_centroid", "fallback"]
+        # High-quality geocoder bonus (+5)
+        if geocoding_source in (
+            "arcgis",
+            "google",
+            "amazon-location",
+            "amazon_location",
+        ):
+            score += 5
+        # Census geocoder penalty (-5)
+        elif geocoding_source == "census":
+            score -= 5
+        # Fallback geocoding penalty (-10)
+        elif (
+            geocoding_source in ("state_centroid", "fallback")
             or geocoding_confidence == "fallback"
         ):
-            score -= 15
-            logger.debug(
-                f"Location {location.get('name', 'unknown')}: Fallback geocoding used, -15 points"
-            )
-
-        # MINOR DEDUCTIONS
-
-        # Missing postal code after enrichment (-5 points)
-        if validation_results.get("missing_postal", False) or not location.get(
-            "postal_code"
-        ):
-            score -= 5
-            logger.debug(
-                f"Location {location.get('name', 'unknown')}: Missing postal code, -5 points"
-            )
-
-        # Missing city after enrichment (-10 points)
-        if validation_results.get("missing_city", False) or not location.get("city"):
             score -= 10
+
+        # SERVICE-LEVEL RICHNESS (transient scoring annotations, NOT HSDS fields)
+
+        if location.get("_has_phone"):
+            score += 3
+        if location.get("_has_schedule"):
+            score += 3
+        if location.get("_has_website"):
+            score += 3
+
+        # QUALITY PENALTIES
+
+        # Placeholder address (-75)
+        if validation_results.get("has_placeholder_address", False):
+            score -= 75
             logger.debug(
-                f"Location {location.get('name', 'unknown')}: Missing city, -10 points"
+                f"Location {location.get('name', 'unknown')}: "
+                "Placeholder address detected, -75 points"
             )
 
-        # Clamp score to 0-100 range
-        final_score = max(0, min(100, score))
+        # Wrong state (-20)
+        if not validation_results.get("within_state_bounds", True):
+            score -= 20
+            logger.debug(
+                f"Location {location.get('name', 'unknown')}: "
+                "Outside claimed state bounds, -20 points"
+            )
+
+        # Clamp to [0, SCRAPED_DATA_CAP]
+        final_score = max(0, min(SCRAPED_DATA_CAP, score))
 
         logger.info(
             f"Location {location.get('name', 'unknown')}: "
@@ -137,6 +158,40 @@ class ConfidenceScorer:
         )
 
         return final_score
+
+    def _has_full_address(self, location: Dict[str, Any]) -> bool:
+        """Check if location has a complete address (all 4 components)."""
+        address = location.get("address_1") or location.get("address") or ""
+        city = location.get("city") or ""
+        state = location.get("state_province") or location.get("state") or ""
+        postal = location.get("postal_code") or ""
+        return bool(address and city and state and postal)
+
+    def _has_meaningful_description(self, location: Dict[str, Any]) -> bool:
+        """Check if location has a meaningful description (>10 chars)."""
+        description = location.get("description") or ""
+        return len(description.strip()) > 10
+
+    def apply_source_corroboration(self, base_score: int, source_count: int) -> int:
+        """Apply source corroboration bonus based on number of distinct scrapers.
+
+        Args:
+            base_score: Current confidence score
+            source_count: Number of distinct scrapers confirming this location
+
+        Returns:
+            Updated score with corroboration bonus, capped at SCRAPED_DATA_CAP
+        """
+        if source_count <= 1:
+            return base_score
+
+        # +5 for 2 sources, +10 for 3+ (capped)
+        if source_count == 2:
+            bonus = 5
+        else:
+            bonus = 10
+
+        return min(base_score + bonus, SCRAPED_DATA_CAP)
 
     def get_validation_status(self, confidence_score: int) -> str:
         """Determine validation status based on confidence score.
@@ -169,17 +224,14 @@ class ConfidenceScorer:
             Organization confidence score from 0-100
         """
         if not location_scores:
-            # No locations means we can't validate the organization
             return 0
 
-        # Calculate average, weighted towards lower scores
-        # (one bad location affects the whole organization)
         avg_score = sum(location_scores) / len(location_scores)
         min_score = min(location_scores)
 
         # If any location is rejected, heavily penalize the organization
         if min_score < self.rejection_threshold:
-            org_score = min(avg_score, 50)  # Cap at 50 if any location is rejected
+            org_score = min(avg_score, 50)
         else:
             org_score = avg_score
 
@@ -197,11 +249,8 @@ class ConfidenceScorer:
         Returns:
             Service confidence score from 0-100
         """
-        # Services inherit their location's confidence
-        # with a small penalty if service data is incomplete
         score = location_score
 
-        # Deduct for missing service details
         if not service_data.get("name"):
             score -= 5
         if not service_data.get("description"):

--- a/tests/test_reconciler/test_location_creator.py
+++ b/tests/test_reconciler/test_location_creator.py
@@ -426,8 +426,10 @@ def test_process_location_existing(
         # Verify version was NOT created for existing location
         mock_tracker_instance.create_version.assert_not_called()
 
-        # Verify merge was called
-        mock_merge_instance.merge_location.assert_called_once_with(test_uuid)
+        # Verify merge was called with location_id and confidence score
+        mock_merge_instance.merge_location.assert_called_once()
+        merge_call_args = mock_merge_instance.merge_location.call_args
+        assert merge_call_args[0][0] == test_uuid
 
         # Verify result
         assert location_id == test_uuid
@@ -473,15 +475,18 @@ def test_process_location_with_organization_id(
         # Verify source was created
         mock_create_source.assert_called_once()
 
-        # Verify organization ID update was called
-        mock_db.execute.assert_called_once()
-        call_args = mock_db.execute.call_args
-        assert isinstance(call_args[0][0], TextClause)
-        assert call_args[0][1]["id"] == test_uuid
-        assert call_args[0][1]["organization_id"] == org_id
+        # Verify db.execute called for org_id update + confidence score query
+        assert mock_db.execute.call_count == 2
+        # First call: organization ID update
+        org_call_args = mock_db.execute.call_args_list[0]
+        assert isinstance(org_call_args[0][0], TextClause)
+        assert org_call_args[0][1]["id"] == test_uuid
+        assert org_call_args[0][1]["organization_id"] == org_id
 
-        # Verify merge was called
-        mock_merge_instance.merge_location.assert_called_once_with(test_uuid)
+        # Verify merge was called with location_id and confidence score
+        mock_merge_instance.merge_location.assert_called_once()
+        merge_call_args = mock_merge_instance.merge_location.call_args
+        assert merge_call_args[0][0] == test_uuid
 
         # Verify result
         assert location_id == test_uuid

--- a/tests/test_reconciler/test_merge_strategy.py
+++ b/tests/test_reconciler/test_merge_strategy.py
@@ -419,3 +419,96 @@ def test_merge_organization_conversion_error(mock_db: MagicMock) -> None:
     # Should call execute twice (original query + fallback query) and handle error gracefully
     assert mock_db.execute.call_count == 2
     mock_db.commit.assert_not_called()
+
+
+# ========================================
+# Source Corroboration Tests
+# ========================================
+
+
+def test_merge_location_with_multi_source_confidence_bonus(
+    mock_db: MagicMock, test_location_sources: List[Dict[str, str]]
+) -> None:
+    """Test that merge_location applies source corroboration bonus for multi-source locations."""
+    merge_strategy = MergeStrategy(mock_db)
+    location_id = str(uuid.uuid4())
+
+    # Mock the database query to return 3 sources (3 distinct scrapers)
+    mock_result = MagicMock()
+    mock_result.fetchall.return_value = test_location_sources
+    mock_db.execute.return_value = mock_result
+
+    # Call merge with a confidence score
+    updated_score = merge_strategy.merge_location(
+        location_id, current_confidence_score=73
+    )
+
+    # 3 distinct scrapers should give +10 bonus: 73 + 10 = 83
+    assert updated_score == 83
+
+
+def test_merge_location_confidence_caps_at_90(
+    mock_db: MagicMock, test_location_sources: List[Dict[str, str]]
+) -> None:
+    """Test that source corroboration bonus doesn't exceed scraped data cap of 90."""
+    merge_strategy = MergeStrategy(mock_db)
+    location_id = str(uuid.uuid4())
+
+    mock_result = MagicMock()
+    mock_result.fetchall.return_value = test_location_sources
+    mock_db.execute.return_value = mock_result
+
+    # High base score + bonus should still cap at 90
+    updated_score = merge_strategy.merge_location(
+        location_id, current_confidence_score=85
+    )
+
+    assert updated_score == 90
+
+
+def test_merge_location_single_source_no_bonus(mock_db: MagicMock) -> None:
+    """Test that single-source locations get no corroboration bonus."""
+    merge_strategy = MergeStrategy(mock_db)
+    location_id = str(uuid.uuid4())
+
+    # Single source record
+    single_source = [
+        {
+            "id": "source1",
+            "scraper_id": "scraper1",
+            "name": "Location 1",
+            "description": "Description",
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+        },
+    ]
+
+    mock_result = MagicMock()
+    mock_result.fetchall.return_value = single_source
+    mock_db.execute.return_value = mock_result
+
+    updated_score = merge_strategy.merge_location(
+        location_id, current_confidence_score=73
+    )
+
+    # Single source: no bonus
+    assert updated_score is None
+
+
+def test_merge_location_no_confidence_score_returns_none(
+    mock_db: MagicMock, test_location_sources: List[Dict[str, str]]
+) -> None:
+    """Test that merge_location without confidence score returns None."""
+    merge_strategy = MergeStrategy(mock_db)
+    location_id = str(uuid.uuid4())
+
+    mock_result = MagicMock()
+    mock_result.fetchall.return_value = test_location_sources
+    mock_db.execute.return_value = mock_result
+
+    # No confidence score passed (backward compat)
+    updated_score = merge_strategy.merge_location(location_id)
+
+    assert updated_score is None

--- a/tests/test_validator/test_scoring.py
+++ b/tests/test_validator/test_scoring.py
@@ -1,4 +1,4 @@
-"""Tests for confidence scoring algorithm."""
+"""Tests for confidence scoring algorithm — build-up model."""
 
 import pytest
 from typing import Dict, Any
@@ -13,41 +13,48 @@ class TestConfidenceScorer:
         """Set up test fixtures."""
         self.scorer = ConfidenceScorer()
 
-        # Base location with good data (should score high)
+        # Good location with full address and description (arcgis geocoded)
         self.good_location = {
             "name": "Community Food Bank",
             "latitude": 40.7128,
             "longitude": -74.0060,
-            "address": "123 Real Street",
+            "address_1": "123 Real Street",
             "city": "New York",
-            "state": "NY",
+            "state_province": "NY",
             "postal_code": "10001",
+            "description": "A community food bank serving the greater NYC area",
             "geocoding_source": "arcgis",
         }
 
-        # Location missing coordinates after enrichment (should score 0)
+        # Bare minimum location (coordinates + name only, no bonuses)
+        self.bare_location = {
+            "name": "Food Pantry",
+            "latitude": 40.7128,
+            "longitude": -74.0060,
+        }
+
+        # Location missing coordinates after enrichment
         self.no_coords_location = {
             "name": "Food Pantry",
             "latitude": None,
             "longitude": None,
-            "address": "456 Main St",
+            "address_1": "456 Main St",
             "city": "Brooklyn",
-            "state": "NY",
+            "state_province": "NY",
         }
 
-        # Location with 0,0 coordinates (should score 0)
+        # Location with 0,0 coordinates
         self.zero_coords_location = {
             "name": "Food Bank",
             "latitude": 0.0,
             "longitude": 0.0,
-            "address": "789 Oak Ave",
+            "address_1": "789 Oak Ave",
             "city": "Queens",
-            "state": "NY",
+            "state_province": "NY",
         }
 
-    def test_perfect_score_location(self):
-        """Test location with all valid data scores 100."""
-        validation_results = {
+        # Good validation results (no issues)
+        self.good_validation = {
             "has_coordinates": True,
             "is_zero_coordinates": False,
             "within_us_bounds": True,
@@ -57,11 +64,12 @@ class TestConfidenceScorer:
             "geocoding_confidence": "high",
         }
 
-        score = self.scorer.calculate_score(self.good_location, validation_results)
-        assert score == 100
+    # ========================================
+    # Critical Failures (unchanged)
+    # ========================================
 
     def test_missing_coordinates_scores_zero(self):
-        """Test location without coordinates after enrichment scores 0."""
+        """Location without coordinates after enrichment scores 0."""
         validation_results = {
             "has_coordinates": False,
             "is_zero_coordinates": False,
@@ -71,12 +79,11 @@ class TestConfidenceScorer:
             "has_placeholder_address": False,
             "geocoding_confidence": "failed",
         }
-
         score = self.scorer.calculate_score(self.no_coords_location, validation_results)
         assert score == 0
 
     def test_zero_coordinates_scores_zero(self):
-        """Test location with 0,0 coordinates scores 0."""
+        """Location with 0,0 coordinates scores 0."""
         validation_results = {
             "has_coordinates": True,
             "is_zero_coordinates": True,
@@ -86,307 +93,393 @@ class TestConfidenceScorer:
             "has_placeholder_address": False,
             "geocoding_confidence": "low",
         }
-
         score = self.scorer.calculate_score(
             self.zero_coords_location, validation_results
         )
         assert score == 0
 
     def test_outside_us_bounds_scores_five(self):
-        """Test location outside US bounds scores 5."""
+        """Location outside US bounds scores 5."""
         location = {
             **self.good_location,
             "latitude": 51.5074,  # London
             "longitude": -0.1276,
         }
         validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
+            **self.good_validation,
             "within_us_bounds": False,
             "within_state_bounds": False,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
         }
-
         score = self.scorer.calculate_score(location, validation_results)
         assert score == 5
 
     def test_test_data_scores_five(self):
-        """Test location identified as test data scores 5."""
+        """Location identified as test data scores 5."""
         location = {
             **self.good_location,
             "name": "Test Food Bank",
-            "address": "123 Test Street",
+            "address_1": "123 Test Street",
             "city": "Anytown",
             "postal_code": "00000",
         }
         validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
+            **self.good_validation,
             "is_test_data": True,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
         }
-
         score = self.scorer.calculate_score(location, validation_results)
         assert score == 5
 
-    def test_placeholder_address_deducts_75_points(self):
-        """Test placeholder address reduces score by 75 points."""
+    # ========================================
+    # Base Score
+    # ========================================
+
+    def test_base_score_is_60(self):
+        """Bare minimum valid location (coords + name only) gets base score of 60."""
+        score = self.scorer.calculate_score(self.bare_location, self.good_validation)
+        assert score == 60
+
+    # ========================================
+    # Completeness Bonuses
+    # ========================================
+
+    def test_full_address_bonus(self):
+        """Full address (street + city + state + zip) adds +5."""
+        location = {
+            **self.bare_location,
+            "address_1": "123 Real Street",
+            "city": "New York",
+            "state_province": "NY",
+            "postal_code": "10001",
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + full address 5 = 65
+        assert score == 65
+
+    def test_description_bonus(self):
+        """Meaningful description (>10 chars) adds +3."""
+        location = {
+            **self.bare_location,
+            "description": "A community food bank serving the greater area",
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + description 3 = 63
+        assert score == 63
+
+    def test_short_description_no_bonus(self):
+        """Short description (<=10 chars) gets no bonus."""
+        location = {
+            **self.bare_location,
+            "description": "Food bank",
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 60
+
+    def test_high_quality_geocoder_bonus(self):
+        """High-quality geocoder (arcgis/google/amazon-location) adds +5."""
+        location = {
+            **self.bare_location,
+            "geocoding_source": "arcgis",
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + geocoder 5 = 65
+        assert score == 65
+
+    def test_nominatim_no_bonus_no_penalty(self):
+        """Nominatim geocoder gets neither bonus nor penalty."""
+        location = {
+            **self.bare_location,
+            "geocoding_source": "nominatim",
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 only
+        assert score == 60
+
+    def test_service_phone_bonus(self):
+        """Service-level phone annotation adds +3."""
+        location = {
+            **self.bare_location,
+            "_has_phone": True,
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + phone 3 = 63
+        assert score == 63
+
+    def test_service_schedule_bonus(self):
+        """Service-level schedule annotation adds +3."""
+        location = {
+            **self.bare_location,
+            "_has_schedule": True,
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + schedule 3 = 63
+        assert score == 63
+
+    def test_service_website_bonus(self):
+        """Service-level website annotation adds +3."""
+        location = {
+            **self.bare_location,
+            "_has_website": True,
+        }
+        score = self.scorer.calculate_score(location, self.good_validation)
+        # base 60 + website 3 = 63
+        assert score == 63
+
+    # ========================================
+    # Combined Score — Good Location
+    # ========================================
+
+    def test_good_location_scores_73(self):
+        """Good location with full addr + desc + arcgis scores 73."""
+        # good_location has: full address, description, arcgis geocoder
+        # base 60 + addr 5 + desc 3 + geocoder 5 = 73
+        score = self.scorer.calculate_score(self.good_location, self.good_validation)
+        assert score == 73
+
+    def test_full_data_single_source_scores_82(self):
+        """Location with all completeness bonuses scores 82."""
         location = {
             **self.good_location,
-            "address": "123 Main Street",  # Generic placeholder
+            "_has_phone": True,
+            "_has_schedule": True,
+            "_has_website": True,
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": True,
-            "geocoding_confidence": "high",
-        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 + phone 3 + schedule 3 + website 3 = 82
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 82
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 25  # 100 - 75
+    # ========================================
+    # Geocoding Penalties
+    # ========================================
 
-    def test_wrong_state_deducts_20_points(self):
-        """Test coordinates outside claimed state reduces score by 20."""
-        location = {
-            **self.good_location,
-            "state": "CA",  # Claims California but coords are in NY
-        }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": False,  # Not in claimed state
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
-        }
-
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 80  # 100 - 20
-
-    def test_census_geocoder_deducts_10_points(self):
-        """Test Census geocoder source reduces score by 10."""
+    def test_census_geocoder_penalty(self):
+        """Census geocoder deducts 5 points."""
         location = {
             **self.good_location,
             "geocoding_source": "census",
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "medium",
-        }
+        # base 60 + addr 5 + desc 3 + census -5 = 63
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 63
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 90  # 100 - 10
-
-    def test_fallback_geocoding_deducts_15_points(self):
-        """Test fallback geocoding (state centroid) reduces score by 15."""
+    def test_fallback_geocoding_penalty(self):
+        """Fallback geocoding (state centroid) deducts 10 points."""
         location = {
             **self.good_location,
             "geocoding_source": "state_centroid",
         }
         validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
+            **self.good_validation,
             "geocoding_confidence": "fallback",
         }
-
+        # base 60 + addr 5 + desc 3 - 10 = 58
         score = self.scorer.calculate_score(location, validation_results)
-        assert score == 85  # 100 - 15
+        assert score == 58
 
-    def test_missing_postal_deducts_5_points(self):
-        """Test missing postal code reduces score by 5."""
+    # ========================================
+    # Quality Penalties
+    # ========================================
+
+    def test_placeholder_address_scores_zero(self):
+        """Placeholder address penalty (-75) usually results in rejection."""
+        location = {
+            **self.good_location,
+            "address_1": "123 Main Street",  # Generic placeholder
+        }
+        validation_results = {
+            **self.good_validation,
+            "has_placeholder_address": True,
+        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 - 75 = -2 -> clamped to 0
+        score = self.scorer.calculate_score(location, validation_results)
+        assert score == 0
+
+    def test_wrong_state_penalty(self):
+        """Coordinates outside claimed state deducts 20 points."""
+        location = {
+            **self.good_location,
+            "state_province": "CA",  # Claims California but coords are in NY
+        }
+        validation_results = {
+            **self.good_validation,
+            "within_state_bounds": False,
+        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 - 20 = 53
+        score = self.scorer.calculate_score(location, validation_results)
+        assert score == 53
+
+    # ========================================
+    # Missing Address Components
+    # ========================================
+
+    def test_missing_postal_no_full_address_bonus(self):
+        """Missing postal code means no full address bonus."""
         location = {
             **self.good_location,
             "postal_code": None,
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
-            "missing_postal": True,
-        }
+        # base 60 + desc 3 + geocoder 5 = 68 (no full addr bonus)
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 68
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 95  # 100 - 5
-
-    def test_missing_city_deducts_10_points(self):
-        """Test missing city reduces score by 10."""
+    def test_missing_city_no_full_address_bonus(self):
+        """Missing city means no full address bonus."""
         location = {
             **self.good_location,
             "city": None,
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
-            "missing_city": True,
-        }
+        # base 60 + desc 3 + geocoder 5 = 68 (no full addr bonus)
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 68
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 90  # 100 - 10
+    # ========================================
+    # Score Capping
+    # ========================================
 
-    def test_multiple_deductions_stack(self):
-        """Test multiple quality issues stack deductions."""
+    def test_max_scraped_score_capped_at_90(self):
+        """Even with all bonuses, scraped data can't exceed 90."""
         location = {
             **self.good_location,
-            "address": "123 Main Street",  # Placeholder (-75)
-            "state": "CA",  # Wrong state (-20)
-            "geocoding_source": "census",  # Less reliable (-10)
-            "postal_code": None,  # Missing postal (-5)
+            "_has_phone": True,
+            "_has_schedule": True,
+            "_has_website": True,
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": False,
-            "is_test_data": False,
-            "has_placeholder_address": True,
-            "geocoding_confidence": "medium",
-            "missing_postal": True,
-        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 + phone 3 + sched 3 + web 3 = 82
+        # 82 < 90, so not capped. But let's verify the cap with source corroboration
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score <= 90
 
-        score = self.scorer.calculate_score(location, validation_results)
-        # 100 - 75 - 20 - 10 - 5 = -10, but should be clamped to 0
-        assert score == 0
+    def test_score_never_exceeds_90_for_scraped(self):
+        """Score is clamped to maximum of 90 for scraped data."""
+        score = self.scorer.calculate_score(self.good_location, self.good_validation)
+        assert score <= 90
 
     def test_score_never_negative(self):
-        """Test score is clamped to minimum of 0."""
+        """Score is clamped to minimum of 0."""
         location = {
             **self.good_location,
-            "address": "123 Main Street",  # -75
-            "state": "CA",  # -20
-            "city": None,  # -10
-            "postal_code": None,  # -5
-            "geocoding_source": "fallback",  # -15
+            "address_1": "123 Main Street",  # placeholder
+            "state_province": "CA",  # wrong state
+            "geocoding_source": "fallback",
         }
         validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
+            **self.good_validation,
             "within_state_bounds": False,
-            "is_test_data": False,
             "has_placeholder_address": True,
             "geocoding_confidence": "fallback",
-            "missing_postal": True,
-            "missing_city": True,
         }
-
         score = self.scorer.calculate_score(location, validation_results)
-        assert score == 0  # Should be 0, not negative
+        assert score == 0
 
-    def test_score_never_exceeds_100(self):
-        """Test score is clamped to maximum of 100."""
-        # Even with perfect data, score should not exceed 100
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
+    # ========================================
+    # Stacked Deductions
+    # ========================================
+
+    def test_multiple_deductions_stack(self):
+        """Multiple quality issues stack deductions."""
+        location = {
+            **self.good_location,
+            "address_1": "123 Main Street",  # Placeholder (-75)
+            "state_province": "CA",  # Wrong state (-20)
+            "geocoding_source": "census",  # Census (-5)
         }
+        validation_results = {
+            **self.good_validation,
+            "within_state_bounds": False,
+            "has_placeholder_address": True,
+        }
+        # base 60 + addr 5 + desc 3 - 5 - 75 - 20 = -32 -> clamped to 0
+        score = self.scorer.calculate_score(location, validation_results)
+        assert score == 0
 
-        score = self.scorer.calculate_score(self.good_location, validation_results)
-        assert score == 100
+    # ========================================
+    # Geographic Edge Cases
+    # ========================================
 
-    def test_alaska_location_scores_high(self):
-        """Test valid Alaska location scores appropriately."""
+    def test_alaska_location_scores_appropriately(self):
+        """Valid Alaska location scores based on build-up model."""
         location = {
             **self.good_location,
             "latitude": 61.2181,  # Anchorage
             "longitude": -149.9003,
-            "state": "AK",
+            "state_province": "AK",
             "city": "Anchorage",
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,  # Should handle Alaska
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
-        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 = 73
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 73
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 100
-
-    def test_hawaii_location_scores_high(self):
-        """Test valid Hawaii location scores appropriately."""
+    def test_hawaii_location_scores_appropriately(self):
+        """Valid Hawaii location scores based on build-up model."""
         location = {
             **self.good_location,
             "latitude": 21.3099,  # Honolulu
             "longitude": -157.8581,
-            "state": "HI",
+            "state_province": "HI",
             "city": "Honolulu",
         }
-        validation_results = {
-            "has_coordinates": True,
-            "is_zero_coordinates": False,
-            "within_us_bounds": True,  # Should handle Hawaii
-            "within_state_bounds": True,
-            "is_test_data": False,
-            "has_placeholder_address": False,
-            "geocoding_confidence": "high",
-        }
+        # base 60 + addr 5 + desc 3 + geocoder 5 = 73
+        score = self.scorer.calculate_score(location, self.good_validation)
+        assert score == 73
 
-        score = self.scorer.calculate_score(location, validation_results)
-        assert score == 100
+    # ========================================
+    # Validation Status
+    # ========================================
 
     def test_get_validation_status_verified(self):
-        """Test status is 'verified' for high confidence scores."""
-        assert self.scorer.get_validation_status(100) == "verified"
+        """Status is 'verified' for scores >= 80."""
         assert self.scorer.get_validation_status(90) == "verified"
         assert self.scorer.get_validation_status(80) == "verified"
 
     def test_get_validation_status_needs_review(self):
-        """Test status is 'needs_review' for medium confidence scores."""
+        """Status is 'needs_review' for scores >= threshold and < 80."""
         assert self.scorer.get_validation_status(79) == "needs_review"
         assert self.scorer.get_validation_status(50) == "needs_review"
         assert self.scorer.get_validation_status(10) == "needs_review"
 
     def test_get_validation_status_rejected(self):
-        """Test status is 'rejected' for low confidence scores."""
+        """Status is 'rejected' for scores below threshold."""
         assert self.scorer.get_validation_status(9) == "rejected"
         assert self.scorer.get_validation_status(5) == "rejected"
         assert self.scorer.get_validation_status(0) == "rejected"
 
+    # ========================================
+    # Source Corroboration
+    # ========================================
+
+    def test_source_corroboration_2_sources(self):
+        """Two distinct sources add +5 bonus."""
+        result = self.scorer.apply_source_corroboration(73, 2)
+        assert result == 78
+
+    def test_source_corroboration_3_plus_sources(self):
+        """Three or more distinct sources add +10 bonus (capped)."""
+        result = self.scorer.apply_source_corroboration(73, 3)
+        assert result == 83
+        # 4 sources should also be +10 (capped at 3+)
+        result = self.scorer.apply_source_corroboration(73, 5)
+        assert result == 83
+
+    def test_source_corroboration_capped_at_90(self):
+        """Source corroboration bonus cannot exceed scraped data cap of 90."""
+        result = self.scorer.apply_source_corroboration(85, 3)
+        assert result == 90
+
+    def test_source_corroboration_single_source_no_bonus(self):
+        """Single source gets no corroboration bonus."""
+        result = self.scorer.apply_source_corroboration(73, 1)
+        assert result == 73
+
+    # ========================================
+    # Partial Validation Results
+    # ========================================
+
     def test_score_with_partial_validation_results(self):
-        """Test scoring handles missing validation result keys gracefully."""
-        # Minimal validation results
+        """Scoring handles missing validation result keys gracefully."""
         validation_results = {
             "has_coordinates": True,
             "is_zero_coordinates": False,
             "within_us_bounds": True,
         }
-
         score = self.scorer.calculate_score(self.good_location, validation_results)
-        # Should handle missing keys without error
         assert isinstance(score, int)
-        assert 0 <= score <= 100
+        assert 0 <= score <= 90


### PR DESCRIPTION
## Summary

- Replace deduction-from-100 scoring with **build-up-from-base (60)** model
- Scraped data earns points for quality signals, **capped at 90** — only human corrections reach 91-100
- **Source corroboration bonus**: locations confirmed by multiple scrapers get +5 (2 sources) or +10 (3+)
- Service-level richness (phone, hours, website) now factors into scoring via transient annotations

### Scoring Model

| Signal | Effect |
|--------|--------|
| Base score (valid scraped location) | 60 |
| Full address (street+city+state+zip) | +5 |
| Meaningful description (>10 chars) | +3 |
| High-quality geocoder (arcgis/google) | +5 |
| Phone/schedule/website | +3 each |
| Census geocoder | -5 |
| Fallback geocoder | -10 |
| Wrong state | -20 |
| Placeholder address | -75 |
| 2 scrapers confirm (reconciler) | +5 |
| 3+ scrapers confirm (reconciler) | +10 |
| **Hard cap (scraped)** | **90** |

### Example Score Ranges

| Scenario | Score | Status |
|----------|-------|--------|
| Single source, good geocoder, full addr + desc | 73 | needs_review |
| Single source, all data (phone+hrs+web+desc+addr) | 82 | verified |
| 2 sources, good data | 81-87 | verified |
| Single source, census geocoder, minimal | 55 | needs_review |
| Placeholder address | 0 | rejected |

### Files Changed

- `app/validator/scoring.py` — new build-up model, helpers, `apply_source_corroboration()`
- `app/validator/job_processor.py` — service-level annotations (`_has_phone`/`_has_schedule`/`_has_website`)
- `app/reconciler/merge_strategy.py` — source corroboration during merge
- `app/reconciler/location_creator.py` — passes confidence score to merge
- `tests/test_validator/test_scoring.py` — 35 tests (12 new)
- `tests/test_reconciler/test_merge_strategy.py` — 4 new corroboration tests
- `tests/test_reconciler/test_location_creator.py` — updated assertions
- `CLAUDE.md` — updated scoring documentation

### What Does NOT Change

- Tightbeam human corrections (still 100, bypasses scorer)
- Rejection threshold (stays at 10)
- Status thresholds (verified ≥80, needs_review ≥10, rejected <10)
- Existing data (forward-only, no retroactive re-scoring)
- HSDS data models (no schema changes)

## Test plan

- [x] `./bouy test --pytest tests/test_validator/test_scoring.py` — 35 pass
- [x] `./bouy test --pytest tests/test_reconciler/` — 33 pass
- [x] `./bouy test --pytest` — 2699 pass, 0 fail
- [x] `./bouy test --black` — clean
- [x] `./bouy test --ruff` — clean
- [ ] Manual: run a scraper and verify scores land in 60-90 range

🤖 Generated with [Claude Code](https://claude.com/claude-code)