### PR TITLE
fix: use Maximum instead of Sum for SQS gauge metrics

### DIFF
--- a/infra/stacks/monitoring_dashboard.py
+++ b/infra/stacks/monitoring_dashboard.py
@@ -83,7 +83,7 @@ def scaling_widget(
                 "AWS/SQS",
                 "ApproximateNumberOfMessagesVisible",
                 {"QueueName": queue_name},
-                "Sum",
+                "Maximum",
                 p1,
             )
         ],
@@ -493,13 +493,13 @@ def _add_service_section(
             f"{title} Queue",
             left=[
                 metric(sqs_ns, "ApproximateNumberOfMessagesVisible",
-                       {"QueueName": queue_name}, "Sum", p1),
+                       {"QueueName": queue_name}, "Maximum", p1),
                 metric(sqs_ns, "ApproximateNumberOfMessagesNotVisible",
-                       {"QueueName": queue_name}, "Sum", p1),
+                       {"QueueName": queue_name}, "Maximum", p1),
             ],
             right=[
                 metric(sqs_ns, "ApproximateNumberOfMessagesVisible",
-                       {"QueueName": dlq_name}, "Sum", p1),
+                       {"QueueName": dlq_name}, "Maximum", p1),
             ],
         ),
         graph(
@@ -510,7 +510,7 @@ def _add_service_section(
             ],
             right=[
                 metric(sqs_ns, "ApproximateNumberOfMessagesVisible",
-                       {"QueueName": queue_name}, "Sum", p1),
+                       {"QueueName": queue_name}, "Maximum", p1),
             ],
         ),
         graph(

--- a/infra/stacks/monitoring_dashboard_queues.py
+++ b/infra/stacks/monitoring_dashboard_queues.py
@@ -73,7 +73,9 @@ def add_sqs_queues_section(
 
     db.add_widgets(section("SQS Queues"))
 
-    # Per-queue depth graphs: visible + not-visible, DLQ on right axis
+    # Per-queue depth graphs: visible + not-visible, DLQ on right axis.
+    # SQS queue-depth metrics are gauges (point-in-time), not counters —
+    # use Maximum to see peak depth within each period.
     queue_widgets = []
     for label, qname in queues:
         dlq_name = derive_dlq_name(qname, stack.environment_name)
@@ -85,14 +87,14 @@ def add_sqs_queues_section(
                         ns,
                         "ApproximateNumberOfMessagesVisible",
                         {"QueueName": qname},
-                        "Sum",
+                        "Maximum",
                         p1,
                     ),
                     metric(
                         ns,
                         "ApproximateNumberOfMessagesNotVisible",
                         {"QueueName": qname},
-                        "Sum",
+                        "Maximum",
                         p1,
                     ),
                 ],
@@ -101,7 +103,7 @@ def add_sqs_queues_section(
                         ns,
                         "ApproximateNumberOfMessagesVisible",
                         {"QueueName": dlq_name},
-                        "Sum",
+                        "Maximum",
                         p1,
                     ),
                 ],
@@ -132,6 +134,7 @@ def add_pipeline_section(
     stack: MonitoringStack, db: cloudwatch.Dashboard
 ) -> None:
     """Section 4 -- Pipeline Overview."""
+    p1 = Duration.minutes(1)
     env = stack.environment_name
     queues = [
         stack.queue_name,
@@ -150,7 +153,8 @@ def add_pipeline_section(
             "AWS/SQS",
             "ApproximateNumberOfMessagesVisible",
             {"QueueName": q},
-            "Sum",
+            "Maximum",
+            p1,
         )
         for q in queues
     ]
@@ -159,7 +163,8 @@ def add_pipeline_section(
             "AWS/SQS",
             "ApproximateNumberOfMessagesVisible",
             {"QueueName": d},
-            "Sum",
+            "Maximum",
+            p1,
         )
         for d in dlqs
     ]


### PR DESCRIPTION
## Changes

Update CloudWatch dashboard metrics to use `Maximum` statistic instead of `Sum` for SQS queue-depth metrics across all monitoring dashboard components.

## Rationale

SQS queue-depth metrics (`ApproximateNumberOfMessagesVisible`, `ApproximateNumberOfMessagesNotVisible`) are gauges representing point-in-time queue depth, not cumulative counters. Using `Maximum` provides a more accurate view of peak queue depth within each metric period.

## Files Modified

- `infra/stacks/monitoring_dashboard.py`: Updated 5 metric definitions
- `infra/stacks/monitoring_dashboard_queues.py`: Updated 3 metric definitions and added explanatory comments