### PR TITLE
chore: add ppr-lighthouse as private submodule + gitignore .superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ infra/cdk.context.json
 
 # Claude
 .claude/settings.local.json
+
+# Superpowers brainstorming artifacts (local only)
+.superpowers/

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "plugins/ppr-beacon"]
 	path = plugins/ppr-beacon
 	url = https://github.com/For-The-Greater-Good/ppr-beacon.git
+[submodule "plugins/ppr-lighthouse"]
+	path = plugins/ppr-lighthouse
+	url = https://github.com/For-The-Greater-Good/ppr-lighthouse.git


### PR DESCRIPTION
## Summary

Wires \`plugins/ppr-lighthouse/\` (private repo) as a submodule alongside the other PPR plugins. Pins to current ppr-lighthouse main tip (\`623f11b\`).

Also adds \`.superpowers/\` to \`.gitignore\` — local brainstorming artifacts from the claim-flow design session.

## Why

- ppr-lighthouse has been iterated as a standalone clone for weeks but was never wired into the parent repo.
- About to start the "Claim This Provider" claim-flow work, which will cross-reference:
  - PPR core (\`app/reconciler/\`, \`app/database/\`)
  - ppr-write-api (\`_determine_verification()\` extension)
  - ppr-lighthouse (new claim routes + DynamoDB tables)
  - ppr-beacon (new claim CTA + claimed-state badge)
- Having lighthouse as a submodule means one coordinated commit point for cross-repo changes.

## Verification

- [x] \`git submodule status\` shows lighthouse pinned at 623f11b
- [x] Submodule resolves to the private repo URL
- [x] \`.gitmodules\` entry added correctly
- [ ] Clone with \`--recurse-submodules\` works (confirm on fresh machine)

## Follow-ups

Claim-flow work tracked in the implementation plan — see \`.claude/plans/toasty-soaring-badger.md\` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)