### PR TITLE
feat(reconciler): emit source_drift_detected SNS on owner-protected merges

### DIFF
--- a/app/reconciler/drift_events.py
+++ b/app/reconciler/drift_events.py
@@ -1,0 +1,120 @@
+"""Source-drift event publisher.
+
+Emits `source_drift_detected` SNS events when the reconciler's merge
+strategy suppresses a canonical-field write because `verified_by`
+points at a human writer (admin / source / claimed). The ppr-lighthouse
+plugin subscribes to these events and renders them as "a scraper
+disagreed with X" callouts on the owner dashboard.
+
+Graceful no-op when LIGHTHOUSE_EVENTS_TOPIC_ARN is unset — local `bouy`
+runs and unit tests don't need the AWS side. Failures to publish are
+logged and swallowed so the reconciler never fails a merge over a
+telemetry problem.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+_sns_client: Any = None
+
+
+def _get_topic_arn() -> str | None:
+    return os.environ.get("LIGHTHOUSE_EVENTS_TOPIC_ARN") or None
+
+
+def _get_client() -> Any:
+    """Return a process-cached SNS client. Created on first use."""
+    global _sns_client
+    if _sns_client is None:
+        region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get(
+            "AWS_REGION"
+        )
+        if region:
+            _sns_client = boto3.client("sns", region_name=region)
+        else:
+            _sns_client = boto3.client("sns")
+    return _sns_client
+
+
+def publish_drift_event(
+    *,
+    location_id: str,
+    scraper_name: str,
+    field_name: str,
+    scraper_value: str,
+    canonical_value: str,
+    detected_at: datetime | None = None,
+) -> bool:
+    """Publish one source-drift event. Returns True if sent, False on skip/error.
+
+    Non-fatal: a failure here is logged but never propagated. The
+    reconciler uses the return value only for structured-log bookkeeping.
+    """
+    topic_arn = _get_topic_arn()
+    if not topic_arn:
+        # Local / unit-test mode — silently skip. Structured log makes
+        # it visible without flagging every call as a warning.
+        logger.debug(
+            "drift_event_skipped_no_topic",
+            extra={
+                "location_id": location_id,
+                "scraper_name": scraper_name,
+                "field_name": field_name,
+            },
+        )
+        return False
+
+    event_time = (detected_at or datetime.now(timezone.utc)).isoformat()
+    payload = {
+        "event_type": "source_drift_detected",
+        "event_id": str(uuid.uuid4()),
+        "location_id": location_id,
+        "scraper_name": scraper_name,
+        "field_name": field_name,
+        "scraper_value": scraper_value,
+        "canonical_value": canonical_value,
+        "detected_at": event_time,
+    }
+
+    try:
+        _get_client().publish(
+            TopicArn=topic_arn,
+            Message=json.dumps(payload),
+            MessageAttributes={
+                "event_type": {
+                    "DataType": "String",
+                    "StringValue": "source_drift_detected",
+                },
+            },
+        )
+        logger.info(
+            "drift_event_published",
+            extra={
+                "location_id": location_id,
+                "scraper_name": scraper_name,
+                "field_name": field_name,
+            },
+        )
+        return True
+    except (BotoCoreError, ClientError) as exc:
+        logger.error(
+            "drift_event_publish_failed",
+            extra={
+                "location_id": location_id,
+                "scraper_name": scraper_name,
+                "field_name": field_name,
+                "error": str(exc),
+            },
+        )
+        return False

--- a/app/reconciler/drift_events.py
+++ b/app/reconciler/drift_events.py
@@ -37,9 +37,7 @@ def _get_client() -> Any:
     """Return a process-cached SNS client. Created on first use."""
     global _sns_client
     if _sns_client is None:
-        region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get(
-            "AWS_REGION"
-        )
+        region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
         if region:
             _sns_client = boto3.client("sns", region_name=region)
         else:

--- a/app/reconciler/drift_events.py
+++ b/app/reconciler/drift_events.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from typing import Any
 
 import boto3
@@ -73,7 +73,7 @@ def publish_drift_event(
         )
         return False
 
-    event_time = (detected_at or datetime.now(timezone.utc)).isoformat()
+    event_time = (detected_at or datetime.now(UTC)).isoformat()
     payload = {
         "event_type": "source_drift_detected",
         "event_id": str(uuid.uuid4()),

--- a/app/reconciler/merge_strategy.py
+++ b/app/reconciler/merge_strategy.py
@@ -43,9 +43,7 @@ class MergeStrategy(BaseReconciler):
             return None
         return {"verified_by": result[0]}
 
-    def _fetch_canonical_for_drift(
-        self, location_id: str
-    ) -> dict[str, Any] | None:
+    def _fetch_canonical_for_drift(self, location_id: str) -> dict[str, Any] | None:
         """Fetch the current canonical fields we compare against for drift.
 
         Kept narrow: only the fields a scraper can realistically diverge
@@ -97,9 +95,7 @@ class MergeStrategy(BaseReconciler):
                 scraper_name=scraper_name,
                 field_name=field,
                 scraper_value="" if merged_val is None else str(merged_val),
-                canonical_value=(
-                    "" if canonical_val is None else str(canonical_val)
-                ),
+                canonical_value=("" if canonical_val is None else str(canonical_val)),
             )
 
     def _row_to_dict(self, row: Any, result: HasKeys) -> dict[str, Any]:

--- a/app/reconciler/merge_strategy.py
+++ b/app/reconciler/merge_strategy.py
@@ -8,6 +8,7 @@ from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import Session
 
 from app.reconciler.base import BaseReconciler
+from app.reconciler.drift_events import publish_drift_event
 from app.validator.scoring import HUMAN_VERIFIED_SOURCES
 
 
@@ -41,6 +42,65 @@ class MergeStrategy(BaseReconciler):
         if result is None:
             return None
         return {"verified_by": result[0]}
+
+    def _fetch_canonical_for_drift(
+        self, location_id: str
+    ) -> dict[str, Any] | None:
+        """Fetch the current canonical fields we compare against for drift.
+
+        Kept narrow: only the fields a scraper can realistically diverge
+        on in a way a claimant would want to see (name, description).
+        Coordinates drift every scrape due to geocoder noise — we skip
+        those to avoid alarm fatigue.
+        """
+        result = self.db.execute(
+            text(
+                "SELECT name, description FROM location WHERE id = :id",
+            ),
+            {"id": location_id},
+        ).first()
+        if result is None:
+            return None
+        return {"name": result[0], "description": result[1]}
+
+    def _emit_drift_events(
+        self,
+        *,
+        location_id: str,
+        merged: dict[str, Any],
+        canonical: dict[str, Any],
+        valid_records: list[dict[str, Any]],
+    ) -> None:
+        """Emit one drift event per field that diverges between the
+        scraper-merged data and the canonical owner-curated data.
+
+        The scraper name is inferred from the first source record with
+        a populated scraper_id — good enough for the "which source
+        disagreed" message without threading scraper metadata through
+        the whole merge path.
+        """
+        scraper_name = "unknown"
+        for r in valid_records:
+            sid = r.get("scraper_id") or r.get("scraper_name")
+            if sid:
+                scraper_name = str(sid)
+                break
+
+        for field in ("name", "description"):
+            merged_val = merged.get(field)
+            canonical_val = canonical.get(field)
+            # Treat "nothing vs nothing" and matching strings as no-drift.
+            if (merged_val or "") == (canonical_val or ""):
+                continue
+            publish_drift_event(
+                location_id=str(location_id),
+                scraper_name=scraper_name,
+                field_name=field,
+                scraper_value="" if merged_val is None else str(merged_val),
+                canonical_value=(
+                    "" if canonical_val is None else str(canonical_val)
+                ),
+            )
 
     def _row_to_dict(self, row: Any, result: HasKeys) -> dict[str, Any]:
         """Convert a SQLAlchemy row to a dictionary regardless of result format.
@@ -287,6 +347,18 @@ class MergeStrategy(BaseReconciler):
                     "scraper_count": len(valid_records),
                 },
             )
+            # Emit source-drift events for the fields the scraper merge
+            # would have changed had protection not been in place. The
+            # ppr-lighthouse owner dashboard reads these off SNS →
+            # DriftEvents and renders a per-location callout.
+            canonical = self._fetch_canonical_for_drift(location_id)
+            if canonical:
+                self._emit_drift_events(
+                    location_id=str(location_id),
+                    merged=merged_data,
+                    canonical=canonical,
+                    valid_records=valid_records,
+                )
             # Only keep the is_canonical=TRUE housekeeping; skip content writes.
             self.db.execute(
                 text("UPDATE location SET is_canonical = TRUE WHERE id = :id"),

--- a/tests/test_reconciler/test_drift_events.py
+++ b/tests/test_reconciler/test_drift_events.py
@@ -1,0 +1,106 @@
+"""Tests for app.reconciler.drift_events.
+
+Covers the SNS publisher in isolation — the merge-strategy call-site
+integration is exercised indirectly via test_merge_strategy.py.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+from pytest_mock import MockerFixture
+
+from app.reconciler import drift_events
+from app.reconciler.drift_events import publish_drift_event
+
+
+@pytest.fixture(autouse=True)
+def _reset_client() -> None:
+    """Each test starts with no cached boto3 client so env-var mutations
+    take effect."""
+    drift_events._sns_client = None
+    yield
+    drift_events._sns_client = None
+
+
+def test_skips_when_topic_arn_unset(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.delenv("LIGHTHOUSE_EVENTS_TOPIC_ARN", raising=False)
+    spy = mocker.patch("boto3.client")
+
+    sent = publish_drift_event(
+        location_id="loc-1",
+        scraper_name="vivery",
+        field_name="name",
+        scraper_value="x",
+        canonical_value="y",
+    )
+
+    assert sent is False
+    spy.assert_not_called()
+
+
+def test_publishes_when_topic_arn_is_set(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.setenv(
+        "LIGHTHOUSE_EVENTS_TOPIC_ARN",
+        "arn:aws:sns:us-east-1:123456789012:outreach-events",
+    )
+    sns = MagicMock()
+    mocker.patch("boto3.client", return_value=sns)
+
+    sent = publish_drift_event(
+        location_id="loc-42",
+        scraper_name="feeding_america_nc",
+        field_name="name",
+        scraper_value="Food Bank of Wake",
+        canonical_value="Food Bank of Wake County",
+    )
+
+    assert sent is True
+    sns.publish.assert_called_once()
+    kwargs = sns.publish.call_args.kwargs
+    assert kwargs["TopicArn"].endswith(":outreach-events")
+    payload = json.loads(kwargs["Message"])
+    assert payload["event_type"] == "source_drift_detected"
+    assert payload["location_id"] == "loc-42"
+    assert payload["scraper_name"] == "feeding_america_nc"
+    assert payload["field_name"] == "name"
+    assert payload["scraper_value"] == "Food Bank of Wake"
+    assert payload["canonical_value"] == "Food Bank of Wake County"
+    assert "event_id" in payload
+    assert "detected_at" in payload
+    assert (
+        kwargs["MessageAttributes"]["event_type"]["StringValue"]
+        == "source_drift_detected"
+    )
+
+
+def test_swallows_boto_errors(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> None:
+    monkeypatch.setenv(
+        "LIGHTHOUSE_EVENTS_TOPIC_ARN",
+        "arn:aws:sns:us-east-1:123456789012:outreach-events",
+    )
+    sns = MagicMock()
+    sns.publish.side_effect = ClientError(
+        {"Error": {"Code": "AuthorizationError", "Message": "no"}},
+        "Publish",
+    )
+    mocker.patch("boto3.client", return_value=sns)
+
+    sent = publish_drift_event(
+        location_id="loc-1",
+        scraper_name="vivery",
+        field_name="description",
+        scraper_value="x",
+        canonical_value="y",
+    )
+
+    assert sent is False  # graceful — no exception propagates

--- a/tests/test_reconciler/test_merge_strategy.py
+++ b/tests/test_reconciler/test_merge_strategy.py
@@ -138,18 +138,29 @@ def test_merge_location_preserves_canonical_for_human_writers(
     # Second call: _fetch_existing_verification → returns the human tier.
     verify_result = MagicMock()
     verify_result.first.return_value = (verified_by,)
-    # Third call: housekeeping UPDATE (no content change).
+    # Third call: _fetch_canonical_for_drift → returns the canonical
+    # name/description so drift-event emission can compare against the
+    # scraper-merged values. Matching the merged values here keeps the
+    # diff empty and avoids emitting SNS traffic from this test.
+    canonical_result = MagicMock()
+    canonical_result.first.return_value = (
+        "Merged Location",
+        "Merged description",
+    )
+    # Fourth call: housekeeping UPDATE (no content change).
     housekeeping_result = MagicMock()
     mock_db.execute.side_effect = [
         sources_result,
         verify_result,
+        canonical_result,
         housekeeping_result,
     ]
 
     merge_strategy.merge_location(location_id)
 
-    # Expect exactly three DB calls and NO full-content UPDATE.
-    assert mock_db.execute.call_count == 3
+    # Expect four DB calls: sources → verify → canonical-for-drift →
+    # housekeeping. None of them should be a content UPDATE.
+    assert mock_db.execute.call_count == 4
     content_updates = [
         c
         for c in mock_db.execute.call_args_list


### PR DESCRIPTION
## Summary

Producer side of the claim-flow **source-drift** callout. When \`merge_strategy\` suppresses a canonical-field write because \`verified_by\` points at a human writer (\`admin\`/\`source\`/\`claimed\`), we now emit a \`source_drift_detected\` SNS event per diverging field. The ppr-lighthouse plugin already has the read side (DriftEvents table + owner-dashboard callout, shipped in ppr-lighthouse PR #21) — this wires up the missing producer so real scraper runs start populating it.

## What's in this PR

- **New \`app/reconciler/drift_events.py\`** — thin boto3 SNS publisher
  - Graceful no-op when \`LIGHTHOUSE_EVENTS_TOPIC_ARN\` is unset (local bouy + unit tests keep working without AWS)
  - Swallows \`BotoCoreError\` / \`ClientError\` so the reconciler never fails a merge over telemetry
- **\`merge_strategy.py\`** — after the owner-protected short-circuit, fetch canonical \`name\` + \`description\`, diff against the just-merged scraper values, emit one event per differing field. Coordinates intentionally excluded (geocoder noise would fire false positives).
- **Scraper name** inferred from the first source record carrying \`scraper_id\`; \`"unknown"\` fallback keeps events flowing even when upstream provenance is missing.

## Deployment note

\`LIGHTHOUSE_EVENTS_TOPIC_ARN\` must be set on the reconciler worker env for events to actually land. Until then the publisher is a no-op and the reconciler behaves exactly as before this PR — zero behavioral change in absence of the env var.

## Test coverage

**3 new tests** in \`tests/test_reconciler/test_drift_events.py\` (mocked boto3):

1. \`test_skips_when_topic_arn_unset\` — publisher skips silently, no boto3 call
2. \`test_publishes_when_topic_arn_is_set\` — asserts full payload shape + MessageAttributes
3. \`test_swallows_boto_errors\` — ClientError doesn't propagate

## Test plan

- [x] Python syntax validated (ast.parse)
- [ ] CI validates full test suite (local bouy has Docker issue — relying on CI)
- [ ] Manual on dev: set \`LIGHTHOUSE_EVENTS_TOPIC_ARN\`, run a scraper that touches a claimed location, verify event lands in the lighthouse DriftEvents table once the subscriber Lambda ships

## Follow-up

- SNS-subscriber Lambda in ppr-lighthouse that drains these events into the DriftEvents DynamoDB table

🤖 Generated with [Claude Code](https://claude.com/claude-code)