### PR TITLE
feat(env): document LIGHTHOUSE_DOMAIN for prod custom-domain wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,14 @@ SLACK_SIGNING_SECRET=your_slack_signing_secret
 SLACK_APP_TOKEN=xapp-your-slack-app-token
 LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 
+# ppr-lighthouse Plugin (CDK deployment only, production custom domain)
+# Custom hostname served by the Amplify app. In prod this is typically
+# a subdomain of BEACON_DOMAIN (e.g., portal.directory.plentiful.org).
+# Used for: Amplify custom-domain association, Cognito OAuth callback
+# allowlist, NextAuth canonical URL. Leave unset for dev — the Amplify
+# default *.amplifyapp.com URL is used automatically.
+# LIGHTHOUSE_DOMAIN=portal.your-beacon-domain.example.com
+
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds \`LIGHTHOUSE_DOMAIN\` env var placeholder to \`.env.example\`, mirroring the \`BEACON_DOMAIN\` pattern. Prod will serve lighthouse at a subdomain of \`BEACON_DOMAIN\` (typically \`portal.directory.plentiful.org\`).

## Companion work

Lighthouse CDK PR (follow-up, separate repo) will read this env var to:
- Attach the Amplify custom domain association
- Extend Cognito OAuth app client callback + logout URL allowlists
- Set \`NEXTAUTH_URL\` to the canonical prod URL

## Test plan

No code changes — just documentation placeholder. Verified it's commented out so existing deploys aren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)