### PR TITLE
env: add LIGHTHOUSE_HOSTED_ZONE_ID + generic placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,12 +88,18 @@ SLACK_APP_TOKEN=xapp-your-slack-app-token
 LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 
 # ppr-lighthouse Plugin (CDK deployment only, production custom domain)
-# Custom hostname served by the Amplify app. In prod this is typically
-# a subdomain of BEACON_DOMAIN (e.g., portal.directory.plentiful.org).
-# Used for: Amplify custom-domain association, Cognito OAuth callback
-# allowlist, NextAuth canonical URL. Leave unset for dev — the Amplify
-# default *.amplifyapp.com URL is used automatically.
-# LIGHTHOUSE_DOMAIN=portal.your-beacon-domain.example.com
+# Set BOTH vars to enable the custom domain; leave either unset to fall
+# back to the AWS-generated *.amplifyapp.com URL (the default in dev).
+#
+# LIGHTHOUSE_DOMAIN: full hostname served by the Amplify app, e.g., a
+# subdomain under your hosted zone. Used for the Amplify custom-domain
+# association, the Route53 CNAME, Cognito OAuth callback allowlist, and
+# the canonical NextAuth origin.
+# LIGHTHOUSE_HOSTED_ZONE_ID: Route53 zone that owns the parent zone of
+# LIGHTHOUSE_DOMAIN. CDK adds the subdomain CNAME + ACM validation CNAME
+# under this zone.
+# LIGHTHOUSE_DOMAIN=portal.your-domain.example.com
+# LIGHTHOUSE_HOSTED_ZONE_ID=Z1234567890ABC
 
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS


### PR DESCRIPTION
## Summary
Companion to ppr-lighthouse #33. Adds \`LIGHTHOUSE_HOSTED_ZONE_ID\` alongside the existing \`LIGHTHOUSE_DOMAIN\` var so the Amplify custom-domain wiring is fully env-driven. Swaps the project-specific placeholder to a generic one so \`.env.example\` stays neutral.

- **Both set** → CDK provisions \`CfnDomain\`, subdomain CNAME, and ACM validation CNAME.
- **Either unset** → skip entirely, serve on the AWS-generated \`*.amplifyapp.com\` URL.

## Test plan
- [x] No behavior change on backends — comment-only / opt-in env var
- [ ] Once ppr-lighthouse #33 merges + submodule bumps, deploy dev (without the vars) and confirm the Amplify default URL still works; set the vars in prod \`.env\` and redeploy to activate the custom domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)