### PR TITLE
feat(db): add 'claimed' to location.verified_by CHECK constraint

### DIFF
--- a/init-scripts/11-verification-fields.sql
+++ b/init-scripts/11-verification-fields.sql
@@ -7,12 +7,15 @@
 -- Automated scoring (pipeline) can set 'auto' at score >= 80.
 -- These fields are operational metadata, not HSDS data fields.
 
--- 1. Add verified_by field to location table
+-- 1. Add verified_by field to location table.
+-- NOTE: 'claimed' was added in 12-claimed-verified-by.sql for the
+-- self-service claim flow. Keeping both values here so fresh installs
+-- land with the full set without needing a follow-up migration.
 ALTER TABLE location
 ADD COLUMN IF NOT EXISTS verified_by TEXT
-CONSTRAINT location_verified_by_check CHECK (verified_by IN ('auto', 'admin', 'source'));
+CONSTRAINT location_verified_by_check CHECK (verified_by IN ('auto', 'admin', 'source', 'claimed'));
 
-COMMENT ON COLUMN location.verified_by IS 'Who verified: auto (score>=80), admin (Helm), source (Lighthouse portal), NULL (unverified)';
+COMMENT ON COLUMN location.verified_by IS 'Who verified: auto (score>=80), admin (Helm), source (Lighthouse portal), claimed (Lighthouse claimant), NULL (unverified)';
 
 -- 2. Add verified_at timestamp
 ALTER TABLE location
@@ -28,7 +31,7 @@ WHERE verified_by IS NOT NULL;
 -- Composite index for the beacon quality gate query
 CREATE INDEX IF NOT EXISTS location_beacon_eligible_idx
 ON location(confidence_score, verified_by)
-WHERE verified_by IN ('admin', 'source') AND confidence_score >= 93;
+WHERE verified_by IN ('admin', 'source', 'claimed') AND confidence_score >= 93;
 
 -- 4. Update location_master view to include verification fields
 CREATE OR REPLACE VIEW location_master AS

--- a/init-scripts/12-claimed-verified-by.sql
+++ b/init-scripts/12-claimed-verified-by.sql
@@ -1,0 +1,35 @@
+-- Migration: add 'claimed' to location.verified_by allowed values.
+-- Part of the self-service claim flow (ppr-lighthouse Part 2).
+--
+-- 'claimed' sits alongside 'admin' and 'source' as a trusted verification
+-- tier. It represents a program representative who verified ownership of
+-- a listing via the claim flow (invite, self-verify, or admin-approved
+-- manual review). Reconciler-guard treats claimed fields the same as
+-- admin/source — scraper updates do not overwrite them.
+--
+-- Idempotent: safe to re-run.
+
+BEGIN;
+
+-- 1. Replace the CHECK constraint to include 'claimed'.
+ALTER TABLE location DROP CONSTRAINT IF EXISTS location_verified_by_check;
+ALTER TABLE location
+ADD CONSTRAINT location_verified_by_check
+CHECK (verified_by IN ('auto', 'admin', 'source', 'claimed'));
+
+COMMENT ON COLUMN location.verified_by IS
+  'Who verified: auto (score>=80), admin (Helm), source (Lighthouse portal), claimed (Lighthouse claimant), NULL (unverified)';
+
+-- 2. Extend the beacon-eligible composite index to include claimed, so
+-- claimed locations qualify for rendering on beacon pages.
+DROP INDEX IF EXISTS location_beacon_eligible_idx;
+CREATE INDEX IF NOT EXISTS location_beacon_eligible_idx
+ON location(confidence_score, verified_by)
+WHERE verified_by IN ('admin', 'source', 'claimed') AND confidence_score >= 93;
+
+COMMIT;
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 12-claimed-verified-by.sql completed';
+END $$;


### PR DESCRIPTION
## Summary

Claim-approval hit the CHECK constraint \`location_verified_by_check\` on dev because \`'claimed'\` was never added to the allowed values. The approval orchestrator flipped the claim to approved but step 3 (Write API stamp) failed, leaving a half-applied claim: no ownership row, no verified_by, no approval email.

- New migration \`12-claimed-verified-by.sql\`: drops + re-adds the constraint with \`'claimed'\` included, extends the beacon eligibility composite index.
- \`11-verification-fields.sql\`: updated so fresh installs land correct from the start.
- Idempotent.

After merge, apply to dev Aurora via bastion port-forward, then re-run the approval via admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)