### PR TITLE
chore(.env.example): sync Lighthouse deploy vars + drop retired Helm block

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,19 +87,58 @@ SLACK_SIGNING_SECRET=your_slack_signing_secret
 SLACK_APP_TOKEN=xapp-your-slack-app-token
 LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 
-# ppr-lighthouse Plugin (CDK deployment only, production custom domain)
-# Set BOTH vars to enable the custom domain; leave either unset to fall
-# back to the AWS-generated *.amplifyapp.com URL (the default in dev).
+# ppr-lighthouse Plugin (CDK deployment only)
+#
+# LIGHTHOUSE_ADMIN_EMAIL: first admin user seeded into the owned
+# Cognito pool via a CDK CustomResource at deploy time. Skipped
+# cleanly if unset — use `aws cognito-idp admin-create-user` to
+# bootstrap manually in that case.
+# LIGHTHOUSE_ADMIN_EMAIL=admin@plentiful.org
+#
+# Custom-domain + passkey binding. Set BOTH vars to enable the custom
+# domain; leave either unset to fall back to the AWS-generated
+# *.amplifyapp.com URL (the default in dev). Passkeys / WebAuthn are
+# gated on LIGHTHOUSE_DOMAIN being set — credentials bind to the RP
+# ID they enrolled against, so enabling passkeys on a fresh Amplify
+# preview URL would strand users if the URL ever changes.
 #
 # LIGHTHOUSE_DOMAIN: full hostname served by the Amplify app, e.g., a
 # subdomain under your hosted zone. Used for the Amplify custom-domain
-# association, the Route53 CNAME, Cognito OAuth callback allowlist, and
-# the canonical NextAuth origin.
-# LIGHTHOUSE_HOSTED_ZONE_ID: Route53 zone that owns the parent zone of
-# LIGHTHOUSE_DOMAIN. CDK adds the subdomain CNAME + ACM validation CNAME
-# under this zone.
-# LIGHTHOUSE_DOMAIN=portal.your-domain.example.com
+# association, the Route53 CNAME, Cognito OAuth callback allowlist,
+# and the canonical NextAuth origin.
+# LIGHTHOUSE_HOSTED_ZONE_ID: Route53 zone that owns the parent zone
+# of LIGHTHOUSE_DOMAIN. CDK adds the subdomain CNAME + ACM validation
+# CNAME under this zone.
+# LIGHTHOUSE_DOMAIN=lighthouse.your-domain.example.com
 # LIGHTHOUSE_HOSTED_ZONE_ID=Z1234567890ABC
+#
+# Admin UI → Write API endpoint. Needed so admin location edits,
+# claim approvals, and owner edits reach the ppr-write-api Lambda.
+# Look up post-deploy with:
+#   aws cloudformation describe-stacks --stack-name WriteApiStack-{env} \
+#     --query 'Stacks[0].Outputs[?OutputKey==`WriteApiFunctionUrl`].OutputValue' --output text
+# WRITE_API_LAMBDA_URL=https://xxxxxxxxx.lambda-url.us-east-1.on.aws/
+#
+# Outreach dispatch (OutreachLambda — email + SMS to food banks).
+#
+# SENDER_EMAIL: From address on outreach email. Must be verified in
+# SendGrid. Defaults to noreply@plentiful.org.
+# SENDER_NAME: Display name on outreach email. Defaults to "Plentiful".
+# SENDER_ADDRESS: physical mailing address included in the outreach
+# email footer per CAN-SPAM. **Required in prod** — leaving this
+# blank ships non-compliant email. Can be a registered agent or P.O.
+# Box.
+# OUTREACH_ALLOWLIST: CSV of organization_id values authorized to
+# receive outreach ("*" = all enabled orgs). Useful during cautious
+# rollouts; tighten in prod.
+# SMS_VERIFY_ENABLED: gates the Twilio SMS verification channel.
+# Defaults to "false". Enable once the Twilio number has a registered
+# 10DLC brand/campaign.
+# SENDER_EMAIL=noreply@plentiful.org
+# SENDER_NAME=Plentiful
+# SENDER_ADDRESS=
+# OUTREACH_ALLOWLIST=*
+# SMS_VERIFY_ENABLED=false
 
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS
@@ -196,11 +235,6 @@ TIGHTBEAM_API_KEYS=  # Comma-separated API keys for tightbeam endpoints
 # HOSTED_ZONE_ID=your-route53-hosted-zone-id
 # DOMAIN_NAME=your-domain.example.com
 
-# ppr-helm Plugin (CDK deployment only)
-# HELM_GITHUB_TOKEN=ghp_your-github-pat-here
-# HELM_ADMIN_EMAIL=admin@example.com
-# HELM_ADMIN_PASSWORD=YourSecurePassword123!
-
 # ppr-beacon Plugin (CDK deployment only, production custom domain)
 # BEACON_HOSTED_ZONE_ID=your-route53-hosted-zone-id
 # BEACON_DOMAIN=your-beacon-domain.example.com
@@ -209,3 +243,9 @@ BEACON_GA4_MEASUREMENT_ID=
 BEACON_GOOGLE_SITE_VERIFICATION=
 # Report form shortlink (Typeform via short.io, omit to hide report links)
 BEACON_REPORT_FORM_URL=
+# IndexNow API key — push-based indexing for Bing/Yandex/Naver (feeds ChatGPT
+# Search, Copilot, DuckDuckGo). Generate with:
+#   python3 -c "import secrets; print(secrets.token_hex(16))"
+# Not a secret: the same value is published at https://<domain>/<key>.txt for
+# domain verification. Empty disables IndexNow submission.
+BEACON_INDEXNOW_API_KEY=


### PR DESCRIPTION
## Why

Auditing `ppr-prod/.env` revealed several Lighthouse deploy vars missing in both the prod env file and `.env.example`. The example was also still documenting retired `HELM_*` keys.

## What changed

**`.env.example`**
- Expanded Lighthouse block (was: `LIGHTHOUSE_GITHUB_TOKEN` + custom-domain pair). Now also documents:
  - `LIGHTHOUSE_ADMIN_EMAIL` — seed first Cognito admin via CustomResource.
  - `WRITE_API_LAMBDA_URL` — admin UI → ppr-write-api endpoint (claims, owner edits, admin location edits 500 without it).
  - `SENDER_EMAIL` / `SENDER_NAME` / `SENDER_ADDRESS` — outreach dispatch (SENDER_ADDRESS is CAN-SPAM mandatory in prod).
  - `OUTREACH_ALLOWLIST` — CSV gate for cautious rollouts.
  - `SMS_VERIFY_ENABLED` — gates Twilio flow until 10DLC is registered.
- Removed the `HELM_*` block (token / admin email / admin password). Helm retired in PR #423; keeping the docs around confuses prod operators.

No code changes — docs/sample-env only.