### PR TITLE
chore: bump beacon — BEACON_CLAIM_UI_ENABLED kill-switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,3 +249,12 @@ BEACON_REPORT_FORM_URL=
 # Not a secret: the same value is published at https://<domain>/<key>.txt for
 # domain verification. Empty disables IndexNow submission.
 BEACON_INDEXNOW_API_KEY=
+# Master kill-switch for claim UI on beacon location pages (CTA + managed
+# badge). When disabled (default), verified_by='claimed' rows look like any
+# other verified location and no "Claim This Provider" CTA renders.
+# Dev and prod share a single Aurora DB: keeping this off in dev lets us
+# exercise the lighthouse claim flow end-to-end without leaking dev-only
+# badges to directory.plentiful.org. Flip to true in prod env only when
+# rolling the feature out publicly.
+# Truthy: true / 1 / yes. Anything else disables.
+BEACON_CLAIM_UI_ENABLED=


### PR DESCRIPTION
## Summary

- Bumps `plugins/ppr-beacon` to `c0c231c` (PR #5 in ppr-beacon), which adds the `BEACON_CLAIM_UI_ENABLED` master kill-switch for all claim-related UI on location pages.
- Adds matching `BEACON_CLAIM_UI_ENABLED` entry to `.env.example` with rationale.
- Beacon commit also splits `app/renderer.py` into `renderer.py` + `renderer_filters.py` to stay under the constitution §8 600-line cap (pure refactor, no behavior change).

## Why the kill-switch

Dev and prod share a single Aurora DB. Any claim created in dev flips `verified_by='claimed'` on the shared location row. Without this flag, the next hourly beacon rebuild would swap the "Claim This Provider" CTA for a "Managed by the provider" badge on the public `directory.plentiful.org` — exposing dev-only test claims to end users.

Defaults off. Already wired into `ppr-prod/.env` as `BEACON_CLAIM_UI_ENABLED=false`. Flip to `true` in each env when we're ready to roll the feature out publicly.

## Test plan

- [x] CI green on ppr-beacon PR #5 (all renderer + kill-switch tests pass)
- [x] `claim_ui_enabled=False` fixture proves neither CTA nor managed badge renders (3 new tests in `TestClaimUiKillSwitch`)
- [ ] Parent repo CI green on this PR