### PR TITLE
fix(bouy): push plugin images on --infra-only too

### DIFF
--- a/bouy
+++ b/bouy
@@ -2726,6 +2726,18 @@ print(json.dumps(l))
                     exit 1
                 fi
                 output success "CDK deployment complete"
+
+                # `--infra-only` is the natural retry after a submodule
+                # bump. CDK alone doesn't pick up new plugin images
+                # (their ECR repos live outside the standard image
+                # set), so plugin templates / build code go stale even
+                # when the CDK stack and core images are current. Push
+                # plugin images + force redeploy so the next plugin
+                # build task / service runs against the new code.
+                output info "Building and pushing plugin images..."
+                build_and_push_plugin_images
+                redeploy_plugin_services
+                output success "Plugin images updated"
                 ;;
             full)
                 build_app_image


### PR DESCRIPTION
## Summary

`build_and_push_plugin_images` only ran in `./bouy deploy ENV` (full mode) at Phase 3.5. `--infra-only` skipped it.

That broke the natural recovery path: when a full deploy halts mid-flight (CDK error, e.g. the first `ServicesStack` synth on a fresh env), the standard re-run is `./bouy deploy ENV --infra-only` since core images already pushed. But plugin images live in their own ECR repos (`ppr-beacon-build-{env}` etc.) and only get pushed in Phase 3.5 — which infra-only never reaches. Result: plugin templates / build code go stale on every retry.

**Symptom we hit today:** track-1 submodule bumps deployed via CDK to `LighthouseStack-dev`, but the beacon build container kept rendering old templates (no operator band on home/state pages, no claim CTA in the footer) because its ECR image was 24h stale.

## Fix

Call `build_and_push_plugin_images` + `redeploy_plugin_services` at the end of the `infra` branch, mirroring full mode's Phase 3.5 / Phase 4 plugin handling.

`redeploy_plugin_services` already warns (rather than fails) when the plugin doesn't have a long-running ECS service — beacon is one of those (Step Function task on demand), so the warning is benign.

## Test plan

- [x] `bash -n bouy` — syntax clean
- [x] `./bouy --version` runs
- [ ] On next dev re-deploy: `./bouy deploy dev --infra-only` should now build + push plugin images and warn-but-proceed for plugins without long-running services

🤖 Generated with [Claude Code](https://claude.com/claude-code)