### PR TITLE
chore: bump ppr-lighthouse — modular Twilio Verify (track 1.5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,11 +134,23 @@ LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 # SMS_VERIFY_ENABLED: gates the Twilio SMS verification channel.
 # Defaults to "false". Enable once the Twilio number has a registered
 # 10DLC brand/campaign.
+# SMS_VERIFICATION_MODE: which backend the lighthouse claim flow uses
+# for phone verification. "verify" (default) uses Twilio Verify OTP
+# and works without 10DLC because Twilio is the sender of record.
+# "magic_link" uses the legacy JWT + Twilio SMS magic-link flow and
+# additionally requires SMS_VERIFY_ENABLED=true.
+# TWILIO_VERIFY_SERVICE_SID: per-environment Verify Service ID (VA…)
+# from the Twilio console (Verify → Services). Required when
+# SMS_VERIFICATION_MODE=verify; ignored otherwise. Non-sensitive (the
+# account SID + auth token are the actual creds), but flowed through
+# Amplify env at deploy time.
 # SENDER_EMAIL=noreply@plentiful.org
 # SENDER_NAME=Plentiful
 # SENDER_ADDRESS=
 # OUTREACH_ALLOWLIST=*
 # SMS_VERIFY_ENABLED=false
+# SMS_VERIFICATION_MODE=verify
+# TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -805,6 +805,12 @@ Plugin CDK stacks are discovered automatically from `plugin.yml` → `infra.stac
 
 ## Recent Updates and Features
 
+### Modular Twilio Verify SMS verification (ppr-lighthouse)
+- **Why**: A2P 10DLC carrier campaign approval is still pending; the legacy magic-link SMS verification path is code-complete but disabled. Twilio Verify is a separate product (no 10DLC required, Twilio is sender-of-record) so phone verification ships today.
+- **Switch**: `SMS_VERIFICATION_MODE=verify` (default during 10DLC wait) | `magic_link` (post-10DLC). Flip via Amplify env var, no rebuild.
+- **Verify-mode flow**: `/api/claims/send-verification` → `startVerification(phone)` → user gets 6-digit code → `/api/claims/check-verification` → `checkVerification(phone, code)` → on approved → shared `completeClaimVerification` helper runs the same enrollment / welcome pipeline as the magic-link consumer.
+- **Files**: `src/lib/sms/twilio-verify.ts`, `src/app/api/claims/check-verification/route.ts`, `src/components/claims/OtpInputForm.tsx`, `src/lib/claims/complete-verification.ts`. New Amplify env vars: `SMS_VERIFICATION_MODE`, `TWILIO_VERIFY_SERVICE_SID`.
+
 ### Admin Portal Upload (`portal_ingest` scraper)
 - **AWS-only feature** (Principle XV exemption): Lighthouse admin route `/admin/upload` lets operators bulk-ingest CSV/XLSX location rows.
 - **Flow**: Lighthouse UI → `/api/upload` BFF (CSRF + admin role + `uploadData` permission + server-side parse) → `PPRClient.ingestUpload(rows, metadata)` → Write API `POST /ingest` → S3 ingest bucket → ECS RunTask launches the `portal_ingest` Fargate task → `PortalIngestScraper` reads S3 payload and emits one raw JSON row per entry via `self.submit_to_queue()` → Content Store (SHA-256 dedupe) → LLM → Validator → Reconciler (standard `verified_by='auto'`).


### PR DESCRIPTION
## Summary

Pulls in the entire **modular Twilio Verify (track 1.5)** track, end-to-end tested on dev today. Lighthouse main bumps to \`cacd4b5\`.

### What lands

| PR | What | Why |
|---|---|---|
| #121 | feat(sms): modular Twilio Verify alongside magic-link | Phone verification ships ahead of 10DLC approval — Twilio is sender-of-record |
| #122 | fix: normalize phones to E.164 before Twilio dispatch | HSDS data arrives as 10-digit NANP; Twilio rejects with 60200 buried by privacy-202 |
| #123 | fix: show both SMS + Call buttons regardless of HSDS phone type | Capability tags from scrapers are unreliable; let the user pick |
| #124 | fix: allowlist \`TWILIO_*\`, \`SMS_*\`, \`CONSENT_LOG_TABLE\` in Amplify buildSpec | **The silent bug**: env vars set on the Amplify app were stripped by the buildspec's \`printenv|grep\` filter before reaching the SSR Lambda. Cost us ~3 hours of "why isn't SMS arriving" debugging today. |

### Other bumps in this commit

- \`.env.example\` — documents \`SMS_VERIFICATION_MODE\` + \`TWILIO_VERIFY_SERVICE_SID\` for new operators
- \`CLAUDE.md\` — "Recent Updates and Features" entry pointing at the Verify track

### Pre-cutover state

- ✅ \`TWILIO_VERIFY_SERVICE_SID=VA6d1b8040…\` set on dev Amplify
- ✅ \`SMS_VERIFICATION_MODE=verify\` set on dev Amplify
- ✅ Same vars added to \`ppr-prod/.env\` for prod-deploy alignment
- ✅ End-to-end SMS + voice OTP both verified working on dev today
- ✅ All 4 lighthouse PRs CI-green and merged

### Post-merge

Voice channel had to be enabled at Twilio Console → Verify → Services → Plentiful → Voice (separate from SMS, off by default for new Verify Services). Bryan flipped that during testing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)