### PR TITLE
chore(infra): add Twilio domain-verification TXT record at _twilio.{domain}

### DIFF
--- a/infra/stacks/dns_stack.py
+++ b/infra/stacks/dns_stack.py
@@ -238,6 +238,30 @@ class DnsStack(Stack):
                 ),
             )
 
+        # Twilio domain verification (organization-level binding).
+        # Twilio's "Verify Domain" UI asks for a TXT record at
+        # `_twilio.<domain>` so it can confirm we own the subdomain
+        # before granting org-managed user / domain features against
+        # it. Verifying the subdomain doesn't conflict with verifying
+        # the apex separately later — each verification is its own TXT
+        # at its own host.
+        #
+        # The token below is non-secret (it's the equivalent of a
+        # `verification=<hash>` challenge — useful only as proof of DNS
+        # control during this one-shot handshake). Tracked in
+        # source instead of an SSM parameter so the verification
+        # binding is reproducible across redeploys / fresh accounts.
+        route53.TxtRecord(
+            self,
+            "TwilioDomainVerification",
+            zone=zone,
+            record_name="_twilio",
+            values=[
+                "twilio-domain-verification=3549c54fc8e07957c0457e0640eeee95",
+            ],
+            ttl=Duration.minutes(5),
+        )
+
         CfnOutput(
             self,
             "DomainName",

--- a/infra/tests/test_dns_stack.py
+++ b/infra/tests/test_dns_stack.py
@@ -149,3 +149,35 @@ class TestExportsCloudFront:
         )
         template = assertions.Template.from_stack(dns)
         template.resource_count_is("AWS::SSM::Parameter", 0)
+
+
+class TestTwilioDomainVerification:
+    """Tests for the `_twilio.<domain>` TXT record that proves DNS
+    ownership of the subdomain to Twilio's organization-domain
+    verification flow."""
+
+    def test_creates_twilio_verification_txt_record(self, env):
+        app = cdk.App()
+        dns = DnsStack(
+            app,
+            "DnsStackTwilioTxt",
+            environment_name="dev",
+            hosted_zone_id="Z0123456789ABCDEFGHIJ",
+            domain_name="example.com",
+            http_api_id="abc123",
+            env=env,
+        )
+        template = assertions.Template.from_stack(dns)
+
+        # CDK quotes TXT values per RFC 1035; the record value is the
+        # verification token Twilio displays in its UI.
+        template.has_resource_properties(
+            "AWS::Route53::RecordSet",
+            {
+                "Type": "TXT",
+                "Name": "_twilio.example.com.",
+                "ResourceRecords": [
+                    '"twilio-domain-verification=3549c54fc8e07957c0457e0640eeee95"',
+                ],
+            },
+        )


### PR DESCRIPTION
## Summary

Adds the TXT record Twilio's organization "Verify Domain" UI requires to prove we control \`lighthouse.plentiful.org\`.

| Field | Value |
|---|---|
| Type | \`TXT\` |
| Host | \`_twilio.lighthouse.plentiful.org\` |
| Value | \`twilio-domain-verification=3549c54fc8e07957c0457e0640eeee95\` |
| TTL | 5 min |

The token functions as a one-shot DNS challenge — non-secret, useful only as proof-of-control during the verification handshake. Tracked in source so the binding is reproducible across redeploys / fresh accounts.

Verifying the subdomain does not preclude verifying the apex \`plentiful.org\` separately later — each verification is its own TXT at its own \`_twilio.<host>\`.

## Test plan

- [x] 6/6 tests in \`tests/test_dns_stack.py\` pass (new \`TestTwilioDomainVerification::test_creates_twilio_verification_txt_record\` locks the record name + value)
- [ ] After deploy: open Twilio org "Verify Domain" UI, click **Verify Domain** for \`lighthouse.plentiful.org\` — should clear within minutes (Route53 propagation is fast). If it doesn't on first click, give it ~5 min and retry.

## Note re. SMS link shortening

This is the **org-account-level** domain verification, not the Branded Domain / Click Tracking shortener for SMS. The latter lives under Twilio Messaging → Link Shortening and requires its own DNS setup (typically a CNAME like \`link.<domain>\` to Twilio's click-tracking endpoint). I'll do that as a separate PR once the toll-free + magic-link migration plan lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)