### PR TITLE
chore(env): default SMS to magic-link path; document Click Tracking shortener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,14 +131,21 @@ LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 # OUTREACH_ALLOWLIST: CSV of organization_id values authorized to
 # receive outreach ("*" = all enabled orgs). Useful during cautious
 # rollouts; tighten in prod.
-# SMS_VERIFY_ENABLED: gates the Twilio SMS verification channel.
-# Defaults to "false". Enable once the Twilio number has a registered
-# 10DLC brand/campaign.
+# SMS_VERIFY_ENABLED: kill switch for the Twilio SMS magic-link path.
+# Defaults to "true" since the toll-free sender is TFV-approved.
+# Flip to "false" if Twilio throttles / suspends the toll-free
+# number — voice-via-Verify continues to work either way.
+# SMS_VERIFICATION_MODE: SMS dispatch backend. "magic_link" (default)
+# uses JWT + Twilio SMS magic-link with Messaging Service Click
+# Tracking auto-shortening URLs against the branded
+# `lighthouse.plentiful.org` domain. "verify" falls back to Twilio
+# Verify OTP. Voice always uses Verify regardless.
 # SENDER_EMAIL=noreply@plentiful.org
 # SENDER_NAME=Plentiful
 # SENDER_ADDRESS=
 # OUTREACH_ALLOWLIST=*
-# SMS_VERIFY_ENABLED=false
+# SMS_VERIFY_ENABLED=true
+# SMS_VERIFICATION_MODE=magic_link
 
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS


### PR DESCRIPTION
Aligns \`.env.example\` with the lighthouse-side flip in [ppr-lighthouse PR #129](https://github.com/For-The-Greater-Good/ppr-lighthouse/pull/129).

Toll-free TFV-approved → SMS_VERIFY_ENABLED defaults to \`true\` (kill switch retained), SMS_VERIFICATION_MODE defaults to \`magic_link\`. Comment also calls out that URL shortening is handled by Twilio's Click Tracking on the Messaging Service against the verified \`lighthouse.plentiful.org\` branded domain (TXT record landed in #450).

Pure docstring + default-value change to a sample env. No code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)