### PR TITLE
docs(env): document TWILIO_VERIFY_SERVICE_SID in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,12 +140,20 @@ LIGHTHOUSE_GITHUB_TOKEN=ghp_your-github-pat-here
 # Tracking auto-shortening URLs against the branded
 # `lighthouse.plentiful.org` domain. "verify" falls back to Twilio
 # Verify OTP. Voice always uses Verify regardless.
+# TWILIO_VERIFY_SERVICE_SID: Twilio Verify Service SID (VA…). One per
+# environment. Required for Verify-by-call (and SMS-Verify fallback
+# when SMS_VERIFICATION_MODE=verify). Non-sensitive (account
+# credentials live in the lighthouse Twilio secret), pushed to the
+# Amplify env at CDK deploy via plugins/ppr-lighthouse/infra/
+# lighthouse_amplify_construct.py. Empty value produces a loud
+# runtime error rather than a silent mock fall-through.
 # SENDER_EMAIL=noreply@plentiful.org
 # SENDER_NAME=Plentiful
 # SENDER_ADDRESS=
 # OUTREACH_ALLOWLIST=*
 # SMS_VERIFY_ENABLED=true
 # SMS_VERIFICATION_MODE=magic_link
+# TWILIO_VERIFY_SERVICE_SID=VA...
 
 # ═══════════════════════════════════════════════════════════════
 # LOCAL-ONLY — not used on AWS


### PR DESCRIPTION
## Summary

The Twilio Verify Service SID (VA…) is required for the new "Verify by call" path (and SMS-Verify fallback when \`SMS_VERIFICATION_MODE=verify\`). It's read at CDK deploy time by \`plugins/ppr-lighthouse/infra/lighthouse_amplify_construct.py:230\` and pushed to the Amplify env. Until now it was undocumented in \`.env.example\` — which silently bit a fresh deploy when the value got dropped from a maintainer's local env (the cause of the "TWILIO_VERIFY_SERVICE_SID is not configured" error reported on dev today).

Adds a comment block + commented example line to \`.env.example\`.

## Test plan
- [x] No code changes; documentation-only.
- [x] Real value already live on Amplify dev via the redeploy I'm running in parallel (task `bcz1py2sk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)