### PR TITLE
fix(bouy): include submarine in --images-only redeploy list

### DIFF
--- a/bouy
+++ b/bouy
@@ -2893,7 +2893,13 @@ print(tasks[0]['taskArn'])
 
                 # Force ECS services to pull new images
                 output info "Forcing ECS service redeployment..."
-                ECS_SERVICES="worker validator reconciler recorder"
+                # Include `submarine` so the service re-resolves :latest to
+                # the just-pushed digest. Without this, the submarine service
+                # holds a cached digest (resolved at its last deployment) and
+                # can break when ECR lifecycle GCs that digest — see the
+                # 2026-05-13 outage where the service ran with desired=15 /
+                # running=0 because the cached digest no longer existed.
+                ECS_SERVICES="worker validator reconciler recorder submarine"
                 CLUSTER="pantry-pirate-radio-${DEPLOY_ENV}"
                 for svc in $ECS_SERVICES; do
                     SERVICE_NAME="pantry-pirate-radio-${svc}-${DEPLOY_ENV}"
@@ -2989,7 +2995,13 @@ print(tasks[0]['taskArn'])
 
                 # Phase 4: Force ECS services and Lambda to pull new images
                 output info "Phase 4: Forcing service redeployment..."
-                ECS_SERVICES="worker validator reconciler recorder"
+                # Include `submarine` so the service re-resolves :latest to
+                # the just-pushed digest. Without this, the submarine service
+                # holds a cached digest (resolved at its last deployment) and
+                # can break when ECR lifecycle GCs that digest — see the
+                # 2026-05-13 outage where the service ran with desired=15 /
+                # running=0 because the cached digest no longer existed.
+                ECS_SERVICES="worker validator reconciler recorder submarine"
                 CLUSTER="pantry-pirate-radio-${DEPLOY_ENV}"
                 for svc in $ECS_SERVICES; do
                     SERVICE_NAME="pantry-pirate-radio-${svc}-${DEPLOY_ENV}"


### PR DESCRIPTION
## Summary

The \`./bouy deploy --images-only\` mode redeploys ECS services after pushing new images, but \`submarine\` was missing from the hardcoded service list. Result: images-only deploys pushed fresh submarine images to ECR without ever updating the submarine service, leaving the service to run on whatever digest it resolved to at its last CDK deploy.

## The outage this caused (2026-05-13)

Manual catch-up scan dispatched ~35k crawl jobs. Auto-scaler bumped \`submarine\` desired count to 15. Every task launch failed:

\`\`\`
CannotPullContainerError: pull image manifest has been retried 7 time(s):
failed to resolve ref ...submarine-prod:latest@sha256:56b2eb3d7877...: not found
\`\`\`

ECR's "keep last 10 untagged images" lifecycle rule had GC'd the digest the service was holding from a prior deploy.

Mitigation that day: registered a new task-definition revision pointing at \`:latest\` (forcing ECS to re-resolve), then \`--force-new-deployment\`. Submarine has been crawling normally since.

## What this PR changes

Adds \`submarine\` to \`ECS_SERVICES\` in both \`--images-only\` and full deploy code paths in \`bouy\`. Every images-only deploy now \`--force-new-deployment\`s submarine after pushing a fresh image, so the service always re-resolves \`:latest\` to the current digest. The digest can never go stale.

## Test plan

- [x] bash syntax check (\`bash -n bouy\`)
- [ ] Next \`./bouy deploy prod --images-only\` should include "Redeployed submarine" in the output (will verify on the next deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)