### PR TITLE
feat(ptf): cluster-dedup near-duplicate canonicals on /locations endpoint

### DIFF
--- a/app/api/v1/partners/ptf/locations_queries.py
+++ b/app/api/v1/partners/ptf/locations_queries.py
@@ -29,7 +29,8 @@ def clamp_offset(value: int) -> int:
 
 # Both queries below share the same tie-break invariants:
 #  1. DISTINCT ON (l.id) collapses multi-address/multi-phone rows in the
-#     list query; LIMIT 1 with the same ORDER BY does the same for detail.
+#     list query (inside the `candidates` CTE); LIMIT 1 with the same
+#     ORDER BY does the same for detail.
 #  2. Physical address wins via `address_type = 'physical'` filter on the
 #     JOIN (rather than ORDER BY, so seq scans are smaller).
 #  3. For multiple eligible FA crosswalk rows for one ZIP, lowest
@@ -47,6 +48,20 @@ def clamp_offset(value: int) -> int:
 # (driven by `has_qualifying_source` alone) still gets "FANO" if a
 # qualifying source exists, regardless of ZIP match.
 #
+# `_LIST_SQL` additionally clusters near-duplicate canonicals at the
+# endpoint as defense-in-depth: the reconciler's name-or-org-constrained
+# merge tier bails when independent scrapers produce different names AND
+# different orgs for the same physical pantry, so duplicates leak into
+# `location`. ST_ClusterDBSCAN(eps:=0.0005, minpoints:=1) groups rows
+# whose (lng,lat) sit within ~55m of each other (eps is in SRID-4326
+# degrees, ~111m per degree at the equator, narrower at higher lats);
+# minpoints=1 means isolated rows form their own singleton cluster so no
+# unique location is ever dropped. The survivor per cluster is picked by
+# `has_qualifying_source DESC, confidence_score DESC NULLS LAST, id ASC`
+# so the FANO enrichment block is never silently stripped when a non-FANO
+# sibling exists — matches the eps used by the inbound /sync endpoint
+# (`services.py:_build_qualified_cte`).
+#
 # The CTE is inlined into both _LIST_SQL and _DETAIL_SQL rather than
 # string-concatenated so bandit's B608 (hardcoded_sql_expressions) heuristic
 # stays clean. Allowlist values are bound via SQLAlchemy `expanding=True`
@@ -59,66 +74,112 @@ WITH qualifying_source AS (
     WHERE scraper_id IN :allowlist
       AND (source_type IS NULL OR source_type != 'submarine')
     GROUP BY location_id
-)
-SELECT DISTINCT ON (l.id)
-    l.id,
-    l.name,
-    l.alternate_name AS short_name,
-    l.description,
-    l.latitude,
-    l.longitude,
-    l.organization_id,
-    o.name AS org_name,
-    o.description AS org_description,
-    o.email AS org_email,
-    o.website AS org_website,
-    a.address_1,
-    a.address_2,
-    a.city,
-    a.state_province,
-    a.postal_code,
-    p.number AS phone_number,
-    CASE WHEN COALESCE(qs.has_qualifying_source, false)
-         THEN fa.fa_org_id END AS fa_org_id,
-    CASE WHEN COALESCE(qs.has_qualifying_source, false)
-         THEN fa.fa_org_name END AS fa_org_name,
-    COALESCE(qs.has_qualifying_source, false) AS has_qualifying_source,
-    (fa.fa_org_id IS NOT NULL) AS zip_matched_fa
-FROM location l
-LEFT JOIN organization o ON l.organization_id = o.id
-LEFT JOIN address a ON a.location_id = l.id AND a.address_type = 'physical'
-LEFT JOIN phone p ON p.location_id = l.id
-LEFT JOIN feeding_america_zip_coverage fa
-       ON fa.zip = SUBSTR(a.postal_code, 1, 5)
-LEFT JOIN qualifying_source qs ON qs.location_id = l.id
-WHERE (l.validation_status != 'rejected' OR l.validation_status IS NULL)
-  AND l.latitude IS NOT NULL
-  AND l.longitude IS NOT NULL
-  AND NOT (l.latitude = 0 AND l.longitude = 0)
-  AND (l.name IS NOT NULL OR o.name IS NOT NULL)
-  -- Require at least one piece of contact info OR a schedule. A location
-  -- with neither is unreachable by the consuming app and shouldn't appear
-  -- in the PTF feed. Empty strings count as missing (some scrapers store
-  -- '' rather than NULL for absent values). Phone uses an explicit EXISTS
-  -- rather than `p.id IS NOT NULL` from the LEFT JOIN above so the filter
-  -- doesn't depend on which phone row the JOIN happens to pick — if any
-  -- phone row has a real number, the location qualifies. Schedule existence
-  -- uses schedule_location_id_idx (partial, WHERE location_id IS NOT NULL).
-  AND (
-      EXISTS (
-          SELECT 1 FROM phone
-          WHERE location_id = l.id
-            AND number IS NOT NULL AND number != ''
+),
+candidates AS (
+    SELECT DISTINCT ON (l.id)
+        l.id,
+        l.name,
+        l.alternate_name AS short_name,
+        l.description,
+        l.latitude,
+        l.longitude,
+        l.confidence_score,
+        l.organization_id,
+        o.name AS org_name,
+        o.description AS org_description,
+        o.email AS org_email,
+        o.website AS org_website,
+        a.address_1,
+        a.address_2,
+        a.city,
+        a.state_province,
+        a.postal_code,
+        p.number AS phone_number,
+        CASE WHEN COALESCE(qs.has_qualifying_source, false)
+             THEN fa.fa_org_id END AS fa_org_id,
+        CASE WHEN COALESCE(qs.has_qualifying_source, false)
+             THEN fa.fa_org_name END AS fa_org_name,
+        COALESCE(qs.has_qualifying_source, false) AS has_qualifying_source,
+        (fa.fa_org_id IS NOT NULL) AS zip_matched_fa
+    FROM location l
+    LEFT JOIN organization o ON l.organization_id = o.id
+    LEFT JOIN address a ON a.location_id = l.id AND a.address_type = 'physical'
+    LEFT JOIN phone p ON p.location_id = l.id
+    LEFT JOIN feeding_america_zip_coverage fa
+           ON fa.zip = SUBSTR(a.postal_code, 1, 5)
+    LEFT JOIN qualifying_source qs ON qs.location_id = l.id
+    WHERE (l.validation_status != 'rejected' OR l.validation_status IS NULL)
+      AND l.latitude IS NOT NULL
+      AND l.longitude IS NOT NULL
+      AND NOT (l.latitude = 0 AND l.longitude = 0)
+      AND (l.name IS NOT NULL OR o.name IS NOT NULL)
+      -- Require at least one piece of contact info OR a schedule. A
+      -- location with neither is unreachable by the consuming app and
+      -- shouldn't appear in the PTF feed. Empty strings count as missing
+      -- (some scrapers store '' rather than NULL for absent values).
+      -- Phone uses an explicit EXISTS rather than `p.id IS NOT NULL` from
+      -- the LEFT JOIN above so the filter doesn't depend on which phone
+      -- row the JOIN happens to pick — if any phone row has a real
+      -- number, the location qualifies. Schedule existence uses
+      -- schedule_location_id_idx (partial, WHERE location_id IS NOT NULL).
+      AND (
+          EXISTS (
+              SELECT 1 FROM phone
+              WHERE location_id = l.id
+                AND number IS NOT NULL AND number != ''
+          )
+          OR (o.email IS NOT NULL AND o.email != '')
+          OR (o.website IS NOT NULL AND o.website != '')
+          OR EXISTS (SELECT 1 FROM schedule s WHERE s.location_id = l.id)
       )
-      OR (o.email IS NOT NULL AND o.email != '')
-      OR (o.website IS NOT NULL AND o.website != '')
-      OR EXISTS (SELECT 1 FROM schedule s WHERE s.location_id = l.id)
-  )
-  {bbox}
-  {qfilter}
-ORDER BY l.id,
-         fa.fa_org_id NULLS LAST,
-         p.id NULLS LAST
+      {bbox}
+      {qfilter}
+    ORDER BY l.id,
+             fa.fa_org_id NULLS LAST,
+             p.id NULLS LAST
+),
+clustered AS (
+    SELECT c.*,
+           ST_ClusterDBSCAN(
+               ST_SetSRID(
+                   ST_MakePoint(
+                       CAST(c.longitude AS float8),
+                       CAST(c.latitude AS float8)
+                   ),
+                   4326
+               ),
+               eps := 0.0005,
+               minpoints := 1
+           ) OVER () AS cluster_id
+    FROM candidates c
+)
+SELECT DISTINCT ON (cluster_id)
+    id,
+    name,
+    short_name,
+    description,
+    latitude,
+    longitude,
+    organization_id,
+    org_name,
+    org_description,
+    org_email,
+    org_website,
+    address_1,
+    address_2,
+    city,
+    state_province,
+    postal_code,
+    phone_number,
+    fa_org_id,
+    fa_org_name,
+    has_qualifying_source,
+    zip_matched_fa
+FROM clustered
+ORDER BY cluster_id,
+         has_qualifying_source DESC,
+         confidence_score DESC NULLS LAST,
+         id
 LIMIT :limit OFFSET :offset
 """
 

--- a/app/api/v1/partners/ptf/locations_router.py
+++ b/app/api/v1/partners/ptf/locations_router.py
@@ -104,6 +104,11 @@ async def list_ptf_locations(
         returned=len(items),
         dropped=dropped,
         fa_matched=fa_matched,
+        # Near-duplicate canonicals are collapsed at query time via
+        # ST_ClusterDBSCAN — see `_LIST_SQL` in locations_queries.py.
+        # Flag included so CloudWatch can confirm the cluster path is
+        # live, and so a future drop in fa_matched can be correlated.
+        dedup_active=True,
     )
     response.headers["Cache-Control"] = _LIST_CACHE_CONTROL
     return items

--- a/tests/test_ptf_locations_integration.py
+++ b/tests/test_ptf_locations_integration.py
@@ -592,3 +592,254 @@ class TestContactOrScheduleFilter:
             limit=200, offset=0, bbox=(44.9, -65.5, 45.1, -64.5)
         )
         assert loc_id not in {str(r.id) for r in rows}
+
+
+class TestNearDuplicateCollapse:
+    """Defense-in-depth: when the reconciler leaves multiple `location`
+    rows for the same physical pantry (different scrapers, different
+    names, no shared org), the endpoint must collapse them to one row
+    via ST_ClusterDBSCAN so Plentiful's map doesn't show three pins on
+    top of each other.
+
+    Scenario mirrors the real Beaverton Adventist Church (SDA) case
+    that triggered this work: three slightly-different names at the
+    same lat/lng, only one of which has a FANO-allowlisted scraper
+    source. The survivor must be the FANO row so the
+    `feeding_america_food_bank` enrichment block isn't silently dropped.
+    """
+
+    @pytest_asyncio.fixture
+    async def beaverton_triple(self, db_session: AsyncSession):
+        # Three independent orgs — mirrors the reconciler-can't-merge
+        # case where same-name and same-org tier-2 dedup both fail.
+        org_ids = [str(uuid.uuid4()) for _ in range(3)]
+        loc_ids = [str(uuid.uuid4()) for _ in range(3)]
+
+        for oid, name in zip(
+            org_ids,
+            (
+                "Beaverton Adventist (Org A)",
+                "Oregon Food Bank Affiliate (Org B)",
+                "Beaverton SDA Org (Org C)",
+            ),
+            strict=True,
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, description, email, website)
+                    VALUES (:id, :name, 'beaverton-triple test org',
+                            NULL, 'https://example.org')
+                    """
+                ),
+                {"id": oid, "name": name},
+            )
+
+        # Three locations, all within ~30m at 14645 SW Davis Rd.
+        # Latitude ~45.4869, longitude ~-122.8331 (real Beaverton coords).
+        # 0.0001 deg ≈ 11m, so 0.0002 deg ≈ 22m — well inside the
+        # 0.0005-deg (~55m) DBSCAN epsilon used by the query.
+        seeds = [
+            (
+                loc_ids[0],
+                org_ids[0],
+                "Beaverton Adventist Church (SDA)",
+                45.4869,
+                -122.8331,
+                70,
+                "no_fa_scraper",  # NOT in FANO allowlist
+            ),
+            (
+                loc_ids[1],
+                org_ids[1],
+                "Beaverton Adventist Church (SDA)",
+                45.4870,
+                -122.8332,
+                65,
+                "vivery_api",  # FANO-allowlisted
+            ),
+            (
+                loc_ids[2],
+                org_ids[2],
+                "Beaverton Seventh Day Adventist",
+                45.4871,
+                -122.8330,
+                80,  # Highest confidence — but still must lose to FANO row.
+                "no_fa_scraper",
+            ),
+        ]
+
+        for loc_id, org_id, name, lat, lng, conf, scraper in seeds:
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, :name, :lat, :lng,
+                            'physical', 'verified', :conf)
+                    """
+                ),
+                {
+                    "id": loc_id,
+                    "org": org_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                    "conf": conf,
+                },
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO address (
+                        id, location_id, address_1, city,
+                        state_province, postal_code, country, address_type
+                    )
+                    VALUES (:id, :loc, :addr, 'Beaverton',
+                            'OR', :zip, 'US', 'physical')
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "addr": "14645 SW Davis Rd",
+                    # 97007 must NOT exist in feeding_america_zip_coverage
+                    # for this scenario so the only FA-block driver is the
+                    # qualifying_source CTE — keeps the assertions about
+                    # survivor pick clean. The fa_org_id stays NULL on the
+                    # row but `has_qualifying_source` still flips per the
+                    # CASE-gate.
+                    "zip": "97007",
+                },
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, :scraper, :name, :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "scraper": scraper,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+            # Each location needs one piece of contact info to pass the
+            # "must be reachable" filter. Org website is set above.
+
+        await db_session.flush()
+        return {
+            "loc_ids": loc_ids,
+            "fano_loc_id": loc_ids[1],
+            "highest_conf_loc_id": loc_ids[2],
+        }
+
+    @pytest.mark.asyncio
+    async def test_three_close_rows_collapse_to_one(self, db_session, beaverton_triple):
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(45.48, -122.84, 45.49, -122.82),  # tight on Beaverton seeds
+        )
+        seeded_ids = set(beaverton_triple["loc_ids"])
+        returned = {str(r.id) for r in rows if str(r.id) in seeded_ids}
+        assert (
+            len(returned) == 1
+        ), f"expected exactly one survivor from triple, got {len(returned)}: {returned}"
+
+    @pytest.mark.asyncio
+    async def test_survivor_is_fano_qualifying_row(self, db_session, beaverton_triple):
+        """Even though the FANO row has the LOWEST confidence_score (65)
+        of the three, it must win — Plentiful's only reason to call this
+        endpoint is the FA enrichment block, so dropping it in favor of
+        a higher-confidence sibling is a regression we never tolerate.
+        """
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(45.48, -122.84, 45.49, -122.82),
+        )
+        seeded_ids = set(beaverton_triple["loc_ids"])
+        survivors = [r for r in rows if str(r.id) in seeded_ids]
+        assert len(survivors) == 1
+        winner = survivors[0]
+        assert str(winner.id) == beaverton_triple["fano_loc_id"], (
+            f"survivor should be the FANO-allowlisted row, "
+            f"got {winner.id} (expected {beaverton_triple['fano_loc_id']})"
+        )
+        assert winner.has_qualifying_source is True
+
+    @pytest.mark.asyncio
+    async def test_far_apart_rows_are_not_merged(self, db_session: AsyncSession):
+        """Singleton clusters (minpoints=1) must not drop unique
+        locations. Two rows >55m apart must both come back."""
+        org_id = str(uuid.uuid4())
+        far_a = str(uuid.uuid4())
+        far_b = str(uuid.uuid4())
+
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO organization (id, name, description, website)
+                VALUES (:id, 'Far Org', 'far-apart test org',
+                        'https://example.org')
+                """
+            ),
+            {"id": org_id},
+        )
+        # ~0.01 deg apart (~1.1km) — well outside the 0.0005 epsilon.
+        for loc_id, lat, lng, name in (
+            (far_a, 38.0, -77.0, "Far Pantry A"),
+            (far_b, 38.01, -77.01, "Far Pantry B"),
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, :name, :lat, :lng,
+                            'physical', 'verified', 75)
+                    """
+                ),
+                {"id": loc_id, "org": org_id, "name": name, "lat": lat, "lng": lng},
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, 'no_fa_scraper', :name, :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(37.9, -77.1, 38.1, -76.9),
+        )
+        ids = {str(r.id) for r in rows}
+        assert far_a in ids
+        assert far_b in ids

--- a/tests/test_ptf_locations_queries.py
+++ b/tests/test_ptf_locations_queries.py
@@ -172,6 +172,57 @@ class TestQuerySQL:
         assert "&&" in sql_text
 
     @pytest.mark.asyncio
+    async def test_list_query_clusters_near_duplicate_canonicals(self):
+        """Defense-in-depth: when the reconciler leaves near-duplicate
+        location rows (different name AND different org so its widen-
+        radius merge bails), the endpoint must collapse them via
+        ST_ClusterDBSCAN with eps matching the inbound /sync endpoint."""
+        session = _capture_session()
+        query = PtfLocationsQuery(session)
+        await query.list_locations(limit=10, offset=0)
+        sql_text = str(session.execute.call_args[0][0])
+        assert "ST_ClusterDBSCAN" in sql_text, "list query must run cluster-based dedup"
+        # eps must match the inbound /sync endpoint (services.py) so
+        # operators reason about one tolerance, not two.
+        assert "eps := 0.0005" in sql_text
+        # minpoints=1 means isolated rows form their own singleton
+        # cluster — no unique location is ever dropped.
+        assert "minpoints := 1" in sql_text
+        # Survivor pick must prefer FANO-qualifying rows so the
+        # feeding_america_food_bank enrichment block is never silently
+        # stripped in favor of a non-FANO sibling.
+        norm = " ".join(sql_text.split())
+        assert "has_qualifying_source DESC" in norm
+        # …then highest confidence, then a stable id tie-break.
+        assert (
+            "confidence_score DESC NULLS LAST" in norm
+        ), "survivor pick must fall back to confidence_score after FANO"
+
+    @pytest.mark.asyncio
+    async def test_list_query_keeps_confidence_score_for_survivor_ordering(self):
+        """The clustered survivor pick orders by `confidence_score DESC
+        NULLS LAST`. That requires the column in the inner SELECT — a
+        future refactor that drops it would break dedup silently."""
+        session = _capture_session()
+        query = PtfLocationsQuery(session)
+        await query.list_locations(limit=10, offset=0)
+        sql_text = str(session.execute.call_args[0][0])
+        # `c.confidence_score` (with table alias) shouldn't be required,
+        # but the column name itself must appear in the candidates SELECT.
+        assert "confidence_score" in sql_text
+
+    @pytest.mark.asyncio
+    async def test_detail_query_does_not_cluster(self):
+        """The detail endpoint must keep returning exactly the row asked
+        for — clustering it would silently rewrite the response.id for
+        any consumer that cached a non-survivor id from a prior list."""
+        session = _capture_session()
+        query = PtfLocationsQuery(session)
+        await query.get_location("11111111-2222-3333-4444-555555555555")
+        sql_text = str(session.execute.call_args[0][0])
+        assert "ST_ClusterDBSCAN" not in sql_text
+
+    @pytest.mark.asyncio
     async def test_get_by_id_binds_uuid_param(self):
         session = _capture_session()
         query = PtfLocationsQuery(session)


### PR DESCRIPTION
## Summary
- The public PTF map endpoint was returning multiple rows for the same physical pantry — e.g. three "Beaverton Adventist Church (SDA)" rows at 14645 SW Davis Rd with three different `location.id`s. The reconciler couldn't merge them because its tier-2 widen-radius merge requires matching name OR org, and independent scrapers produced different names AND different orgs.
- Defense-in-depth at the endpoint: wrap the existing per-`l.id` SELECT in a `candidates` CTE, cluster with `ST_ClusterDBSCAN(eps:=0.0005, minpoints:=1)` (~55m, same `eps` as the inbound `/sync` endpoint), then `DISTINCT ON (cluster_id) ORDER BY has_qualifying_source DESC, confidence_score DESC NULLS LAST, id`. FANO-allowlisted rows win survivor pick so the `feeding_america_food_bank` enrichment block is never silently stripped in favor of a non-FANO sibling.
- Detail endpoint intentionally unchanged — `/locations/{id}` must keep returning exactly the row asked for; rewriting `response.id` would break ID stability for any consumer that cached a non-survivor id from a prior list response.

## Test plan
- [x] New unit tests in `tests/test_ptf_locations_queries.py`: SQL contains `ST_ClusterDBSCAN` with correct `eps`/`minpoints`, survivor order prefers FANO then confidence, detail SQL does NOT cluster.
- [x] New real-DB integration tests in `tests/test_ptf_locations_integration.py`:
  - Three close rows collapse to one.
  - FANO row wins survivor even with the *lowest* `confidence_score` (65 vs 80).
  - Singletons >55m apart are never merged.
- [x] Full PTF suite passes (209 tests): `./bouy exec app pytest tests/test_ptf_locations_*.py tests/test_ptf_*.py`
- [x] `./bouy test --ruff` / `--black` / `--bandit` clean on the changed files. mypy clean on the two changed source files.
- [ ] Reviewer: confirm the survivor priority (`has_qualifying_source DESC, confidence_score DESC NULLS LAST, id`) matches operator expectations. The inbound `/sync` endpoint uses `confidence_score DESC NULLS LAST, id` — this adds the FANO prefix so a low-confidence FANO row beats a high-confidence non-FANO sibling.

## Follow-up
Widen reconciler tier-1 tolerance from ~11m → ~50–100m (`app/reconciler/location_creator.py:151,194-195`) so this endpoint-level merge becomes a no-op for new data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)