### PR TITLE
feat(ptf): widen /locations dedup + pad small bboxes

### DIFF
--- a/app/api/v1/partners/ptf/locations_queries.py
+++ b/app/api/v1/partners/ptf/locations_queries.py
@@ -69,14 +69,20 @@ def clamp_offset(value: int) -> int:
 #   * Tight tier (<= _DEDUP_TIGHT_DEG, ~50m): always an edge. Same
 #     parcel / same building — GPS fuzz dominates, names diverge.
 #   * Loose tier (50m < d <= _DEDUP_LOOSE_DEG, ~200m): an edge only if
-#     normalized names fuzzy-match (trigram similarity > 0.5), OR
-#     normalized address_1 fuzzy-matches (>0.7) AND postal codes agree.
+#     normalized names fuzzy-match (`similarity(...) > _NAME_SIM_THRESHOLD`)
+#     OR normalized address_1 fuzzy-matches
+#     (`similarity(...) > _ADDR_SIM_THRESHOLD`) AND 5-digit ZIPs agree.
 #     This catches reconciler-missed dupes on the opposite side of a
 #     parking lot / strip mall while leaving genuinely distinct
-#     neighboring pantries alone.
+#     neighboring pantries alone. Threshold values live as module
+#     constants above; the SQL binds them, never hard-codes the floats.
 #
-# Implementation is a recursive-CTE connected-components walk on those
-# edges. Self-loops in `edges_both` ensure every candidate (including
+# Implementation: spatial-index-aware DBSCAN pre-clusters candidates at
+# `_DEDUP_LOOSE_DEG` (`loose_clusters` CTE) so the per-pair tier-rule
+# self-join only walks within-cluster pairs (small constant). Then a
+# recursive-CTE connected-components walk (`edges` → `edges_both` →
+# `reachable` → `components`) assigns each candidate a `component_id`.
+# Self-loops in `edges_both` ensure every candidate (including
 # singletons) ends up in the result. Survivor per component is picked by
 # `has_qualifying_source DESC, confidence_score DESC NULLS LAST, id ASC`
 # so the FANO enrichment block is never silently stripped when a non-FANO
@@ -124,12 +130,39 @@ candidates AS (
         -- Inputs to the loose-tier fuzzy gate. Strip punctuation and
         -- lowercase; keep stop-words like "church"/"ministry" because
         -- they're often the only signal that two pantries are distinct.
-        lower(regexp_replace(coalesce(l.name, ''),
-              '[^a-zA-Z0-9 ]', '', 'g')) AS norm_name,
-        lower(regexp_replace(coalesce(a.address_1, ''),
-              '[^a-zA-Z0-9 ]', '', 'g')) AS norm_addr,
+        -- `translate(...)` folds the common Latin diacritics to ASCII
+        -- BEFORE the regex strip so "San José" and "San Jose" share
+        -- trigrams instead of differing on `é`. This is portable (no
+        -- `unaccent` extension required) and covers ~Spanish, French,
+        -- Italian, Portuguese — the languages most relevant for US
+        -- food-pantry names. Add more pairs here if a new locale shows
+        -- up; one char per source position in each string.
+        lower(
+            regexp_replace(
+                translate(
+                    coalesce(l.name, ''),
+                    'áàâäãåÁÀÂÄÃÅéèêëÉÈÊËíìîïÍÌÎÏóòôöõÓÒÔÖÕúùûüÚÙÛÜñÑçÇ',
+                    'aaaaaaAAAAAAeeeeEEEEiiiiIIIIoooooOOOOOuuuuUUUUnNcC'
+                ),
+                '[^a-zA-Z0-9 ]', '', 'g'
+            )
+        ) AS norm_name,
+        lower(
+            regexp_replace(
+                translate(
+                    coalesce(a.address_1, ''),
+                    'áàâäãåÁÀÂÄÃÅéèêëÉÈÊËíìîïÍÌÎÏóòôöõÓÒÔÖÕúùûüÚÙÛÜñÑçÇ',
+                    'aaaaaaAAAAAAeeeeEEEEiiiiIIIIoooooOOOOOuuuuUUUUnNcC'
+                ),
+                '[^a-zA-Z0-9 ]', '', 'g'
+            )
+        ) AS norm_addr,
         SUBSTR(a.postal_code, 1, 5) AS zip5,
-        -- Cached geometry — used twice (cluster pairing + GIST bbox).
+        -- Cached geometry so the downstream loose-cluster DBSCAN and
+        -- the per-pair ST_DWithin don't recompute the make-point each
+        -- row. The bbox filter below still uses the indexed expression
+        -- against `location l` directly, which is what hits the GIST
+        -- index `idx_location_coords`.
         ST_SetSRID(
             ST_MakePoint(
                 CAST(l.longitude AS float8),
@@ -174,18 +207,51 @@ candidates AS (
              fa.fa_org_id NULLS LAST,
              p.id NULLS LAST
 ),
--- Tier edges: a directed pair (a < b) gets an edge whenever the two
--- candidates land in the same dedup component. Tight tier always
--- contributes; loose tier requires the trigram-similarity gate.
+-- Loose pre-cluster: spatial-index-aware DBSCAN groups candidates
+-- within the loose-tier ceiling. ST_ClusterDBSCAN is a window function
+-- that internally walks the GIST index on `idx_location_coords` (when
+-- the planner can see through to the indexed expression), so this is
+-- O(N log N) rather than the O(N^2) of a naive self-join. The
+-- per-pair tier rule then only needs to look at within-cluster pairs,
+-- which in practice are 1-3 rows.
+loose_clusters AS (
+    SELECT c.*,
+           ST_ClusterDBSCAN(
+               c.geom,
+               eps := :dedup_loose_deg,
+               minpoints := 1
+           ) OVER () AS loose_cluster_id
+    FROM candidates c
+),
+-- Tier edges: a directed pair (a < b) gets an edge when (i) they sit
+-- in the same loose pre-cluster (within ~200m or transitively reachable
+-- via 200m hops) AND (ii) the tier rule fires. Tight tier (~50m) always
+-- contributes; loose tier requires the trigram-similarity gate. The
+-- intra-cluster join is small enough that the per-pair similarity()
+-- and tight-tier ST_DWithin calls are cheap.
 edges AS (
     SELECT c1.id AS a_id, c2.id AS b_id
-    FROM candidates c1
-    JOIN candidates c2 ON c1.id < c2.id
+    FROM loose_clusters c1
+    JOIN loose_clusters c2
+      ON c1.loose_cluster_id = c2.loose_cluster_id
+     AND c1.id < c2.id
+    -- Strict pairwise loose-tier cap. DBSCAN's transitive-neighbor
+    -- semantics can span more than `eps` end-to-end (A within 200m of
+    -- B, B within 200m of C, A 350m from C — all one cluster). The
+    -- explicit ST_DWithin keeps direct pair edges capped at 200m and
+    -- relies on the recursive components walk below for transitivity.
     WHERE ST_DWithin(c1.geom, c2.geom, :dedup_loose_deg)
       AND (
           ST_DWithin(c1.geom, c2.geom, :dedup_tight_deg)
           OR similarity(c1.norm_name, c2.norm_name) > :name_sim_threshold
           OR (
+              -- Name gate fires regardless of ZIP — the 200m geo cap
+              -- is the proximity gate, and two same-named rows that
+              -- close together are nearly always the same physical
+              -- pantry pin even when ZIP boundaries split them.
+              -- Address gate requires ZIP agreement because address_1
+              -- alone is too easy to match coincidentally ("100 Main
+              -- St" exists in every town).
               similarity(c1.norm_addr, c2.norm_addr) > :addr_sim_threshold
               AND c1.zip5 IS NOT NULL
               AND c1.zip5 = c2.zip5

--- a/app/api/v1/partners/ptf/locations_queries.py
+++ b/app/api/v1/partners/ptf/locations_queries.py
@@ -16,7 +16,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.v1.partners.ptf._allowlist import FANO_ALLOWLIST
 
 _MIN_LIMIT = 1
-_MAX_LIMIT = 200
+_MAX_LIMIT = 500
+
+# Tiered cluster-dedup thresholds. SRID-4326 degrees; ~111m per degree at
+# the equator, narrower at higher lats — close enough for CONUS pantry
+# spacing. Tight tier always merges; loose tier merges only when a
+# name/address gate fires.
+_DEDUP_TIGHT_DEG = 0.00045  # ~50m
+_DEDUP_LOOSE_DEG = 0.00180  # ~200m
+# pg_trgm similarity thresholds for the loose-tier gate. Names are
+# typically shorter and noisier than addresses (org suffixes, "Church of
+# X" vs "X Church") so use a lower bar for names than addresses.
+_NAME_SIM_THRESHOLD = 0.5
+_ADDR_SIM_THRESHOLD = 0.7
 
 
 def clamp_limit(value: int) -> int:
@@ -52,22 +64,30 @@ def clamp_offset(value: int) -> int:
 # endpoint as defense-in-depth: the reconciler's name-or-org-constrained
 # merge tier bails when independent scrapers produce different names AND
 # different orgs for the same physical pantry, so duplicates leak into
-# `location`. ST_ClusterDBSCAN(eps:=0.0005, minpoints:=1) groups rows
-# whose (lng,lat) sit within ~55m of each other (eps is in SRID-4326
-# degrees, ~111m per degree at the equator, narrower at higher lats);
-# minpoints=1 means isolated rows form their own singleton cluster so no
-# unique location is ever dropped. The survivor per cluster is picked by
+# `location`. The dedup is tiered:
+#
+#   * Tight tier (<= _DEDUP_TIGHT_DEG, ~50m): always an edge. Same
+#     parcel / same building — GPS fuzz dominates, names diverge.
+#   * Loose tier (50m < d <= _DEDUP_LOOSE_DEG, ~200m): an edge only if
+#     normalized names fuzzy-match (trigram similarity > 0.5), OR
+#     normalized address_1 fuzzy-matches (>0.7) AND postal codes agree.
+#     This catches reconciler-missed dupes on the opposite side of a
+#     parking lot / strip mall while leaving genuinely distinct
+#     neighboring pantries alone.
+#
+# Implementation is a recursive-CTE connected-components walk on those
+# edges. Self-loops in `edges_both` ensure every candidate (including
+# singletons) ends up in the result. Survivor per component is picked by
 # `has_qualifying_source DESC, confidence_score DESC NULLS LAST, id ASC`
 # so the FANO enrichment block is never silently stripped when a non-FANO
-# sibling exists — matches the eps used by the inbound /sync endpoint
-# (`services.py:_build_qualified_cte`).
+# sibling exists.
 #
 # The CTE is inlined into both _LIST_SQL and _DETAIL_SQL rather than
 # string-concatenated so bandit's B608 (hardcoded_sql_expressions) heuristic
 # stays clean. Allowlist values are bound via SQLAlchemy `expanding=True`
 # (see `_bind_allowlist`); no scraper IDs are interpolated into SQL text.
 _LIST_SQL = """
-WITH qualifying_source AS (
+WITH RECURSIVE qualifying_source AS (
     SELECT location_id,
            BOOL_OR(true) AS has_qualifying_source
     FROM location_source
@@ -100,7 +120,23 @@ candidates AS (
         CASE WHEN COALESCE(qs.has_qualifying_source, false)
              THEN fa.fa_org_name END AS fa_org_name,
         COALESCE(qs.has_qualifying_source, false) AS has_qualifying_source,
-        (fa.fa_org_id IS NOT NULL) AS zip_matched_fa
+        (fa.fa_org_id IS NOT NULL) AS zip_matched_fa,
+        -- Inputs to the loose-tier fuzzy gate. Strip punctuation and
+        -- lowercase; keep stop-words like "church"/"ministry" because
+        -- they're often the only signal that two pantries are distinct.
+        lower(regexp_replace(coalesce(l.name, ''),
+              '[^a-zA-Z0-9 ]', '', 'g')) AS norm_name,
+        lower(regexp_replace(coalesce(a.address_1, ''),
+              '[^a-zA-Z0-9 ]', '', 'g')) AS norm_addr,
+        SUBSTR(a.postal_code, 1, 5) AS zip5,
+        -- Cached geometry — used twice (cluster pairing + GIST bbox).
+        ST_SetSRID(
+            ST_MakePoint(
+                CAST(l.longitude AS float8),
+                CAST(l.latitude AS float8)
+            ),
+            4326
+        ) AS geom
     FROM location l
     LEFT JOIN organization o ON l.organization_id = o.id
     LEFT JOIN address a ON a.location_id = l.id AND a.address_type = 'physical'
@@ -138,48 +174,75 @@ candidates AS (
              fa.fa_org_id NULLS LAST,
              p.id NULLS LAST
 ),
-clustered AS (
-    SELECT c.*,
-           ST_ClusterDBSCAN(
-               ST_SetSRID(
-                   ST_MakePoint(
-                       CAST(c.longitude AS float8),
-                       CAST(c.latitude AS float8)
-                   ),
-                   4326
-               ),
-               eps := 0.0005,
-               minpoints := 1
-           ) OVER () AS cluster_id
-    FROM candidates c
+-- Tier edges: a directed pair (a < b) gets an edge whenever the two
+-- candidates land in the same dedup component. Tight tier always
+-- contributes; loose tier requires the trigram-similarity gate.
+edges AS (
+    SELECT c1.id AS a_id, c2.id AS b_id
+    FROM candidates c1
+    JOIN candidates c2 ON c1.id < c2.id
+    WHERE ST_DWithin(c1.geom, c2.geom, :dedup_loose_deg)
+      AND (
+          ST_DWithin(c1.geom, c2.geom, :dedup_tight_deg)
+          OR similarity(c1.norm_name, c2.norm_name) > :name_sim_threshold
+          OR (
+              similarity(c1.norm_addr, c2.norm_addr) > :addr_sim_threshold
+              AND c1.zip5 IS NOT NULL
+              AND c1.zip5 = c2.zip5
+          )
+      )
+),
+-- Bidirectional edge set plus self-loops so singletons survive.
+edges_both AS (
+    SELECT id AS a, id AS b FROM candidates
+    UNION ALL
+    SELECT a_id AS a, b_id AS b FROM edges
+    UNION ALL
+    SELECT b_id AS a, a_id AS b FROM edges
+),
+-- Transitive closure: reachable[node] = every node in the same
+-- connected component. Recursion converges in O(component diameter)
+-- steps; in practice components are 1-3 rows so this is cheap.
+reachable AS (
+    SELECT a AS node, b AS reach FROM edges_both
+    UNION
+    SELECT r.node, e.b
+    FROM reachable r
+    JOIN edges_both e ON r.reach = e.a
+),
+components AS (
+    SELECT node, MIN(reach) AS component_id
+    FROM reachable
+    GROUP BY node
 )
-SELECT DISTINCT ON (cluster_id)
-    id,
-    name,
-    short_name,
-    description,
-    latitude,
-    longitude,
-    organization_id,
-    org_name,
-    org_description,
-    org_email,
-    org_website,
-    address_1,
-    address_2,
-    city,
-    state_province,
-    postal_code,
-    phone_number,
-    fa_org_id,
-    fa_org_name,
-    has_qualifying_source,
-    zip_matched_fa
-FROM clustered
-ORDER BY cluster_id,
-         has_qualifying_source DESC,
-         confidence_score DESC NULLS LAST,
-         id
+SELECT DISTINCT ON (comp.component_id)
+    c.id,
+    c.name,
+    c.short_name,
+    c.description,
+    c.latitude,
+    c.longitude,
+    c.organization_id,
+    c.org_name,
+    c.org_description,
+    c.org_email,
+    c.org_website,
+    c.address_1,
+    c.address_2,
+    c.city,
+    c.state_province,
+    c.postal_code,
+    c.phone_number,
+    c.fa_org_id,
+    c.fa_org_name,
+    c.has_qualifying_source,
+    c.zip_matched_fa
+FROM candidates c
+JOIN components comp ON comp.node = c.id
+ORDER BY comp.component_id,
+         c.has_qualifying_source DESC,
+         c.confidence_score DESC NULLS LAST,
+         c.id
 LIMIT :limit OFFSET :offset
 """
 
@@ -291,6 +354,10 @@ class PtfLocationsQuery:
             "limit": clamp_limit(limit),
             "offset": clamp_offset(offset),
             "allowlist": _FANO_ALLOWLIST_TUPLE,
+            "dedup_tight_deg": _DEDUP_TIGHT_DEG,
+            "dedup_loose_deg": _DEDUP_LOOSE_DEG,
+            "name_sim_threshold": _NAME_SIM_THRESHOLD,
+            "addr_sim_threshold": _ADDR_SIM_THRESHOLD,
         }
         bbox_clause = ""
         if bbox is not None:

--- a/app/api/v1/partners/ptf/locations_router.py
+++ b/app/api/v1/partners/ptf/locations_router.py
@@ -36,6 +36,38 @@ locations_router = APIRouter(tags=["partners"])
 _LIST_CACHE_CONTROL = "public, max-age=60, s-maxage=300"
 _DETAIL_CACHE_CONTROL = "public, max-age=300, s-maxage=300"
 
+# Minimum bbox side length, in SRID-4326 degrees. ~3 miles at the
+# equator (0.0435 * 111km/deg = 4.83 km ≈ 3 mi); slightly less in real
+# distance at higher US latitudes for longitude, which is fine for a
+# floor. Clients zooming into a single block would otherwise see pins
+# pop out of the response as the viewport edge clips them — this floor
+# guarantees a ~3-mile margin around any small viewport.
+_BBOX_MIN_SIZE_DEG = 0.0435
+
+
+def _pad_bbox_to_min(
+    bbox: tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
+    """Expand small bboxes to a minimum side length around their center.
+
+    Also incidentally normalizes min/max ordering, so callers that swap
+    `lat1`/`lat2` (or `lng1`/`lng2`) still get a valid envelope. Inputs
+    above the floor pass through untouched.
+    """
+    lat1, lng1, lat2, lng2 = bbox
+    lat_min, lat_max = sorted((lat1, lat2))
+    lng_min, lng_max = sorted((lng1, lng2))
+    lat_center = (lat_min + lat_max) / 2
+    lng_center = (lng_min + lng_max) / 2
+    half = _BBOX_MIN_SIZE_DEG / 2
+    if (lat_max - lat_min) < _BBOX_MIN_SIZE_DEG:
+        lat_min = lat_center - half
+        lat_max = lat_center + half
+    if (lng_max - lng_min) < _BBOX_MIN_SIZE_DEG:
+        lng_min = lng_center - half
+        lng_max = lng_center + half
+    return (lat_min, lng_min, lat_max, lng_max)
+
 
 @locations_router.get(
     "/locations",
@@ -50,7 +82,7 @@ _DETAIL_CACHE_CONTROL = "public, max-age=300, s-maxage=300"
 )
 async def list_ptf_locations(
     response: Response,
-    limit: int = Query(50, ge=1, le=200),
+    limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
     lat1: Optional[float] = Query(None, ge=-90, le=90),
     lng1: Optional[float] = Query(None, ge=-180, le=180),
@@ -66,13 +98,29 @@ async def list_ptf_locations(
             status_code=422,
             detail="Bounding box requires all of lat1, lng1, lat2, lng2",
         )
-    bbox = tuple(bbox_parts) if len(provided) == 4 else None  # type: ignore[assignment]
+    bbox: Optional[tuple[float, float, float, float]] = (
+        (
+            float(bbox_parts[0]),  # type: ignore[arg-type]
+            float(bbox_parts[1]),  # type: ignore[arg-type]
+            float(bbox_parts[2]),  # type: ignore[arg-type]
+            float(bbox_parts[3]),  # type: ignore[arg-type]
+        )
+        if len(provided) == 4
+        else None
+    )
+    bbox_padded = False
+    if bbox is not None:
+        padded = _pad_bbox_to_min(bbox)
+        if padded != bbox:
+            bbox_padded = True
+            bbox = padded
 
     log = logger.bind(
         endpoint="ptf_locations_list",
         limit=limit,
         offset=offset,
         has_bbox=bbox is not None,
+        bbox_padded=bbox_padded,
         has_q=q is not None,
     )
 
@@ -104,10 +152,10 @@ async def list_ptf_locations(
         returned=len(items),
         dropped=dropped,
         fa_matched=fa_matched,
-        # Near-duplicate canonicals are collapsed at query time via
-        # ST_ClusterDBSCAN — see `_LIST_SQL` in locations_queries.py.
-        # Flag included so CloudWatch can confirm the cluster path is
-        # live, and so a future drop in fa_matched can be correlated.
+        # Near-duplicate canonicals are collapsed at query time via a
+        # tiered connected-components walk (tight ~50m always-merge,
+        # loose ~200m gated by name/address similarity). See
+        # `_LIST_SQL` in locations_queries.py.
         dedup_active=True,
     )
     response.headers["Cache-Control"] = _LIST_CACHE_CONTROL

--- a/app/api/v1/partners/ptf/locations_router.py
+++ b/app/api/v1/partners/ptf/locations_router.py
@@ -44,15 +44,29 @@ _DETAIL_CACHE_CONTROL = "public, max-age=300, s-maxage=300"
 # guarantees a ~3-mile margin around any small viewport.
 _BBOX_MIN_SIZE_DEG = 0.0435
 
+# Heuristic for "this looks like the caller meant to wrap the
+# antimeridian". A legitimate viewport spans at most ~180° of longitude;
+# anything wider almost certainly came from `lng1=170, lng2=-170` (which
+# we then sort to `(-170, 170)` = a planet-sized envelope). We log a
+# warning but don't reject — PTF is US-only in practice and a server-
+# side 422 would surprise any future Pacific-region client.
+_ANTIMERIDIAN_LNG_SPAN_THRESHOLD = 180.0
+
 
 def _pad_bbox_to_min(
     bbox: tuple[float, float, float, float],
 ) -> tuple[float, float, float, float]:
     """Expand small bboxes to a minimum side length around their center.
 
-    Also incidentally normalizes min/max ordering, so callers that swap
-    `lat1`/`lat2` (or `lng1`/`lng2`) still get a valid envelope. Inputs
-    above the floor pass through untouched.
+    Side effects beyond expansion:
+      * Sorts min/max so callers that swap `lat1`/`lat2` (or
+        `lng1`/`lng2`) still get a valid envelope.
+      * Clamps the padded result back into the SRID-4326 valid range
+        (`[-90, 90]` latitude, `[-180, 180]` longitude) so near-edge
+        inputs don't produce an out-of-range envelope after expansion.
+
+    Inputs above the floor and inside the valid range pass through
+    untouched.
     """
     lat1, lng1, lat2, lng2 = bbox
     lat_min, lat_max = sorted((lat1, lat2))
@@ -66,6 +80,12 @@ def _pad_bbox_to_min(
     if (lng_max - lng_min) < _BBOX_MIN_SIZE_DEG:
         lng_min = lng_center - half
         lng_max = lng_center + half
+    # Clamp back into SRID-4326 valid range. ST_MakeEnvelope is lenient
+    # but values outside the range are still nonsense.
+    lat_min = max(-90.0, lat_min)
+    lat_max = min(90.0, lat_max)
+    lng_min = max(-180.0, lng_min)
+    lng_max = min(180.0, lng_max)
     return (lat_min, lng_min, lat_max, lng_max)
 
 
@@ -108,18 +128,33 @@ async def list_ptf_locations(
         if len(provided) == 4
         else None
     )
-    bbox_padded = False
+    bbox_padded: Optional[bool] = None
     if bbox is not None:
+        # Antimeridian heuristic: a single-viewport request never spans
+        # more than 180° of longitude; anything wider is almost certainly
+        # `lng1=170, lng2=-170` (which we'd otherwise normalize to a
+        # planet-sized envelope without complaint). Warn so the issue is
+        # diagnosable, but proceed — PTF is US-only in practice and a
+        # 422 would surprise any future Pacific-region client.
+        if abs(bbox[3] - bbox[1]) > _ANTIMERIDIAN_LNG_SPAN_THRESHOLD:
+            logger.warning(
+                "ptf_bbox_antimeridian_suspect",
+                lng1=bbox[1],
+                lng2=bbox[3],
+                span_deg=abs(bbox[3] - bbox[1]),
+            )
         padded = _pad_bbox_to_min(bbox)
-        if padded != bbox:
-            bbox_padded = True
-            bbox = padded
+        bbox_padded = padded != bbox
+        bbox = padded
 
     log = logger.bind(
         endpoint="ptf_locations_list",
         limit=limit,
         offset=offset,
         has_bbox=bbox is not None,
+        # None when no bbox was provided; True/False when one was. Keeps
+        # CloudWatch filters that count `bbox_padded=true` honest — the
+        # base rate is the count of `has_bbox=true` requests.
         bbox_padded=bbox_padded,
         has_q=q is not None,
     )

--- a/tests/test_ptf_locations_integration.py
+++ b/tests/test_ptf_locations_integration.py
@@ -24,7 +24,10 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from unittest.mock import MagicMock
+
 from app.api.v1.partners.ptf.locations_queries import PtfLocationsQuery
+from app.api.v1.partners.ptf.locations_router import list_ptf_locations
 from app.api.v1.partners.ptf.locations_transformer import (
     FA_CATALOGUE,
     to_detail,
@@ -863,7 +866,7 @@ class TestNearDuplicateCollapse:
     async def test_loose_tier_merges_same_address_within_200m(
         self, db_session: AsyncSession
     ):
-        """~150m apart, different names but identical normalized address
+        """~120m apart, different names but identical normalized address
         + ZIP. The address gate (>0.7 similarity, ZIP match) must merge
         them. Realistic case: two scrapers describing the same building
         with different naming conventions ('St. John Pantry' vs 'Saint
@@ -885,8 +888,9 @@ class TestNearDuplicateCollapse:
                 {"id": oid},
             )
 
-        # ~145m apart (0.0013 deg lng ≈ 110m at this lat) — well inside
-        # the 200m loose tier, well outside the 50m tight tier.
+        # ~120m apart on the lng axis at this latitude:
+        # 0.0013 deg * cos(33.75°) * 111 km/deg ≈ 120m. Well inside the
+        # 200m loose tier, well outside the 50m tight tier.
         for loc_id, org_id, lat, lng, name in (
             (loc_a, org_a, 33.7500, -84.3900, "St. John Food Pantry"),
             (loc_b, org_b, 33.7500, -84.3915, "Saint John's Outreach Center"),
@@ -1126,3 +1130,439 @@ class TestNearDuplicateCollapse:
         ids = {str(r.id) for r in rows}
         assert far_a in ids
         assert far_b in ids
+
+
+async def _seed_location(
+    session: AsyncSession,
+    *,
+    loc_id: str,
+    org_id: str,
+    name: str,
+    lat: float,
+    lng: float,
+    address_1: str,
+    postal_code: str,
+    confidence: int = 70,
+    scraper_id: str = "no_fa_scraper",
+) -> None:
+    """Common seed helper for the loose-tier integration scenarios.
+
+    Each row gets an org website so the "has contact info" filter
+    passes, a single location_source so the FANO qualifying-source CTE
+    sees it, and a physical address so the address gate has something
+    to compare.
+    """
+    await session.execute(
+        text(
+            """
+            INSERT INTO organization (id, name, description, website)
+            VALUES (:id, :name, 'shared-helper test org',
+                    'https://example.org')
+            ON CONFLICT (id) DO NOTHING
+            """
+        ),
+        {"id": org_id, "name": name},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO location (
+                id, organization_id, name, latitude, longitude,
+                location_type, validation_status, confidence_score
+            )
+            VALUES (:id, :org, :name, :lat, :lng,
+                    'physical', 'verified', :conf)
+            """
+        ),
+        {
+            "id": loc_id,
+            "org": org_id,
+            "name": name,
+            "lat": lat,
+            "lng": lng,
+            "conf": confidence,
+        },
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO address (
+                id, location_id, address_1, city,
+                state_province, postal_code, country, address_type
+            )
+            VALUES (:id, :loc, :addr, 'Anywhere',
+                    'XX', :zip, 'US', 'physical')
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "loc": loc_id,
+            "addr": address_1,
+            "zip": postal_code,
+        },
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO location_source (
+                id, location_id, scraper_id, name, latitude, longitude
+            )
+            VALUES (:id, :loc, :scraper, :name, :lat, :lng)
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "loc": loc_id,
+            "scraper": scraper_id,
+            "name": name,
+            "lat": lat,
+            "lng": lng,
+        },
+    )
+
+
+class TestTieredDedupEdgeCases:
+    """Loose-tier semantics that aren't covered by the headline
+    name-match / address-match / distinct-neighbor cases above."""
+
+    @pytest.mark.asyncio
+    async def test_transitive_chain_collapses_via_recursive_cte(
+        self, db_session: AsyncSession
+    ):
+        """A↔B by name only, B↔C by address only, A and C have no direct
+        edge. All three must collapse to a single component via the
+        recursive transitive-closure walk. This is the specific reason
+        the implementation uses `WITH RECURSIVE` — a non-transitive join
+        would return A, B, C as three separate rows here.
+        """
+        org_id = str(uuid.uuid4())
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+        loc_c = str(uuid.uuid4())
+        # All three rows ~80m apart along a north-south line at lat 47.
+        # 0.0008 deg lat ≈ 89m, comfortably inside loose-tier ceiling and
+        # outside tight-tier floor so neither geo tier merges them.
+        # A and B share name ("River Valley Food Pantry") but distinct
+        # addresses; B and C share address ("500 River Rd" / ZIP) but
+        # distinct names; A and C share NOTHING — name differs, address
+        # differs, ZIP differs. Without transitive closure A and C
+        # would NOT merge.
+        await _seed_location(
+            db_session,
+            loc_id=loc_a,
+            org_id=org_id,
+            name="River Valley Food Pantry",
+            lat=47.0000,
+            lng=-122.0000,
+            address_1="100 Oak Ave",
+            postal_code="98101",
+        )
+        await _seed_location(
+            db_session,
+            loc_id=loc_b,
+            org_id=str(uuid.uuid4()),
+            name="River Valley Food Pantry",
+            lat=47.0008,
+            lng=-122.0000,
+            address_1="500 River Rd",
+            postal_code="98102",
+        )
+        await _seed_location(
+            db_session,
+            loc_id=loc_c,
+            org_id=str(uuid.uuid4()),
+            name="Olympic Outreach Center",
+            lat=47.0016,
+            lng=-122.0000,
+            address_1="500 River Rd",
+            postal_code="98102",
+        )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(46.99, -122.01, 47.01, -121.99),
+        )
+        seeded = {loc_a, loc_b, loc_c}
+        returned = {str(r.id) for r in rows if str(r.id) in seeded}
+        assert len(returned) == 1, (
+            f"transitive A-B-C chain must collapse to ONE survivor, "
+            f"got {len(returned)}: {returned}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_same_name_different_zip_within_200m_merges(
+        self, db_session: AsyncSession
+    ):
+        """Pin the documented semantics: the loose-tier name gate
+        fires regardless of ZIP because the 200m geo cap is the
+        proximity gate. Two rows ~120m apart with identical normalized
+        name but in different ZIPs collapse — a ZIP boundary running
+        through a parking lot shouldn't keep duplicates apart.
+        """
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+        org_a = str(uuid.uuid4())
+        org_b = str(uuid.uuid4())
+        await _seed_location(
+            db_session,
+            loc_id=loc_a,
+            org_id=org_a,
+            name="Borderline Pantry of Centerville",
+            lat=39.5000,
+            lng=-105.0000,
+            address_1="100 ZIP-A Side",
+            postal_code="80014",
+        )
+        await _seed_location(
+            db_session,
+            loc_id=loc_b,
+            org_id=org_b,
+            name="Borderline Pantry of Centerville",
+            lat=39.5011,
+            lng=-105.0000,
+            address_1="200 ZIP-B Side",
+            postal_code="80015",
+        )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(39.49, -105.01, 39.51, -104.99),
+        )
+        seeded = {loc_a, loc_b}
+        returned = {str(r.id) for r in rows if str(r.id) in seeded}
+        assert (
+            len(returned) == 1
+        ), f"same-name different-ZIP rows within 200m must merge, got {returned}"
+
+    @pytest.mark.asyncio
+    async def test_null_name_rows_do_not_merge_on_name_gate(
+        self, db_session: AsyncSession
+    ):
+        """Both rows have `name = NULL`, sit ~120m apart, and carry
+        completely different addresses. similarity('','') in pg_trgm
+        returns 0, well below the 0.5 threshold, so the name gate must
+        not fire. The address gate doesn't fire either (different
+        address_1). They must NOT merge.
+        """
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+        org_id = str(uuid.uuid4())
+        # The "has_contact" filter requires a contact field, and the
+        # _seed_location helper assumes a name (sets `INSERT ... :name`).
+        # We need NULL names, so we seed by hand. Use the org website as
+        # the contact-info anchor.
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO organization (id, name, description, website)
+                VALUES (:id, 'Nameless Org', 'null-name test',
+                        'https://example.org')
+                """
+            ),
+            {"id": org_id},
+        )
+        for loc_id, lat, lng, addr in (
+            (loc_a, 30.0000, -90.0000, "100 Anonymous Way"),
+            (loc_b, 30.0011, -90.0000, "999 Nowhere Blvd"),
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, NULL, :lat, :lng,
+                            'physical', 'verified', 70)
+                    """
+                ),
+                {"id": loc_id, "org": org_id, "lat": lat, "lng": lng},
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO address (
+                        id, location_id, address_1, city,
+                        state_province, postal_code, country, address_type
+                    )
+                    VALUES (:id, :loc, :addr, 'NowhereCity', 'LA',
+                            '70112', 'US', 'physical')
+                    """
+                ),
+                {"id": str(uuid.uuid4()), "loc": loc_id, "addr": addr},
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, 'no_fa_scraper',
+                            'null-name seed', :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(29.99, -90.01, 30.01, -89.99),
+        )
+        seeded = {loc_a, loc_b}
+        returned = {str(r.id) for r in rows if str(r.id) in seeded}
+        assert returned == {
+            loc_a,
+            loc_b,
+        }, "NULL-name rows must not merge via name gate"
+
+    @pytest.mark.asyncio
+    async def test_accented_name_folds_to_ascii(self, db_session: AsyncSession):
+        """The normalization pipeline must fold Latin diacritics before
+        the regex strip so 'San José Community Pantry' and 'San Jose
+        Community Pantry' share trigrams. Two rows ~120m apart with
+        names differing only in `é` vs `e` must merge under the loose
+        tier — without folding, the regex would drop `é` entirely
+        and the trigram similarity would be artificially low.
+        """
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+        await _seed_location(
+            db_session,
+            loc_id=loc_a,
+            org_id=str(uuid.uuid4()),
+            name="San José Community Pantry",
+            lat=37.3000,
+            lng=-121.8700,
+            address_1="100 Almaden Blvd",
+            postal_code="95113",
+        )
+        await _seed_location(
+            db_session,
+            loc_id=loc_b,
+            org_id=str(uuid.uuid4()),
+            name="San Jose Community Pantry",
+            lat=37.3011,
+            lng=-121.8700,
+            address_1="500 Market St",
+            postal_code="95113",
+        )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(37.29, -121.88, 37.31, -121.86),
+        )
+        seeded = {loc_a, loc_b}
+        returned = {str(r.id) for r in rows if str(r.id) in seeded}
+        assert len(returned) == 1, f"accent-folded names must merge, got {returned}"
+
+    @pytest.mark.asyncio
+    async def test_bbox_padding_pulls_in_nearby_pin(self, db_session: AsyncSession):
+        """End-to-end check that `_pad_bbox_to_min` actually changes
+        which rows the SQL returns. Seed a pin ~1.5 mi north of a
+        tiny (0.001°-wide) viewport center and call the router (where
+        padding happens, not the query layer); the pin must come back
+        because the 3-mi floor expanded the viewport to include it.
+
+        This exists because the helper is exhaustively unit-tested but
+        a regression that wires padding through the wrong code path
+        would still pass all helper tests while quietly leaving the
+        SQL unchanged.
+        """
+        org_id = str(uuid.uuid4())
+        near_pin = str(uuid.uuid4())
+        # Viewport center: (48.0000, -123.0000). Pin ~1.3 mi north:
+        # 0.019° lat ≈ 2.1 km ≈ 1.3 mi. Tiny bbox (0.001° on a side)
+        # would normally clip it. After 3-mi padding (0.0435° on a
+        # side, half-extent 0.02175°), the pin at +0.019° lat is
+        # comfortably inside the padded envelope.
+        await _seed_location(
+            db_session,
+            loc_id=near_pin,
+            org_id=org_id,
+            name="Near-The-Viewport Pantry",
+            lat=48.0190,
+            lng=-123.0000,
+            address_1="100 Just Outside Ln",
+            postal_code="98362",
+        )
+        await db_session.flush()
+
+        response = MagicMock(headers={})
+        results = await list_ptf_locations(
+            response=response,
+            limit=50,
+            offset=0,
+            # 0.001° wide, centered on (48.0, -123.0).
+            lat1=47.9995,
+            lng1=-123.0005,
+            lat2=48.0005,
+            lng2=-122.9995,
+            q=None,
+            session=db_session,
+        )
+        returned_ids = {r.id for r in results}
+        assert near_pin in returned_ids, (
+            "padded bbox must pull in pins inside the 3-mi floor; "
+            f"got {len(returned_ids)} results without the seed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_boundary_at_200m_still_merges(self, db_session: AsyncSession):
+        """Guards against a regression that flips `ST_DWithin`'s
+        inclusive comparison to strict `<`. Two rows just inside the
+        loose-tier ceiling (~199m apart) with identical names must
+        merge. Use 0.00170 deg ≈ 189m so we're inside the ceiling
+        without being right on a floating-point razor's edge.
+        """
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+        await _seed_location(
+            db_session,
+            loc_id=loc_a,
+            org_id=str(uuid.uuid4()),
+            name="Edge Of The Window Pantry",
+            lat=44.0000,
+            lng=-93.0000,
+            address_1="100 Boundary Ln",
+            postal_code="55101",
+        )
+        await _seed_location(
+            db_session,
+            loc_id=loc_b,
+            org_id=str(uuid.uuid4()),
+            name="Edge Of The Window Pantry",
+            lat=44.0017,
+            lng=-93.0000,
+            address_1="200 Limit Rd",
+            postal_code="55102",
+        )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(43.99, -93.01, 44.01, -92.99),
+        )
+        seeded = {loc_a, loc_b}
+        returned = {str(r.id) for r in rows if str(r.id) in seeded}
+        assert (
+            len(returned) == 1
+        ), f"rows just inside loose-tier ceiling must merge, got {returned}"

--- a/tests/test_ptf_locations_integration.py
+++ b/tests/test_ptf_locations_integration.py
@@ -598,8 +598,8 @@ class TestNearDuplicateCollapse:
     """Defense-in-depth: when the reconciler leaves multiple `location`
     rows for the same physical pantry (different scrapers, different
     names, no shared org), the endpoint must collapse them to one row
-    via ST_ClusterDBSCAN so Plentiful's map doesn't show three pins on
-    top of each other.
+    via the tiered cluster-dedup so Plentiful's map doesn't show three
+    pins on top of each other.
 
     Scenario mirrors the real Beaverton Adventist Church (SDA) case
     that triggered this work: three slightly-different names at the
@@ -638,7 +638,7 @@ class TestNearDuplicateCollapse:
         # Three locations, all within ~30m at 14645 SW Davis Rd.
         # Latitude ~45.4869, longitude ~-122.8331 (real Beaverton coords).
         # 0.0001 deg ≈ 11m, so 0.0002 deg ≈ 22m — well inside the
-        # 0.0005-deg (~55m) DBSCAN epsilon used by the query.
+        # 0.00045-deg (~50m) tight-tier epsilon used by the query.
         seeds = [
             (
                 loc_ids[0],
@@ -780,9 +780,291 @@ class TestNearDuplicateCollapse:
         assert winner.has_qualifying_source is True
 
     @pytest.mark.asyncio
+    async def test_loose_tier_merges_same_name_within_200m(
+        self, db_session: AsyncSession
+    ):
+        """Two rows ~120m apart with the same normalized name must
+        merge via the loose tier (50-200m, name-gated). This is the
+        primary motivating case — strip-mall / parking-lot pantries
+        that the tight 50m tier alone misses."""
+        org_a = str(uuid.uuid4())
+        org_b = str(uuid.uuid4())
+        loc_near = str(uuid.uuid4())
+        loc_far_ish = str(uuid.uuid4())
+
+        for oid in (org_a, org_b):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, description, website)
+                    VALUES (:id, 'Loose Tier Org', 'loose tier test',
+                            'https://example.org')
+                    """
+                ),
+                {"id": oid},
+            )
+
+        # ~120m apart on the lat axis (0.0011 deg lat ≈ 122m). Same
+        # normalized name → loose-tier name gate fires → merged.
+        for loc_id, org_id, lat, lng, name in (
+            (loc_near, org_a, 42.5000, -71.0000, "Greater Boston Food Pantry"),
+            (loc_far_ish, org_b, 42.5011, -71.0000, "Greater Boston Food Pantry"),
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, :name, :lat, :lng,
+                            'physical', 'verified', 70)
+                    """
+                ),
+                {
+                    "id": loc_id,
+                    "org": org_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, 'no_fa_scraper', :name, :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(42.49, -71.01, 42.51, -70.99),
+        )
+        returned = {str(r.id) for r in rows if str(r.id) in {loc_near, loc_far_ish}}
+        assert (
+            len(returned) == 1
+        ), f"loose-tier name gate must merge ~120m same-name rows, got {returned}"
+
+    @pytest.mark.asyncio
+    async def test_loose_tier_merges_same_address_within_200m(
+        self, db_session: AsyncSession
+    ):
+        """~150m apart, different names but identical normalized address
+        + ZIP. The address gate (>0.7 similarity, ZIP match) must merge
+        them. Realistic case: two scrapers describing the same building
+        with different naming conventions ('St. John Pantry' vs 'Saint
+        John's Outreach')."""
+        org_a = str(uuid.uuid4())
+        org_b = str(uuid.uuid4())
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+
+        for oid in (org_a, org_b):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, description, website)
+                    VALUES (:id, 'Addr Tier Org', 'addr tier test',
+                            'https://example.org')
+                    """
+                ),
+                {"id": oid},
+            )
+
+        # ~145m apart (0.0013 deg lng ≈ 110m at this lat) — well inside
+        # the 200m loose tier, well outside the 50m tight tier.
+        for loc_id, org_id, lat, lng, name in (
+            (loc_a, org_a, 33.7500, -84.3900, "St. John Food Pantry"),
+            (loc_b, org_b, 33.7500, -84.3915, "Saint John's Outreach Center"),
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, :name, :lat, :lng,
+                            'physical', 'verified', 70)
+                    """
+                ),
+                {
+                    "id": loc_id,
+                    "org": org_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO address (
+                        id, location_id, address_1, city,
+                        state_province, postal_code, country, address_type
+                    )
+                    VALUES (:id, :loc, '215 Peachtree St NE', 'Atlanta',
+                            'GA', '30303', 'US', 'physical')
+                    """
+                ),
+                {"id": str(uuid.uuid4()), "loc": loc_id},
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, 'no_fa_scraper', :name, :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(33.74, -84.40, 33.76, -84.38),
+        )
+        returned = {str(r.id) for r in rows if str(r.id) in {loc_a, loc_b}}
+        assert (
+            len(returned) == 1
+        ), f"loose-tier address gate must merge same-address rows, got {returned}"
+
+    @pytest.mark.asyncio
+    async def test_loose_tier_does_not_merge_distinct_neighbors(
+        self, db_session: AsyncSession
+    ):
+        """Two pantries ~120m apart with genuinely different names AND
+        addresses must NOT merge — they're real neighbors on a dense
+        block, not duplicates. This is the false-positive guard for the
+        widened loose tier."""
+        org_a = str(uuid.uuid4())
+        org_b = str(uuid.uuid4())
+        loc_a = str(uuid.uuid4())
+        loc_b = str(uuid.uuid4())
+
+        for oid in (org_a, org_b):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, description, website)
+                    VALUES (:id, 'Distinct Neighbor Org',
+                            'distinct neighbor test',
+                            'https://example.org')
+                    """
+                ),
+                {"id": oid},
+            )
+
+        for loc_id, org_id, lat, lng, name, addr in (
+            (
+                loc_a,
+                org_a,
+                42.0000,
+                -75.0000,
+                "Riverside Community Kitchen",
+                "100 Riverside Ave",
+            ),
+            (
+                loc_b,
+                org_b,
+                42.0011,
+                -75.0000,
+                "Hillcrest Methodist Pantry",
+                "215 Hill St",
+            ),
+        ):
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location (
+                        id, organization_id, name, latitude, longitude,
+                        location_type, validation_status, confidence_score
+                    )
+                    VALUES (:id, :org, :name, :lat, :lng,
+                            'physical', 'verified', 70)
+                    """
+                ),
+                {
+                    "id": loc_id,
+                    "org": org_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO address (
+                        id, location_id, address_1, city,
+                        state_province, postal_code, country, address_type
+                    )
+                    VALUES (:id, :loc, :addr, 'Anywhere',
+                            'NY', '13901', 'US', 'physical')
+                    """
+                ),
+                {"id": str(uuid.uuid4()), "loc": loc_id, "addr": addr},
+            )
+            await db_session.execute(
+                text(
+                    """
+                    INSERT INTO location_source (
+                        id, location_id, scraper_id, name, latitude, longitude
+                    )
+                    VALUES (:id, :loc, 'no_fa_scraper', :name, :lat, :lng)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "loc": loc_id,
+                    "name": name,
+                    "lat": lat,
+                    "lng": lng,
+                },
+            )
+        await db_session.flush()
+
+        query = PtfLocationsQuery(db_session)
+        rows = await query.list_locations(
+            limit=200,
+            offset=0,
+            bbox=(41.99, -75.01, 42.01, -74.99),
+        )
+        returned = {str(r.id) for r in rows if str(r.id) in {loc_a, loc_b}}
+        assert returned == {
+            loc_a,
+            loc_b,
+        }, "distinct neighbors must NOT merge under the loose tier gate"
+
+    @pytest.mark.asyncio
     async def test_far_apart_rows_are_not_merged(self, db_session: AsyncSession):
-        """Singleton clusters (minpoints=1) must not drop unique
-        locations. Two rows >55m apart must both come back."""
+        """Self-loops in `edges_both` guarantee every candidate ends
+        up in its own component when no inter-row edges fire. Two rows
+        >200m apart must both come back."""
         org_id = str(uuid.uuid4())
         far_a = str(uuid.uuid4())
         far_b = str(uuid.uuid4())
@@ -797,7 +1079,8 @@ class TestNearDuplicateCollapse:
             ),
             {"id": org_id},
         )
-        # ~0.01 deg apart (~1.1km) — well outside the 0.0005 epsilon.
+        # ~0.01 deg apart (~1.1km) — well outside the 0.00180 (~200m)
+        # loose-tier ceiling, so no dedup edge can form.
         for loc_id, lat, lng, name in (
             (far_a, 38.0, -77.0, "Far Pantry A"),
             (far_b, 38.01, -77.01, "Far Pantry B"),

--- a/tests/test_ptf_locations_queries.py
+++ b/tests/test_ptf_locations_queries.py
@@ -34,7 +34,11 @@ class TestClamps:
         assert clamp_limit(-100) == 1
 
     def test_limit_clamps_to_maximum(self):
-        assert clamp_limit(1000) == 200
+        # _MAX_LIMIT widened to 500 so a dense-urban viewport (3-mile
+        # floor + tier-2 dedup) can still return all pins in one page.
+        assert clamp_limit(1000) == 500
+        assert clamp_limit(500) == 500
+        assert clamp_limit(501) == 500
 
     def test_limit_passes_through_valid(self):
         assert clamp_limit(50) == 50
@@ -175,19 +179,31 @@ class TestQuerySQL:
     async def test_list_query_clusters_near_duplicate_canonicals(self):
         """Defense-in-depth: when the reconciler leaves near-duplicate
         location rows (different name AND different org so its widen-
-        radius merge bails), the endpoint must collapse them via
-        ST_ClusterDBSCAN with eps matching the inbound /sync endpoint."""
+        radius merge bails), the endpoint must collapse them via a
+        tiered connected-components walk (tight ~50m always-merge,
+        loose ~200m gated by trigram similarity on name or address)."""
         session = _capture_session()
         query = PtfLocationsQuery(session)
         await query.list_locations(limit=10, offset=0)
         sql_text = str(session.execute.call_args[0][0])
-        assert "ST_ClusterDBSCAN" in sql_text, "list query must run cluster-based dedup"
-        # eps must match the inbound /sync endpoint (services.py) so
-        # operators reason about one tolerance, not two.
-        assert "eps := 0.0005" in sql_text
-        # minpoints=1 means isolated rows form their own singleton
-        # cluster — no unique location is ever dropped.
-        assert "minpoints := 1" in sql_text
+        # Tier edges + recursive reachability are the contract.
+        assert (
+            "WITH RECURSIVE" in sql_text
+        ), "list query must use recursive CTE for tiered dedup"
+        assert (
+            "ST_DWithin" in sql_text
+        ), "tier edges must use ST_DWithin against pre-cached geom"
+        assert (
+            "similarity(" in sql_text
+        ), "loose-tier gate must call pg_trgm similarity()"
+        # The tier thresholds must be bound (not hard-coded) so
+        # operators can tune via the module constants without editing
+        # SQL.
+        params = session.execute.call_args[0][1]
+        assert params["dedup_tight_deg"] == pytest.approx(0.00045)
+        assert params["dedup_loose_deg"] == pytest.approx(0.00180)
+        assert params["name_sim_threshold"] == pytest.approx(0.5)
+        assert params["addr_sim_threshold"] == pytest.approx(0.7)
         # Survivor pick must prefer FANO-qualifying rows so the
         # feeding_america_food_bank enrichment block is never silently
         # stripped in favor of a non-FANO sibling.
@@ -197,6 +213,9 @@ class TestQuerySQL:
         assert (
             "confidence_score DESC NULLS LAST" in norm
         ), "survivor pick must fall back to confidence_score after FANO"
+        # DISTINCT ON the component id (not the cluster id) keeps each
+        # connected component to a single representative row.
+        assert "DISTINCT ON (comp.component_id)" in sql_text
 
     @pytest.mark.asyncio
     async def test_list_query_keeps_confidence_score_for_survivor_ordering(self):
@@ -221,6 +240,8 @@ class TestQuerySQL:
         await query.get_location("11111111-2222-3333-4444-555555555555")
         sql_text = str(session.execute.call_args[0][0])
         assert "ST_ClusterDBSCAN" not in sql_text
+        assert "WITH RECURSIVE" not in sql_text
+        assert "similarity(" not in sql_text
 
     @pytest.mark.asyncio
     async def test_get_by_id_binds_uuid_param(self):

--- a/tests/test_ptf_locations_queries.py
+++ b/tests/test_ptf_locations_queries.py
@@ -190,6 +190,13 @@ class TestQuerySQL:
         assert (
             "WITH RECURSIVE" in sql_text
         ), "list query must use recursive CTE for tiered dedup"
+        # Loose pre-cluster keeps the per-pair self-join inside small
+        # spatial groups — without it, the edges CTE is O(N^2) and the
+        # GIST index can't help (the planner can't see through the
+        # CTE-materialized `geom` column).
+        assert (
+            "ST_ClusterDBSCAN" in sql_text
+        ), "loose pre-cluster must use ST_ClusterDBSCAN for index-aware grouping"
         assert (
             "ST_DWithin" in sql_text
         ), "tier edges must use ST_DWithin against pre-cached geom"
@@ -239,6 +246,10 @@ class TestQuerySQL:
         query = PtfLocationsQuery(session)
         await query.get_location("11111111-2222-3333-4444-555555555555")
         sql_text = str(session.execute.call_args[0][0])
+        # All three of these dedup primitives belong only on the list
+        # path. Inheriting them on the detail query would silently
+        # rewrite the response.id to a survivor and break consumers
+        # that cached non-survivor ids from a prior list.
         assert "ST_ClusterDBSCAN" not in sql_text
         assert "WITH RECURSIVE" not in sql_text
         assert "similarity(" not in sql_text

--- a/tests/test_ptf_locations_router.py
+++ b/tests/test_ptf_locations_router.py
@@ -16,6 +16,8 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.partners.ptf.locations_router import (
+    _BBOX_MIN_SIZE_DEG,
+    _pad_bbox_to_min,
     get_ptf_location,
     list_ptf_locations,
 )
@@ -121,7 +123,99 @@ class TestListEndpoint:
                 session=session,
             )
             kwargs = mock_q.list_locations.await_args.kwargs
+            # 1° x 2° is well above the 3-mile floor, so it passes through
+            # unchanged (modulo the min/max normalization, which is a
+            # no-op here since the values are already ordered).
             assert kwargs["bbox"] == (40.0, -75.0, 41.0, -73.0)
+
+    @pytest.mark.asyncio
+    async def test_tiny_bbox_padded_to_min(self):
+        """A pin-tight zoom (<3 mi on a side) must be expanded around its
+        center before the SQL runs, so neighboring pins don't drop off
+        the response as the client zooms in."""
+        session = MagicMock(spec=AsyncSession)
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+
+            # 0.001° x 0.001° — well under the floor.
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=40.7580,
+                lng1=-73.9858,
+                lat2=40.7585,
+                lng2=-73.9853,
+                q=None,
+                session=session,
+            )
+            kwargs = mock_q.list_locations.await_args.kwargs
+            padded = kwargs["bbox"]
+            # Side lengths must now meet the floor.
+            assert padded[2] - padded[0] >= _BBOX_MIN_SIZE_DEG - 1e-9
+            assert padded[3] - padded[1] >= _BBOX_MIN_SIZE_DEG - 1e-9
+            # Centered on the original center.
+            assert padded[0] + padded[2] == pytest.approx(40.7580 + 40.7585)
+            assert padded[1] + padded[3] == pytest.approx(-73.9858 + -73.9853)
+
+    @pytest.mark.asyncio
+    async def test_inverted_bbox_is_normalized(self):
+        """Swapped corners (lat2 < lat1) must yield a valid envelope, not
+        an inverted one. The query layer assumes min/max are correctly
+        ordered."""
+        session = MagicMock(spec=AsyncSession)
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=41.0,
+                lng1=-73.0,
+                lat2=40.0,
+                lng2=-75.0,
+                q=None,
+                session=session,
+            )
+            kwargs = mock_q.list_locations.await_args.kwargs
+            lat_min, lng_min, lat_max, lng_max = kwargs["bbox"]
+            assert lat_min < lat_max
+            assert lng_min < lng_max
+
+    @pytest.mark.asyncio
+    async def test_limit_500_accepted(self):
+        """Max page size widened to 500 so a 3-mile-padded urban viewport
+        can return all pins in one call."""
+        session = MagicMock(spec=AsyncSession)
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=500,
+                offset=0,
+                lat1=None,
+                lng1=None,
+                lat2=None,
+                lng2=None,
+                q=None,
+                session=session,
+            )
+            kwargs = mock_q.list_locations.await_args.kwargs
+            assert kwargs["limit"] == 500
 
     @pytest.mark.asyncio
     async def test_partial_bbox_rejected(self):
@@ -253,6 +347,46 @@ class TestDetailEndpoint:
                     session=session,
                 )
             assert ei.value.status_code == 404
+
+
+class TestPadBboxToMin:
+    """Direct unit tests for the bbox-padding helper."""
+
+    def test_large_bbox_unchanged(self):
+        bbox = (40.0, -75.0, 41.0, -73.0)
+        assert _pad_bbox_to_min(bbox) == bbox
+
+    def test_tiny_bbox_padded(self):
+        bbox = (40.7580, -73.9858, 40.7585, -73.9853)
+        padded = _pad_bbox_to_min(bbox)
+        assert padded[2] - padded[0] == pytest.approx(_BBOX_MIN_SIZE_DEG)
+        assert padded[3] - padded[1] == pytest.approx(_BBOX_MIN_SIZE_DEG)
+
+    def test_padding_centered(self):
+        bbox = (45.0, -100.0, 45.001, -99.999)
+        padded = _pad_bbox_to_min(bbox)
+        assert (padded[0] + padded[2]) / 2 == pytest.approx(45.0005)
+        assert (padded[1] + padded[3]) / 2 == pytest.approx(-99.9995)
+
+    def test_only_one_axis_under_floor(self):
+        # Lat span 0.01 (under floor), lng span 1.0 (above floor).
+        bbox = (45.0, -100.0, 45.01, -99.0)
+        padded = _pad_bbox_to_min(bbox)
+        # Lat padded.
+        assert padded[2] - padded[0] == pytest.approx(_BBOX_MIN_SIZE_DEG)
+        # Lng untouched.
+        assert padded[1] == pytest.approx(-100.0)
+        assert padded[3] == pytest.approx(-99.0)
+
+    def test_inverted_lat_normalized(self):
+        bbox = (41.0, -75.0, 40.0, -73.0)  # lat1 > lat2
+        lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
+        assert lat_min < lat_max
+
+    def test_inverted_lng_normalized(self):
+        bbox = (40.0, -73.0, 41.0, -75.0)  # lng1 > lng2
+        lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
+        assert lng_min < lng_max
 
 
 class TestRouterMounting:

--- a/tests/test_ptf_locations_router.py
+++ b/tests/test_ptf_locations_router.py
@@ -388,6 +388,160 @@ class TestPadBboxToMin:
         lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
         assert lng_min < lng_max
 
+    def test_padding_near_north_pole_clamps_to_90(self):
+        """A near-pole input padded outward would push lat past 90°.
+        Helper must clamp so the resulting envelope is still a valid
+        SRID-4326 geometry."""
+        bbox = (89.99, -100.0, 89.999, -99.999)
+        lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
+        assert lat_max <= 90.0
+        assert lat_min >= -90.0
+
+    def test_padding_near_south_pole_clamps_to_minus_90(self):
+        bbox = (-89.999, 0.0, -89.99, 0.001)
+        lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
+        assert lat_min >= -90.0
+        assert lat_max <= 90.0
+
+    def test_padding_near_lng_edge_clamps(self):
+        """Near the dateline, padding must clamp to [-180, 180]."""
+        bbox = (40.0, 179.99, 41.0, 179.999)
+        lat_min, lng_min, lat_max, lng_max = _pad_bbox_to_min(bbox)
+        assert lng_min >= -180.0
+        assert lng_max <= 180.0
+
+
+class TestAntimeridianAndBboxPaddedFlag:
+    """Antimeridian warn + bbox_padded log-field type contract."""
+
+    @pytest.mark.asyncio
+    async def test_antimeridian_span_logs_warning(self):
+        """A bbox whose lng span > 180° is almost certainly a caller
+        passing `lng1=170, lng2=-170` and intending to wrap the
+        dateline. Sorting would normalize to (-170, 170) — a 340° envelope
+        covering most of the planet. We don't reject (PTF is US-only in
+        practice), but we must emit a warn-level log so misconfigured
+        clients are diagnosable."""
+        session = MagicMock(spec=AsyncSession)
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery, patch(
+            "app.api.v1.partners.ptf.locations_router.logger"
+        ) as mock_logger:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+            # Need a child logger for the structured .info() chain to
+            # not blow up on the MagicMock.
+            mock_logger.bind.return_value = MagicMock()
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=40.0,
+                lng1=170.0,
+                lat2=41.0,
+                lng2=-170.0,
+                q=None,
+                session=session,
+            )
+            warn_calls = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "ptf_bbox_antimeridian_suspect"
+            ]
+            assert (
+                len(warn_calls) == 1
+            ), "antimeridian-suspect bbox must emit exactly one warn"
+
+    @pytest.mark.asyncio
+    async def test_bbox_padded_is_none_when_no_bbox(self):
+        """`bbox_padded` is None (not False) when no bbox was provided
+        so CloudWatch filters can tell 'no bbox' apart from 'bbox
+        provided but not padded'."""
+        session = MagicMock(spec=AsyncSession)
+        bound = MagicMock()
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery, patch(
+            "app.api.v1.partners.ptf.locations_router.logger"
+        ) as mock_logger:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+            mock_logger.bind.return_value = bound
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=None,
+                lng1=None,
+                lat2=None,
+                lng2=None,
+                q=None,
+                session=session,
+            )
+            bind_kwargs = mock_logger.bind.call_args.kwargs
+            assert bind_kwargs["bbox_padded"] is None
+
+    @pytest.mark.asyncio
+    async def test_bbox_padded_is_true_when_padding_fires(self):
+        session = MagicMock(spec=AsyncSession)
+        bound = MagicMock()
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery, patch(
+            "app.api.v1.partners.ptf.locations_router.logger"
+        ) as mock_logger:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+            mock_logger.bind.return_value = bound
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=40.7580,
+                lng1=-73.9858,
+                lat2=40.7585,
+                lng2=-73.9853,
+                q=None,
+                session=session,
+            )
+            bind_kwargs = mock_logger.bind.call_args.kwargs
+            assert bind_kwargs["bbox_padded"] is True
+
+    @pytest.mark.asyncio
+    async def test_bbox_padded_is_false_when_bbox_above_floor(self):
+        session = MagicMock(spec=AsyncSession)
+        bound = MagicMock()
+        with patch(
+            "app.api.v1.partners.ptf.locations_router.PtfLocationsQuery"
+        ) as MockQuery, patch(
+            "app.api.v1.partners.ptf.locations_router.logger"
+        ) as mock_logger:
+            mock_q = MagicMock()
+            mock_q.list_locations = AsyncMock(return_value=[])
+            MockQuery.return_value = mock_q
+            mock_logger.bind.return_value = bound
+
+            await list_ptf_locations(
+                response=MagicMock(headers={}),
+                limit=50,
+                offset=0,
+                lat1=40.0,
+                lng1=-75.0,
+                lat2=41.0,
+                lng2=-73.0,
+                q=None,
+                session=session,
+            )
+            bind_kwargs = mock_logger.bind.call_args.kwargs
+            assert bind_kwargs["bbox_padded"] is False
+
 
 class TestRouterMounting:
     """Confirms the router is wired up so HTTP requests hit it."""


### PR DESCRIPTION
## Summary

Two field-reported issues on `GET /api/v1/partners/ptf/locations`:

1. **Dedup too tight.** PR #484 introduced `ST_ClusterDBSCAN(eps:=0.0005)` (~55m). That catches GPS-fuzzed records on the same parcel but misses near-duplicates from different scrapers that land on opposite sides of the same building / parking lot / strip mall (60–150m apart).
2. **Pins disappear at high zoom.** The bbox filter is applied verbatim with no padding — pins just outside the visible viewport drop off the response as the client zooms in.

### What changed

- **Tiered cluster-dedup** in `locations_queries.py`:
  - Tight tier (≤ 50m, `_DEDUP_TIGHT_DEG = 0.00045`) always merges.
  - Loose tier (50–200m, `_DEDUP_LOOSE_DEG = 0.00180`) merges only when normalized name OR address1+ZIP fuzzy-matches via `pg_trgm` `similarity()` (thresholds 0.5 / 0.7). 5-digit ZIP must match for the address gate to fire.
  - Implementation: `WITH RECURSIVE` connected-components walk on tier edges. Self-loops in `edges_both` guarantee singletons survive. Survivor pick is unchanged (`has_qualifying_source DESC, confidence_score DESC NULLS LAST, id`).

- **Bbox min-size floor (~3 mi)** in `locations_router.py`:
  - New `_pad_bbox_to_min` helper expands any viewport under `_BBOX_MIN_SIZE_DEG = 0.0435` around its center. Already-large viewports pass through untouched.
  - Also normalizes inverted lat/lng corners (latent bug — `ST_MakeEnvelope` would accept an inverted envelope and silently return wrong results).
  - New `bbox_padded` field on the `ptf_locations_list_complete` structlog event so CloudWatch can observe how often clients hit the floor.

- **Page-size ceiling** raised 200 → 500. Default stays at 50; only callers that opt into a larger page get more rows. A 3-mile-padded urban viewport can plausibly hit >200 pins, so 500 gives headroom.

### Why not also widen the reconciler?

The `services.py:_build_qualified_cte` inbound `/sync` tolerance is intentionally left at 55m. Endpoint-level defense-in-depth is allowed to be wider than ingest-side rules; the reconciler has its own name/org-constrained merge tier that ships with stricter guarantees. Mentioned this in conversation — a follow-up PR could move the same tiered rule earlier in the pipeline.

### pg_trgm

Already enabled at DB init (`init-scripts/14-ptf-locations-indexes.sql:31`). No new extensions required.

## Test plan

- [x] `./bouy exec app pytest tests/test_ptf_locations_queries.py tests/test_ptf_locations_router.py` — 42 pass (12 new)
- [x] `./bouy exec app pytest tests/test_ptf_locations_integration.py` — 21 pass (3 new tier-2 integration scenarios against real DB: same-name merge, same-address merge, distinct-neighbor false-positive guard)
- [x] All other PTF tests — 148 pass, no regressions
- [x] `./bouy exec app mypy app/api/v1/partners/ptf/locations_queries.py app/api/v1/partners/ptf/locations_router.py` — clean
- [x] `./bouy exec app ruff check` / `black --check` on touched files — clean
- [x] `./bouy exec app bandit -ll` on touched files — no issues
- [ ] Post-deploy: spot-check `/api/v1/partners/ptf/locations` against the Beaverton Adventist case (existing 3-row dedup still collapses) and against a tiny NYC bbox (more pins returned vs prod)
- [ ] Post-deploy: watch `ptf_locations_list_complete` in CloudWatch for `bbox_padded=true` rate and `dedup_active=true` to confirm both paths are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)