### PR TITLE
fix(api): default HSDS location reads to canonical, non-rejected rows (API-1)

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy import (
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -122,6 +123,14 @@ class LocationModel(Base):
         nullable=True,
     )
     geocoding_source = Column(Text, nullable=True)
+
+    # Canonical / soft-delete marker. The reconciler keeps one canonical
+    # survivor per real-world location and flips merged-away duplicates to
+    # is_canonical=FALSE. The DB column already existed; it was previously
+    # unmapped on the ORM model, so the HSDS read repositories could not
+    # filter on it and served duplicates. Public read paths default to
+    # is_canonical=TRUE (see LocationRepository visibility filter).
+    is_canonical = Column(Boolean, nullable=False, default=True)
 
     # Verification tracking (ppr-beacon quality gate)
     verified_by = Column(Text, nullable=True)  # 'auto', 'admin', 'source', 'claimed'

--- a/app/database/repositories.py
+++ b/app/database/repositories.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional, Sequence, TypeVar
 from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import String, and_, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -26,6 +26,34 @@ from .models import (
 )
 
 ModelType = TypeVar("ModelType")
+
+
+def _visible_location_clause(model: type[LocationModel]) -> Any:
+    """Predicate for the public-visible subset of locations.
+
+    The reconciler soft-deletes merged-away duplicates (``is_canonical=FALSE``)
+    and the validator marks low-quality rows ``validation_status='rejected'``.
+    Every public-facing surface (map, PTF, consumer, export) hides both; the
+    HSDS read repository historically did not, leaking ~11k rows. Read paths
+    apply this clause by default and skip it only when ``include_hidden=True``.
+
+    ``validation_status`` is nullable; a NULL status is treated as visible
+    (it predates the validator and means "not yet rejected").
+
+    The status comparison casts to text so the predicate is portable across
+    deployments: prod stores ``validation_status`` as a named Postgres enum
+    (``location_validation_status_enum``) while other environments store it as
+    plain text. Casting to text avoids binding the literal as the named enum
+    type (which fails to prepare where that type is absent) and Postgres
+    coerces enum labels to text identically, so semantics are unchanged.
+    """
+    return and_(
+        model.is_canonical.is_(True),
+        or_(
+            model.validation_status.is_(None),
+            cast(model.validation_status, String) != "rejected",
+        ),
+    )
 
 
 class BaseRepository(ABC, Generic[ModelType]):
@@ -205,8 +233,15 @@ class LocationRepository(BaseRepository[LocationModel]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, LocationModel)
 
-    async def get_by_id(self, id: UUID) -> Optional[LocationModel]:
-        """Get location by ID with eager loading."""
+    async def get_by_id(
+        self, id: UUID, include_hidden: bool = False
+    ) -> Optional[LocationModel]:
+        """Get location by ID with eager loading.
+
+        Defaults to the public-visible subset (canonical, non-rejected) so a
+        soft-deleted duplicate or rejected row cannot be surfaced by id. Pass
+        ``include_hidden=True`` for admin/debug tooling that needs every row.
+        """
         query = (
             select(self.model)
             .options(
@@ -216,6 +251,8 @@ class LocationRepository(BaseRepository[LocationModel]):
             )
             .filter(self.model.id == str(id))
         )
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
@@ -224,13 +261,21 @@ class LocationRepository(BaseRepository[LocationModel]):
         skip: int = 0,
         limit: int = 100,
         filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
     ) -> Sequence[LocationModel]:
-        """Get all locations with eager loading to prevent lazy load errors."""
+        """Get all locations with eager loading to prevent lazy load errors.
+
+        Defaults to canonical, non-rejected rows; ``include_hidden=True`` opts
+        back into the full set.
+        """
         query = select(self.model).options(
             selectinload(self.model.services_at_location)
             # Temporarily disabled schedules due to async loading issues
             # selectinload(self.model.schedules)
         )
+
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
 
         # Apply filters
         if filters:
@@ -244,6 +289,29 @@ class LocationRepository(BaseRepository[LocationModel]):
         result = await self.session.execute(query)
         return result.scalars().all()
 
+    async def count(
+        self,
+        filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
+    ) -> int:
+        """Count locations, matching get_all's default visibility filter.
+
+        Overrides BaseRepository.count so paginated totals stay consistent with
+        the rows actually returned (otherwise totals would count hidden rows).
+        """
+        query = select(func.count()).select_from(self.model)
+
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
+
+        if filters:
+            for key, value in filters.items():
+                if hasattr(self.model, key):
+                    query = query.filter(getattr(self.model, key) == value)
+
+        result = await self.session.execute(query)
+        return result.scalar() or 0
+
     async def get_locations_by_radius(
         self,
         center: GeoPoint,
@@ -251,8 +319,9 @@ class LocationRepository(BaseRepository[LocationModel]):
         skip: int = 0,
         limit: int = 100,
         filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
     ) -> Sequence[LocationModel]:
-        """Get locations within radius of a point."""
+        """Get locations within radius of a point (canonical, non-rejected)."""
         if HAS_GEOALCHEMY2:
             # Use PostGIS for accurate distance calculations
             radius_meters = radius_miles * 1609.34
@@ -301,6 +370,9 @@ class LocationRepository(BaseRepository[LocationModel]):
                 )
             )
 
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
+
         # Apply additional filters
         if filters:
             for key, value in filters.items():
@@ -329,8 +401,9 @@ class LocationRepository(BaseRepository[LocationModel]):
         skip: int = 0,
         limit: int = 100,
         filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
     ) -> Sequence[LocationModel]:
-        """Get locations within bounding box."""
+        """Get locations within bounding box (canonical, non-rejected)."""
         if HAS_GEOALCHEMY2:
             # Use PostGIS for accurate bounding box queries
             bbox_geom = func.ST_SetSRID(
@@ -357,6 +430,9 @@ class LocationRepository(BaseRepository[LocationModel]):
                 )
             )
 
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
+
         # Apply additional filters
         if filters:
             for key, value in filters.items():
@@ -370,21 +446,19 @@ class LocationRepository(BaseRepository[LocationModel]):
         return result.scalars().all()
 
     async def get_locations_with_services(
-        self, skip: int = 0, limit: int = 100
+        self, skip: int = 0, limit: int = 100, include_hidden: bool = False
     ) -> Sequence[LocationModel]:
-        """Get locations with their services."""
-        query = (
-            select(self.model)
-            .options(
-                selectinload(self.model.services_at_location).selectinload(
-                    ServiceAtLocationModel.service
-                )
-                # Temporarily disabled schedules due to async loading issues
-                # selectinload(self.model.schedules)
+        """Get locations with their services (canonical, non-rejected)."""
+        query = select(self.model).options(
+            selectinload(self.model.services_at_location).selectinload(
+                ServiceAtLocationModel.service
             )
-            .offset(skip)
-            .limit(limit)
+            # Temporarily disabled schedules due to async loading issues
+            # selectinload(self.model.schedules)
         )
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
+        query = query.offset(skip).limit(limit)
         result = await self.session.execute(query)
         return result.scalars().all()
 
@@ -393,8 +467,9 @@ class LocationRepository(BaseRepository[LocationModel]):
         center: GeoPoint,
         radius_miles: float,
         filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
     ) -> int:
-        """Count locations within radius of a point."""
+        """Count locations within radius of a point (canonical, non-rejected)."""
         if HAS_GEOALCHEMY2:
             # Use PostGIS for accurate distance calculations
             radius_meters = radius_miles * 1609.34
@@ -434,6 +509,9 @@ class LocationRepository(BaseRepository[LocationModel]):
                 )
             )
 
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
+
         # Apply additional filters
         if filters:
             for key, value in filters.items():
@@ -447,8 +525,9 @@ class LocationRepository(BaseRepository[LocationModel]):
         self,
         bbox: GeoBoundingBox,
         filters: Optional[dict[str, Any]] = None,
+        include_hidden: bool = False,
     ) -> int:
-        """Count locations within bounding box."""
+        """Count locations within bounding box (canonical, non-rejected)."""
         if HAS_GEOALCHEMY2:
             # Use PostGIS for accurate bounding box queries
             bbox_geom = func.ST_SetSRID(
@@ -482,6 +561,9 @@ class LocationRepository(BaseRepository[LocationModel]):
                     )
                 )
             )
+
+        if not include_hidden:
+            query = query.filter(_visible_location_clause(self.model))
 
         # Apply additional filters
         if filters:

--- a/tests/test_api_canonical_filter.py
+++ b/tests/test_api_canonical_filter.py
@@ -1,0 +1,220 @@
+"""API-1 regression guard: HSDS location read paths default to visible rows.
+
+The audit found that ``LocationRepository`` served soft-deleted duplicates
+(``is_canonical=FALSE``) and ``validation_status='rejected'`` rows on the public
+HSDS API (``/locations`` etc.), because neither the repository nor the endpoints
+applied any canonical/validation predicate. In production this exposed 11,376
+rows that every other surface (map/PTF/export) hides.
+
+These tests lock in the fix: the location read paths must default to
+``is_canonical = TRUE AND validation_status != 'rejected'`` and must skip that
+filter only when ``include_hidden=True`` is explicitly passed (admin/debug).
+"""
+
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from app.database.models import LocationModel
+from app.database.repositories import LocationRepository
+
+
+def _sql(query) -> str:
+    """Compile a SQLAlchemy statement to a lowercase SQL string."""
+    return str(
+        query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": False},
+        )
+    ).lower()
+
+
+class _CapturingSession:
+    """Async session stub that records the last statement passed to execute()."""
+
+    def __init__(self) -> None:
+        self.captured = None
+        self.execute = AsyncMock(side_effect=self._execute)
+
+    async def _execute(self, statement, *args, **kwargs):
+        self.captured = statement
+        result = Mock()
+        scalars = Mock()
+        scalars.all.return_value = []
+        result.scalars.return_value = scalars
+        result.scalar_one_or_none.return_value = None
+        result.scalar.return_value = 0
+        return result
+
+
+def test_location_model_maps_is_canonical():
+    """is_canonical exists in the DB but was unmapped on the ORM model."""
+    assert hasattr(LocationModel, "is_canonical")
+
+
+# The visibility predicate renders (postgresql dialect) as
+#   location.is_canonical IS true AND
+#   (location.validation_status IS NULL OR location.validation_status != ...)
+# We assert on the WHERE-clause phrasing, not the bare column name, because the
+# mapped column also appears in the SELECT list regardless of filtering.
+_CANONICAL_PRED = "is_canonical is true"
+_REJECTED_PRED = "validation_status is null"
+
+
+@pytest.mark.asyncio
+async def test_get_all_defaults_to_canonical_non_rejected():
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.get_all()
+    sql = _sql(session.captured)
+    assert _CANONICAL_PRED in sql
+    assert _REJECTED_PRED in sql
+
+
+@pytest.mark.asyncio
+async def test_get_all_include_hidden_skips_filter():
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.get_all(include_hidden=True)
+    sql = _sql(session.captured)
+    assert _CANONICAL_PRED not in sql
+    assert _REJECTED_PRED not in sql
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_defaults_to_canonical_non_rejected():
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.get_by_id(uuid4())
+    sql = _sql(session.captured)
+    assert _CANONICAL_PRED in sql
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_include_hidden_returns_any_row():
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.get_by_id(uuid4(), include_hidden=True)
+    sql = _sql(session.captured)
+    assert _CANONICAL_PRED not in sql
+
+
+@pytest.mark.asyncio
+async def test_count_defaults_to_canonical_non_rejected():
+    """count() must match get_all() filtering or pagination totals are wrong."""
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.count()
+    sql = _sql(session.captured)
+    assert _CANONICAL_PRED in sql
+    assert _REJECTED_PRED in sql
+
+
+@pytest.mark.asyncio
+async def test_bbox_and_radius_default_to_visible():
+    from app.models.hsds.query import GeoBoundingBox, GeoPoint
+
+    session = _CapturingSession()
+    repo = LocationRepository(session)
+    await repo.count_by_bbox(
+        GeoBoundingBox(
+            min_latitude=40.0,
+            max_latitude=41.0,
+            min_longitude=-74.0,
+            max_longitude=-73.0,
+        )
+    )
+    assert _CANONICAL_PRED in _sql(session.captured)
+
+    await repo.count_by_radius(GeoPoint(latitude=40.0, longitude=-73.5), 5.0)
+    assert _CANONICAL_PRED in _sql(session.captured)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_repository_hides_noncanonical_and_rejected_end_to_end(db_session):
+    """End-to-end: seed canonical / non-canonical / rejected rows against the
+    real test DB and prove the repository returns only the visible one.
+
+    This is the production behavior that removes the ~11,376 leaked rows: a
+    soft-deleted duplicate (is_canonical=FALSE) and a rejected row must not be
+    returned by default, and must be retrievable only via include_hidden=True.
+    """
+    from sqlalchemy import text
+
+    org_id = str(uuid4())
+    visible_id = str(uuid4())
+    duplicate_id = str(uuid4())
+    rejected_id = str(uuid4())
+
+    await db_session.execute(
+        text(
+            "INSERT INTO organization (id, name, description) "
+            "VALUES (:id, :name, :desc)"
+        ),
+        {"id": org_id, "name": "API-1 Visibility Org", "desc": "API-1 seed org"},
+    )
+    seed = [
+        (visible_id, "Visible Pantry", "needs_review", True),
+        (duplicate_id, "Soft-deleted Duplicate", "needs_review", False),
+        (rejected_id, "Rejected Pantry", "rejected", True),
+    ]
+    for loc_id, name, status, canonical in seed:
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO location (
+                    id, organization_id, name, latitude, longitude,
+                    location_type, validation_status, confidence_score,
+                    is_canonical
+                )
+                VALUES (
+                    :id, :org, :name, 40.0, -74.0,
+                    'physical', :status, 70, :canonical
+                )
+                """
+            ),
+            {
+                "id": loc_id,
+                "org": org_id,
+                "name": name,
+                "status": status,
+                "canonical": canonical,
+            },
+        )
+    await db_session.flush()
+
+    repo = LocationRepository(db_session)
+
+    # Default: only the canonical, non-rejected row of this org is returned.
+    returned = await repo.get_all(filters={"organization_id": org_id}, limit=1000)
+    returned_ids = {str(loc.id) for loc in returned}
+    assert visible_id in returned_ids
+    assert duplicate_id not in returned_ids
+    assert rejected_id not in returned_ids
+
+    # count() agrees with get_all() so pagination totals are correct.
+    assert await repo.count(filters={"organization_id": org_id}) == 1
+
+    # get_by_id hides the soft-deleted duplicate and the rejected row…
+    assert await repo.get_by_id(uuid4_from(duplicate_id)) is None
+    assert await repo.get_by_id(uuid4_from(rejected_id)) is None
+    assert await repo.get_by_id(uuid4_from(visible_id)) is not None
+
+    # …but include_hidden=True opts back into every row (admin/debug).
+    assert (
+        await repo.get_by_id(uuid4_from(duplicate_id), include_hidden=True) is not None
+    )
+    hidden_all = await repo.get_all(
+        filters={"organization_id": org_id}, limit=1000, include_hidden=True
+    )
+    assert len(hidden_all) == 3
+
+
+def uuid4_from(value: str):
+    """Local helper: parse a string UUID (kept near its single use site)."""
+    from uuid import UUID
+
+    return UUID(value)


### PR DESCRIPTION
## Audit finding API-1 / API-7 (Tier 0)

The official HSDS REST API (`GET /api/v1/locations`, `/locations/{id}`, `/locations/search`) served **soft-deleted duplicate** locations (`is_canonical = FALSE`) and **`validation_status = 'rejected'`** rows, because `LocationRepository` applied only caller-supplied equality filters and never restricted to the visible subset that every *other* surface (map, PTF, consumer, export) already hides.

**Production blast radius (verified against prod DB):** `11,376` extra rows served by the HSDS API but hidden everywhere else — `10,150` non-canonical duplicates + `1,226` rejected. Food-insecure users (and downstream HSDS consumers) saw the same pantry multiple times and/or saw rows flagged unfit to publish.

## Change

- Map the previously-**unmapped** `is_canonical` column on `LocationModel` (the DB column existed; the ORM never exposed it, so the repository couldn't filter on it).
- Add a shared visibility predicate — `is_canonical = TRUE AND validation_status != 'rejected'` (NULL status treated as visible) — and apply it across **every** `LocationRepository` read path: `get_by_id`, `get_all`, `count` (override, so pagination totals match), `get_locations_by_radius`, `get_locations_by_bbox`, `count_by_radius`, `count_by_bbox`, `get_locations_with_services`.
- Add an `include_hidden=False` opt-in so admin/debug tooling can still retrieve every row.
- Cast `validation_status` to text in the predicate so it is portable across the prod **enum** column and the **text**-typed test DB (Postgres coerces enum→label identically; semantics unchanged).

Scope: this PR is the **locations** fix (the verified 11,376-row number). Rejected-`organization`/`service` filtering is a separable lower-impact follow-up.

## Verification (TDD)

- Unit tests compile each read query and assert the visibility predicate is present by default and **absent** with `include_hidden=True`.
- An end-to-end integration test seeds canonical / non-canonical / rejected rows in the real test DB and proves only the visible row is returned, `count()` agrees (=1), `get_by_id` hides the others, and `include_hidden=True` returns all three.
- `black`, `ruff`, `mypy` clean on changed files; 242 passing across `tests/test_api`, `tests/test_database`, repository and location-API suites (no regressions).

Read-API only — confirmed no pipeline/reconciler/write-API caller uses `LocationRepository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)