### PR TITLE
fix(api): filter is_canonical on map + PTF list/detail serve paths (API-2/3)

### DIFF
--- a/app/api/v1/map/router.py
+++ b/app/api/v1/map/router.py
@@ -344,6 +344,8 @@ async def get_map_location_detail(
         LEFT JOIN organization o ON o.id = l.organization_id
         LEFT JOIN phone p ON p.location_id = l.id
         WHERE l.id = :location_id
+          AND l.is_canonical = true
+          AND (l.validation_status IS NULL OR l.validation_status != 'rejected')
     """
 
     from sqlalchemy import text

--- a/app/api/v1/map/services.py
+++ b/app/api/v1/map/services.py
@@ -147,6 +147,7 @@ class MapDataService:
               AND l.longitude IS NOT NULL
               AND l.latitude BETWEEN -90 AND 90
               AND l.longitude BETWEEN -180 AND 180
+              AND l.is_canonical = true
               AND (l.validation_status IS NULL OR l.validation_status != 'rejected')
         """
 

--- a/app/api/v1/partners/ptf/locations_queries.py
+++ b/app/api/v1/partners/ptf/locations_queries.py
@@ -181,6 +181,7 @@ candidates AS (
            ON fa.zip = SUBSTR(a.postal_code, 1, 5)
     LEFT JOIN qualifying_source qs ON qs.location_id = l.id
     WHERE (l.validation_status != 'rejected' OR l.validation_status IS NULL)
+      AND l.is_canonical = TRUE
       AND l.latitude IS NOT NULL
       AND l.longitude IS NOT NULL
       AND NOT (l.latitude = 0 AND l.longitude = 0)
@@ -356,6 +357,8 @@ LEFT JOIN feeding_america_zip_coverage fa
        ON fa.zip = SUBSTR(a.postal_code, 1, 5)
 LEFT JOIN qualifying_source qs ON qs.location_id = l.id
 WHERE l.id = :location_id
+  AND l.is_canonical = TRUE
+  AND (l.validation_status != 'rejected' OR l.validation_status IS NULL)
   -- Mirror the list-query filter (including the empty-string check). A
   -- location with no contact info AND no schedule is not reachable and
   -- shouldn't be served. Returning empty here means the router responds

--- a/tests/test_api_map_ptf_canonical.py
+++ b/tests/test_api_map_ptf_canonical.py
@@ -1,0 +1,163 @@
+"""API-2/3 regression guard: map + PTF serve paths hide non-canonical/rejected.
+
+The audit found the map LIST (`get_locations_for_map`), the map detail
+(`/map/locations/{id}`), and the PTF list/detail queries did not filter
+`is_canonical`, so soft-deleted duplicate pantries (and, for the detail paths,
+rejected rows) were served — and the PTF serve-time cluster-dedup could even
+pick a non-canonical row as the surviving pin. In production 6,699
+non-canonical rows passed every other PTF/map gate.
+
+These tests lock in `is_canonical = TRUE` (plus the rejected filter on the
+detail paths) on those four query paths.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.partners.ptf.locations_queries import (
+    _DETAIL_SQL,
+    _LIST_SQL,
+    PtfLocationsQuery,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_ptf_list_sql_filters_canonical():
+    assert "l.is_canonical = TRUE" in _LIST_SQL
+
+
+def test_ptf_detail_sql_filters_canonical_and_rejected():
+    assert "l.is_canonical = TRUE" in _DETAIL_SQL
+    assert "validation_status" in _DETAIL_SQL
+
+
+@pytest_asyncio.fixture
+async def visibility_graph(db_session: AsyncSession):
+    """Seed one canonical + one non-canonical + one rejected location.
+
+    All three carry an org website (so they clear the PTF contact-info gate)
+    and a location_source row (so they clear the map LIST inner join), leaving
+    canonicality/validation as the only thing that can hide them.
+    """
+    org_id = str(uuid.uuid4())
+    visible_id = str(uuid.uuid4())
+    duplicate_id = str(uuid.uuid4())
+    rejected_id = str(uuid.uuid4())
+
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO organization (id, name, description, website)
+            VALUES (:id, :name, :desc, :website)
+            """
+        ),
+        {
+            "id": org_id,
+            "name": "Visibility Test Org",
+            "desc": "API-2/3 seed",
+            "website": "https://example.org",
+        },
+    )
+
+    # lat/lng tightly clustered so a single small bbox covers all three.
+    seed = [
+        (visible_id, "Visible Pantry", "needs_review", True, 38.9000, -77.0000),
+        (duplicate_id, "Soft-deleted Dup", "needs_review", False, 38.9001, -77.0001),
+        (rejected_id, "Rejected Pantry", "rejected", True, 38.9002, -77.0002),
+    ]
+    for loc_id, name, status, canonical, lat, lng in seed:
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO location (
+                    id, organization_id, name, latitude, longitude,
+                    location_type, validation_status, confidence_score,
+                    is_canonical
+                )
+                VALUES (
+                    :id, :org, :name, :lat, :lng,
+                    'physical', :status, 70, :canonical
+                )
+                """
+            ),
+            {
+                "id": loc_id,
+                "org": org_id,
+                "name": name,
+                "lat": lat,
+                "lng": lng,
+                "status": status,
+                "canonical": canonical,
+            },
+        )
+        # location_source row (non-submarine) so the map LIST inner join keeps it.
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO location_source (
+                    id, location_id, scraper_id, name, latitude, longitude
+                )
+                VALUES (:id, :loc, 'no_fa_scraper', :name, :lat, :lng)
+                """
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "loc": loc_id,
+                "name": name,
+                "lat": lat,
+                "lng": lng,
+            },
+        )
+    await db_session.flush()
+
+    return {
+        "visible_id": visible_id,
+        "duplicate_id": duplicate_id,
+        "rejected_id": rejected_id,
+        "bbox": (38.89, -77.01, 38.91, -76.99),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ptf_list_excludes_noncanonical_and_rejected(
+    db_session, visibility_graph
+):
+    query = PtfLocationsQuery(db_session)
+    rows = await query.list_locations(
+        limit=200, offset=0, bbox=visibility_graph["bbox"]
+    )
+    ids = {str(r.id) for r in rows}
+    assert visibility_graph["visible_id"] in ids
+    assert visibility_graph["duplicate_id"] not in ids
+    assert visibility_graph["rejected_id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_ptf_detail_404s_for_noncanonical_and_rejected(
+    db_session, visibility_graph
+):
+    query = PtfLocationsQuery(db_session)
+    assert await query.get_location(visibility_graph["visible_id"]) is not None
+    assert await query.get_location(visibility_graph["duplicate_id"]) is None
+    assert await query.get_location(visibility_graph["rejected_id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_map_list_excludes_noncanonical_and_rejected(
+    db_session, visibility_graph
+):
+    from app.api.v1.map.services import MapDataService
+
+    service = MapDataService(db_session)
+    locations, _meta = await service.get_locations_for_map(
+        bbox=visibility_graph["bbox"]
+    )
+    ids = {str(loc["id"]) for loc in locations}
+    assert visibility_graph["visible_id"] in ids
+    assert visibility_graph["duplicate_id"] not in ids
+    assert visibility_graph["rejected_id"] not in ids

--- a/tests/test_ptf_locations_coverage_gaps.py
+++ b/tests/test_ptf_locations_coverage_gaps.py
@@ -365,8 +365,8 @@ async def double_seeded(db_session: AsyncSession):
         text(
             "INSERT INTO location ("
             "id, organization_id, name, latitude, longitude, "
-            "location_type, validation_status) "
-            "VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL)"
+            "location_type, validation_status, is_canonical) "
+            "VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL, TRUE)"
         ),
         {
             "id": loc_multifa,
@@ -400,8 +400,8 @@ async def double_seeded(db_session: AsyncSession):
         text(
             "INSERT INTO location ("
             "id, organization_id, name, latitude, longitude, "
-            "location_type, validation_status) "
-            "VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL)"
+            "location_type, validation_status, is_canonical) "
+            "VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL, TRUE)"
         ),
         {
             "id": loc_multiaddr,

--- a/tests/test_ptf_locations_integration.py
+++ b/tests/test_ptf_locations_integration.py
@@ -71,12 +71,12 @@ async def seeded(db_session: AsyncSession):
             INSERT INTO location (
                 id, organization_id, name, description,
                 latitude, longitude, location_type,
-                validation_status, confidence_score
+                validation_status, confidence_score, is_canonical
             )
             VALUES (
                 :id, :org_id, :name, :desc,
                 :lat, :lng, 'physical',
-                'verified', 75
+                'verified', 75, TRUE
             )
             """
         ),
@@ -96,11 +96,11 @@ async def seeded(db_session: AsyncSession):
             INSERT INTO location (
                 id, organization_id, name,
                 latitude, longitude, location_type,
-                validation_status
+                validation_status, is_canonical
             )
             VALUES (
                 :id, :org_id, :name,
-                :lat, :lng, 'physical', NULL
+                :lat, :lng, 'physical', NULL, TRUE
             )
             """
         ),
@@ -334,9 +334,10 @@ class TestFeedingAmericaJoinSemantics:
                 """
                 INSERT INTO location (
                     id, organization_id, name,
-                    latitude, longitude, location_type, validation_status
+                    latitude, longitude, location_type, validation_status,
+                    is_canonical
                 )
-                VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL)
+                VALUES (:id, :org_id, :name, :lat, :lng, 'physical', NULL, TRUE)
                 """
             ),
             {
@@ -456,10 +457,10 @@ class TestContactOrScheduleFilter:
                     INSERT INTO location (
                         id, organization_id, name,
                         latitude, longitude, location_type,
-                        validation_status, confidence_score
+                        validation_status, confidence_score, is_canonical
                     )
                     VALUES (:id, :org_id, :name, :lat, :lng,
-                            'physical', 'verified', 75)
+                            'physical', 'verified', 75, TRUE)
                     """
                 ),
                 {
@@ -567,10 +568,10 @@ class TestContactOrScheduleFilter:
                 INSERT INTO location (
                     id, organization_id, name,
                     latitude, longitude, location_type,
-                    validation_status, confidence_score
+                    validation_status, confidence_score, is_canonical
                 )
                 VALUES (:id, :org, 'Empty-String Pantry',
-                        45.0, -65.0, 'physical', 'verified', 75)
+                        45.0, -65.0, 'physical', 'verified', 75, TRUE)
                 """
             ),
             {"id": loc_id, "org": org_id},
@@ -678,10 +679,11 @@ class TestNearDuplicateCollapse:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, :name, :lat, :lng,
-                            'physical', 'verified', :conf)
+                            'physical', 'verified', :conf, TRUE)
                     """
                 ),
                 {
@@ -818,10 +820,11 @@ class TestNearDuplicateCollapse:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, :name, :lat, :lng,
-                            'physical', 'verified', 70)
+                            'physical', 'verified', 70, TRUE)
                     """
                 ),
                 {
@@ -900,10 +903,11 @@ class TestNearDuplicateCollapse:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, :name, :lat, :lng,
-                            'physical', 'verified', 70)
+                            'physical', 'verified', 70, TRUE)
                     """
                 ),
                 {
@@ -1006,10 +1010,11 @@ class TestNearDuplicateCollapse:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, :name, :lat, :lng,
-                            'physical', 'verified', 70)
+                            'physical', 'verified', 70, TRUE)
                     """
                 ),
                 {
@@ -1094,10 +1099,11 @@ class TestNearDuplicateCollapse:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, :name, :lat, :lng,
-                            'physical', 'verified', 75)
+                            'physical', 'verified', 75, TRUE)
                     """
                 ),
                 {"id": loc_id, "org": org_id, "name": name, "lat": lat, "lng": lng},
@@ -1168,10 +1174,11 @@ async def _seed_location(
             """
             INSERT INTO location (
                 id, organization_id, name, latitude, longitude,
-                location_type, validation_status, confidence_score
+                location_type, validation_status, confidence_score,
+                is_canonical
             )
             VALUES (:id, :org, :name, :lat, :lng,
-                    'physical', 'verified', :conf)
+                    'physical', 'verified', :conf, TRUE)
             """
         ),
         {
@@ -1376,10 +1383,11 @@ class TestTieredDedupEdgeCases:
                     """
                     INSERT INTO location (
                         id, organization_id, name, latitude, longitude,
-                        location_type, validation_status, confidence_score
+                        location_type, validation_status, confidence_score,
+                        is_canonical
                     )
                     VALUES (:id, :org, NULL, :lat, :lng,
-                            'physical', 'verified', 70)
+                            'physical', 'verified', 70, TRUE)
                     """
                 ),
                 {"id": loc_id, "org": org_id, "lat": lat, "lng": lng},


### PR DESCRIPTION
## Audit findings API-2 / API-3 (Tier 0)

Three serve paths did not restrict to canonical rows, so **soft-deleted duplicate** pantries were exposed:

- `MapDataService.get_locations_for_map` (map LIST) — filtered `validation_status` but not `is_canonical` (its sibling count query already had the filter).
- `GET /map/locations/{id}` (map detail) — no `is_canonical` **and** no rejected filter.
- PTF `_LIST_SQL` candidates CTE + `_DETAIL_SQL` — no `is_canonical`. Worse: the PTF serve-time cluster-dedup walks the candidate set and emits one survivor per cluster, so a non-canonical row could be picked as the surviving pin while the real canonical row is hidden (**false-merge on serve**). The detail path also lacked the rejected filter.

**Production blast radius (verified):** `6,699` non-canonical rows passed every *other* PTF/map gate (coords, contact-info/schedule, name) — exposed directly via detail-by-id and riskable as cluster survivors.

## Change

- `app/api/v1/map/services.py`: add `AND l.is_canonical = true` to the LIST `WHERE`.
- `app/api/v1/map/router.py`: add `AND l.is_canonical = true AND (validation_status IS NULL OR != 'rejected')` to the detail query.
- `app/api/v1/partners/ptf/locations_queries.py`: add `AND l.is_canonical = TRUE` to the `_LIST_SQL` candidates CTE (so cluster-dedup only ever considers canonical survivors) and to `_DETAIL_SQL` (plus the rejected filter).

## Tests

- **New** `tests/test_api_map_ptf_canonical.py`: static guards that the PTF SQL constants carry `is_canonical = TRUE`, plus an end-to-end seed of canonical / non-canonical / rejected rows (each with a location_source + org website so only canonicality/validation can hide them) proving the map LIST, PTF list, and PTF detail all return only the visible one.
- Existing PTF integration/coverage fixtures seeded locations **without** `is_canonical`, relying on the column's `DEFAULT FALSE`; they intend *servable* (canonical) locations, so they now set `is_canonical=TRUE` explicitly — matching the convention the beacon/dedup tests already follow. (The reconciler always sets `is_canonical` explicitly on insert, so prod data is unaffected.)

`black`, `ruff`, `mypy` clean; **292** PTF+map tests pass.

Independent of #493 (API-1) — these are raw-SQL paths, different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)