### PR TITLE
fix(api): fail soft on un-normalizable schedule rows instead of 500 (API-5)

### DIFF
--- a/app/api/v1/locations.py
+++ b/app/api/v1/locations.py
@@ -26,6 +26,11 @@ from app.api.v1.utils import (
     build_filter_dict,
 )
 
+import structlog
+from pydantic import ValidationError
+
+logger = structlog.get_logger(__name__)
+
 router = APIRouter(prefix="/locations", tags=["locations"])
 
 
@@ -83,17 +88,33 @@ async def get_location_schedules(
 
     schedules = []
     for row in rows:
-        schedule = ScheduleInfo(
-            opens_at=str(row.opens_at) if row.opens_at else None,
-            closes_at=str(row.closes_at) if row.closes_at else None,
-            byday=row.byday,
-            bymonthday=row.bymonthday,
-            freq=row.freq,
-            description=row.description,
-            valid_from=row.valid_from.isoformat() if row.valid_from else None,
-            valid_to=row.valid_to.isoformat() if row.valid_to else None,
-            notes=row.notes,
-        )
+        # Fail soft: ScheduleInfo's byday/bymonthday validators RAISE on a value
+        # that the RFC 5545 normalizer can't parse. A single corrupt row (from
+        # any write path that bypassed normalization) must not 500 the whole
+        # page — skip it and log so the bad row is traceable. This matches the
+        # reconciler/submarine/normalizer fail-soft posture for the same fields.
+        try:
+            schedule = ScheduleInfo(
+                opens_at=str(row.opens_at) if row.opens_at else None,
+                closes_at=str(row.closes_at) if row.closes_at else None,
+                byday=row.byday,
+                bymonthday=row.bymonthday,
+                freq=row.freq,
+                description=row.description,
+                valid_from=row.valid_from.isoformat() if row.valid_from else None,
+                valid_to=row.valid_to.isoformat() if row.valid_to else None,
+                notes=row.notes,
+            )
+        except (ValidationError, ValueError, TypeError) as exc:
+            logger.warning(
+                "location_schedule_dropped_invalid",
+                location_id=str(location_id),
+                byday=row.byday,
+                bymonthday=row.bymonthday,
+                freq=row.freq,
+                error=str(exc),
+            )
+            continue
         schedules.append(schedule)
 
     return schedules

--- a/tests/test_api_schedule_failsoft.py
+++ b/tests/test_api_schedule_failsoft.py
@@ -1,0 +1,85 @@
+"""API-5 regression guard: one corrupt schedule row must not 500 a page.
+
+`ScheduleInfo`'s byday/bymonthday field validators RAISE on a value the RFC 5545
+normalizer can't parse (response.py). `get_location_schedules` builds a
+`ScheduleInfo` per DB row, so a single un-normalizable byday/bymonthday stored by
+any write path that bypassed normalization would raise and 500 the entire
+/locations list (and the /locations/{id} detail) for that area.
+
+The handler now fails soft: the bad row is logged and skipped, good rows still
+render.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.locations import get_location_schedules
+
+pytestmark = pytest.mark.integration
+
+
+def test_scheduleinfo_raises_on_unnormalizable_byday():
+    """Precondition: constructing ScheduleInfo with a bad byday raises."""
+    from app.models.hsds.response import ScheduleInfo
+
+    with pytest.raises(Exception):
+        ScheduleInfo(
+            opens_at="09:00", closes_at="17:00", freq="WEEKLY", byday="NOTADAY"
+        )
+
+
+@pytest_asyncio.fixture
+async def location_with_corrupt_schedule(db_session: AsyncSession):
+    org_id = str(uuid.uuid4())
+    loc_id = str(uuid.uuid4())
+
+    await db_session.execute(
+        text(
+            "INSERT INTO organization (id, name, description) "
+            "VALUES (:id, :name, :desc)"
+        ),
+        {"id": org_id, "name": "Schedule Failsoft Org", "desc": "API-5 seed"},
+    )
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO location (
+                id, organization_id, name, latitude, longitude,
+                location_type, validation_status, confidence_score, is_canonical
+            )
+            VALUES (:id, :org, 'Failsoft Pantry', 40.0, -75.0,
+                    'physical', 'needs_review', 70, TRUE)
+            """
+        ),
+        {"id": loc_id, "org": org_id},
+    )
+    # One valid schedule row, one corrupt byday inserted via raw SQL (bypasses
+    # the Pydantic normalizer the write API would otherwise enforce).
+    for byday in ("MO", "TOTALLY-INVALID-BYDAY"):
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO schedule (
+                    id, location_id, freq, wkst, opens_at, closes_at, byday
+                )
+                VALUES (:id, :loc, 'WEEKLY', 'MO', '09:00', '17:00', :byday)
+                """
+            ),
+            {"id": str(uuid.uuid4()), "loc": loc_id, "byday": byday},
+        )
+    await db_session.flush()
+    return loc_id
+
+
+@pytest.mark.asyncio
+async def test_corrupt_schedule_row_is_skipped_not_500(
+    db_session, location_with_corrupt_schedule
+):
+    # Must NOT raise — the corrupt row is dropped, the valid one survives.
+    schedules = await get_location_schedules(location_with_corrupt_schedule, db_session)
+    assert len(schedules) == 1
+    assert schedules[0].byday == "MO"


### PR DESCRIPTION
## Audit findings API-5 / seams-3 (Tier 0)

`ScheduleInfo`'s `byday`/`bymonthday` field validators **raise** (`ValueError` → Pydantic `ValidationError`) on a value the RFC 5545 normalizer can't parse — while the write, reconciler, and submarine paths all **fail soft** for the same fields (drop to NULL + warn). `get_location_schedules` constructs a `ScheduleInfo` per DB row, so a single un-normalizable `byday`/`bymonthday` (stored by any write path that bypassed normalization, or a future drift) would raise and **500 the entire `/locations` list and `/locations/{id}` detail** for that area — every pantry on the page disappears, not just the bad row.

## Change

Wrap the per-row `ScheduleInfo(...)` construction in `get_location_schedules` in `try/except (ValidationError, ValueError, TypeError)`: log `location_schedule_dropped_invalid` (with `location_id`, `byday`, `bymonthday`, `freq`, error) and skip just that row. This aligns the serve path with the fail-soft posture used everywhere else for these fields.

Note: catches Pydantic `ValidationError` specifically — in Pydantic v2 it is **not** a `ValueError` subclass, so the validator's internal `ValueError` surfaces as `ValidationError` at model construction.

## Tests

`tests/test_api_schedule_failsoft.py`:
- Precondition: `ScheduleInfo(byday="NOTADAY")` raises.
- End-to-end: seed a location with one valid (`MO`) and one corrupt (`TOTALLY-INVALID-BYDAY`) schedule row (raw SQL, bypassing the normalizer), and prove `get_location_schedules` returns only the valid one without raising.

`black`/`ruff`/`mypy` clean; 103 location/api tests pass. Independent of the other Tier-0 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)