### PR TITLE
fix(api): deterministic ORDER BY on paginated repository reads (API-6)

### DIFF
--- a/app/database/repositories.py
+++ b/app/database/repositories.py
@@ -84,7 +84,10 @@ class BaseRepository(ABC, Generic[ModelType]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()
@@ -163,7 +166,10 @@ class OrganizationRepository(BaseRepository[OrganizationModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()
@@ -284,7 +290,10 @@ class LocationRepository(BaseRepository[LocationModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()
@@ -380,7 +389,10 @@ class LocationRepository(BaseRepository[LocationModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         if HAS_GEOALCHEMY2:
@@ -440,7 +452,10 @@ class LocationRepository(BaseRepository[LocationModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()
@@ -458,7 +473,10 @@ class LocationRepository(BaseRepository[LocationModel]):
         )
         if not include_hidden:
             query = query.filter(_visible_location_clause(self.model))
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
         result = await self.session.execute(query)
         return result.scalars().all()
 
@@ -615,7 +633,10 @@ class ServiceRepository(BaseRepository[ServiceModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()
@@ -757,7 +778,10 @@ class ServiceAtLocationRepository(BaseRepository[ServiceAtLocationModel]):
                     query = query.filter(getattr(self.model, key) == value)
 
         # Apply pagination
-        query = query.offset(skip).limit(limit)
+        # Stable ORDER BY so OFFSET/LIMIT can't skip/duplicate rows across
+        # pages. id is the PK (unique, non-null); where an upstream order_by
+        # (e.g. distance) already exists, this appends id as a tiebreaker.
+        query = query.order_by(self.model.id).offset(skip).limit(limit)  # type: ignore[attr-defined]
 
         result = await self.session.execute(query)
         return result.scalars().all()

--- a/tests/test_api_pagination_order.py
+++ b/tests/test_api_pagination_order.py
@@ -1,0 +1,127 @@
+"""API-6 regression guard: paginated repository reads have a stable ORDER BY.
+
+Without a deterministic ORDER BY, Postgres may return rows in a different
+physical order between requests, so OFFSET/LIMIT can silently skip or duplicate
+rows across pages of the HSDS list endpoints. Every paginated repository read
+now orders by the primary key (appended as a tiebreaker where an upstream
+order_by such as distance already exists).
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+
+from app.database.repositories import (
+    LocationRepository,
+    OrganizationRepository,
+    ServiceRepository,
+)
+from app.models.hsds.query import GeoBoundingBox
+
+pytestmark = pytest.mark.integration
+
+
+def _sql(query) -> str:
+    return str(
+        query.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": False}
+        )
+    ).lower()
+
+
+class _CapturingSession:
+    def __init__(self) -> None:
+        self.captured = None
+
+    async def execute(self, statement, *args, **kwargs):
+        self.captured = statement
+        from unittest.mock import Mock
+
+        result = Mock()
+        scalars = Mock()
+        scalars.all.return_value = []
+        result.scalars.return_value = scalars
+        return result
+
+
+@pytest.mark.asyncio
+async def test_location_get_all_orders_by_id():
+    session = _CapturingSession()
+    await LocationRepository(session).get_all()
+    assert "order by location.id" in _sql(session.captured)
+
+
+@pytest.mark.asyncio
+async def test_location_bbox_orders_by_id():
+    session = _CapturingSession()
+    await LocationRepository(session).get_locations_by_bbox(
+        GeoBoundingBox(
+            min_latitude=40.0,
+            max_latitude=41.0,
+            min_longitude=-74.0,
+            max_longitude=-73.0,
+        )
+    )
+    assert "order by location.id" in _sql(session.captured)
+
+
+@pytest.mark.asyncio
+async def test_org_and_service_get_all_order_by_id():
+    for repo_cls, table in (
+        (OrganizationRepository, "organization"),
+        (ServiceRepository, "service"),
+    ):
+        session = _CapturingSession()
+        await repo_cls(session).get_all()
+        assert f"order by {table}.id" in _sql(session.captured)
+
+
+@pytest_asyncio.fixture
+async def five_locations(db_session: AsyncSession):
+    org_id = str(uuid.uuid4())
+    await db_session.execute(
+        text(
+            "INSERT INTO organization (id, name, description) "
+            "VALUES (:id, :name, :desc)"
+        ),
+        {"id": org_id, "name": "Pagination Org", "desc": "API-6 seed"},
+    )
+    ids = sorted(str(uuid.uuid4()) for _ in range(5))
+    for i, loc_id in enumerate(ids):
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO location (
+                    id, organization_id, name, latitude, longitude,
+                    location_type, validation_status, confidence_score,
+                    is_canonical
+                )
+                VALUES (:id, :org, :name, 40.0, -74.0,
+                        'physical', 'needs_review', 70, TRUE)
+                """
+            ),
+            {"id": loc_id, "org": org_id, "name": f"Pantry {i}"},
+        )
+    await db_session.flush()
+    return org_id, set(ids)
+
+
+@pytest.mark.asyncio
+async def test_pagination_covers_every_row_exactly_once(db_session, five_locations):
+    org_id, expected_ids = five_locations
+    repo = LocationRepository(db_session)
+
+    seen: list[str] = []
+    for page in range(3):  # limit 2 over 5 rows -> pages of 2,2,1
+        rows = await repo.get_all(
+            skip=page * 2, limit=2, filters={"organization_id": org_id}
+        )
+        seen.extend(str(r.id) for r in rows)
+
+    # No duplicates across pages, and every seeded row appears exactly once.
+    assert len(seen) == len(set(seen)) == 5
+    assert set(seen) == expected_ids


### PR DESCRIPTION
## Audit finding API-6 (Tier 0)

Paginated HSDS list reads (`/locations`, `/organizations`, `/services`, `/service-at-location`, and the location geo lists) had **no stable `ORDER BY`**. Postgres is free to return rows in a different physical order between requests, so `OFFSET`/`LIMIT` can silently **skip or duplicate** pantries across pages.

## Change

Add `ORDER BY <pk>` to every paginated repository read:
- `BaseRepository.get_all` + `LocationRepository.get_all` + `OrganizationRepository.get_all` + `ServiceRepository.get_all` + `ServiceAtLocationRepository.get_all`.
- `LocationRepository.get_locations_by_bbox` and `get_locations_with_services`.
- `LocationRepository.get_locations_by_radius`: `id` is appended **after** the existing distance ordering, so results stay distance-sorted with a deterministic tiebreaker.

`id` is the primary key (unique, non-null) → stable page boundaries. The `self.model.id` reference carries `# type: ignore[attr-defined]` because `BaseRepository.self.model` is the unbound generic `type[ModelType]` (concrete subclasses resolve fine; `warn_unused_ignores = false`).

## Tests

`tests/test_api_pagination_order.py`:
- Static: the `get_all` / bbox / org / service queries compile with `ORDER BY <table>.id`.
- End-to-end: paginate 5 seeded rows in pages of 2 and assert every row appears **exactly once** (no skip, no duplicate).

`black`/`ruff`/`mypy` clean; 113 repository/api tests pass. Based on `main` post-#493 (shares `repositories.py`); independent of the other open Tier-0 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)