### PR TITLE
fix(publisher): filter is_canonical in aggregated map export (PUB-3)

### DIFF
--- a/app/haarrrvest_publisher/export_map_data_aggregated.py
+++ b/app/haarrrvest_publisher/export_map_data_aggregated.py
@@ -216,7 +216,12 @@ class AggregatedMapDataExporter:
                   AND l.longitude IS NOT NULL
                   AND l.latitude BETWEEN -90 AND 90
                   AND l.longitude BETWEEN -180 AND 180
-                  -- Include all locations, not just rejected ones
+                  -- Canonical survivors only: the reconciler soft-deletes
+                  -- merged-away duplicates (is_canonical=FALSE). Without this
+                  -- they get fetched, participate in clustering, and a
+                  -- cluster of only-non-canonical rows would emit a
+                  -- soft-deleted pin. Mirrors every sibling map export.
+                  AND l.is_canonical = true
                   AND (l.validation_status IS NULL OR l.validation_status != 'rejected')
                 ORDER BY cluster_id, ls.scraper_id
             """,

--- a/tests/haarrrvest_publisher/test_aggregated_export_canonical.py
+++ b/tests/haarrrvest_publisher/test_aggregated_export_canonical.py
@@ -1,0 +1,48 @@
+"""PUB-3 regression guard: aggregated map export filters is_canonical.
+
+The aggregated map exporter (the production map export) fetched locations for
+PostGIS clustering without an is_canonical filter, while every sibling map
+export has one. Soft-deleted duplicates (is_canonical=FALSE) would be fetched,
+participate in clustering, and a cluster of only-non-canonical rows would emit a
+soft-deleted pin into the published map data.
+"""
+
+from unittest.mock import MagicMock
+
+from app.haarrrvest_publisher.export_map_data_aggregated import (
+    AggregatedMapDataExporter,
+)
+
+
+def test_aggregated_fetch_sql_filters_is_canonical(tmp_path):
+    exporter = AggregatedMapDataExporter(
+        data_repo_path=tmp_path,
+        pg_conn_string="postgresql://unused",
+        grouping_radius_meters=150,
+    )
+
+    captured: dict[str, str] = {}
+
+    cursor = MagicMock()
+
+    def _execute(sql, params=None):
+        captured["sql"] = sql
+
+    cursor.execute.side_effect = _execute
+    # `for row in cursor` must yield no rows.
+    cursor.__iter__.return_value = iter([])
+
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_cm
+
+    rows = exporter._fetch_all_locations_with_sources(conn)
+
+    assert rows == []
+    sql = captured["sql"].lower()
+    assert "l.is_canonical = true" in sql
+    # And it must keep the existing rejected filter.
+    assert "validation_status" in sql


### PR DESCRIPTION
## Audit finding PUB-3 (Tier 0)

The aggregated map exporter (`export_map_data_aggregated.py`) — the production map data export — fetched locations for PostGIS clustering **without an `is_canonical` filter**, while every sibling map export (`export_map_data.py`, the map service, consumer, PTF) has one. Soft-deleted duplicates (`is_canonical=FALSE`) were fetched, participated in clustering, and a cluster of only-non-canonical rows would emit a soft-deleted pin into the published map data. (The per-cluster "primary" pick prefers a canonical row but falls back to `group[0]`, so non-canonical rows leak.)

## Change

Add `AND l.is_canonical = true` to the `_fetch_all_locations_with_sources` WHERE, alongside the existing rejected filter — matching the sibling exporters and the serve-time paths.

## Tests

`tests/haarrrvest_publisher/test_aggregated_export_canonical.py` captures the executed SQL via a mock cursor and asserts both `l.is_canonical = true` and the existing `validation_status` filter are present. (Real-DB run would require a sync psycopg + PostGIS `ST_ClusterDBSCAN` path the async test harness doesn't provide; the mock-capture check verifies the executed query.)

`black`/`ruff`/`mypy` clean; 77 `haarrrvest_publisher` tests pass. Independent of the other Tier-0 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)