### PR TITLE
fix(submarine): stop NULLing organization_id on hours-only enrichment (SUB-1)

### DIFF
--- a/app/reconciler/submarine_location_handler.py
+++ b/app/reconciler/submarine_location_handler.py
@@ -74,15 +74,27 @@ class SubmarineLocationHandler:
             "name=:name",
             "latitude=:latitude",
             "longitude=:longitude",
-            "organization_id=:organization_id",
         ]
         params: dict[str, Any] = {
             "id": str(location_id),
             "name": location["name"],
             "latitude": float(location["latitude"]),
             "longitude": float(location["longitude"]),
-            "organization_id": str(org_id) if org_id else None,
         }
+
+        # Only (re)link the organization when submarine actually resolved one.
+        # Previously organization_id was ALWAYS in the SET clause, bound to
+        # NULL when org_id was falsy. A submarine job that extracted no
+        # org-level data (the common hours-only case — result_builder emits no
+        # organization block unless an email was found) therefore NULLed the
+        # location's existing organization_id, orphaning canonical pantries
+        # from their org. Submarine's contract is to fill missing
+        # non-geographic text fields, not to re-parent locations
+        # (constitution VI, clarified v1.5.1), so leave the link untouched
+        # when there is nothing to set.
+        if org_id is not None:
+            set_clauses.append("organization_id=:organization_id")
+            params["organization_id"] = str(org_id)
 
         update_description = None
         if "description" in location:

--- a/tests/test_reconciler/test_submarine_location_handler.py
+++ b/tests/test_reconciler/test_submarine_location_handler.py
@@ -185,6 +185,31 @@ class TestUpdateLocation:
         params = db.execute.call_args[0][1]
         assert params["organization_id"] == str(org_id)
 
+    def test_does_not_null_organization_id_when_org_id_none(self):
+        """Regression (SUB-1): org_id=None must NOT wipe the existing org link.
+
+        Previously organization_id was always in the SET clause bound to NULL,
+        so an hours-only submarine enrichment orphaned the location from its
+        organization. With no org resolved, organization_id must not appear in
+        the UPDATE at all.
+        """
+        db = MagicMock(spec=Session)
+        handler = SubmarineLocationHandler(db)
+
+        location_id = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        location = {
+            "name": "Grace Food Pantry",
+            "latitude": 39.78,
+            "longitude": -89.65,
+        }
+
+        handler.update_location(location_id, location, org_id=None)
+
+        sql_arg = str(db.execute.call_args[0][0].text)
+        params = db.execute.call_args[0][1]
+        assert "organization_id" not in sql_arg
+        assert "organization_id" not in params
+
 
 class TestPersistSchedules:
     """Test submarine schedule persistence to location."""


### PR DESCRIPTION
## Audit finding SUB-1 (Tier 1, CRITICAL)

`SubmarineLocationHandler.update_location` always put `organization_id` in the UPDATE `SET` clause, bound to `NULL` whenever `org_id` was falsy:

```python
set_clauses = [..., "organization_id=:organization_id"]
params = {..., "organization_id": str(org_id) if org_id else None}
```

The common submarine job extracts only **hours** — `result_builder` emits no `organization` block unless an **email** was found — so `org_id` arrived as `None` and the UPDATE **wiped the location's existing `organization_id`**, orphaning canonical pantries from their organization.

**Production blast radius (verified):** ~**6,900** canonical locations currently have `organization_id = NULL`; submarine has run on **52,530** locations. Live, ongoing corruption on a priority subsystem.

## Change

Only append `organization_id` to the `SET` clause when `org_id` is actually resolved; otherwise leave the existing link untouched. Aligns with submarine's constitutional contract — fill missing **non-geographic text fields**, not re-parent locations (Principle VI, clarified v1.5.1).

## Tests

New regression `test_does_not_null_organization_id_when_org_id_none`: with `org_id=None`, `organization_id` must not appear in the UPDATE SQL or params. The `org_id`-provided test still asserts it's set when present. 416 reconciler+submarine tests pass; `black`/`ruff` clean. (reconciler is excluded from CI mypy.)

## Follow-up

A separate PR backfills already-orphaned rows by recovering `organization_id` from each location's `location_source` history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)