### PR TITLE
fix(reconciler): persist schedule bymonthday (monthly recurrence) (SUB-6)

### DIFF
--- a/app/reconciler/job_processor.py
+++ b/app/reconciler/job_processor.py
@@ -1680,6 +1680,7 @@ class JobProcessor:
                                                 location_id=location_ids[loc_key],
                                                 metadata=job_result.job.metadata,
                                                 byday=byday,
+                                                bymonthday=schedule.get("bymonthday"),
                                                 description=description,
                                             )
                                         )
@@ -1915,6 +1916,7 @@ class JobProcessor:
                             service_at_location_id=service_at_location_id_for_schedule,
                             metadata=job_result.job.metadata,
                             byday=byday,
+                            bymonthday=schedule.get("bymonthday"),
                             description=description,
                         )
                     )

--- a/app/reconciler/service_creator.py
+++ b/app/reconciler/service_creator.py
@@ -769,6 +769,7 @@ class ServiceCreator(BaseReconciler):
         count: str | None = None,
         interval: int | None = None,
         byday: str | None = None,
+        bymonthday: str | None = None,
         description: str | None = None,
     ) -> uuid.UUID:
         """Create new schedule.
@@ -813,6 +814,7 @@ class ServiceCreator(BaseReconciler):
             count,
             interval,
             byday,
+            bymonthday,
             description
         ) VALUES (
             :id,
@@ -830,6 +832,7 @@ class ServiceCreator(BaseReconciler):
             :count,
             :interval,
             :byday,
+            :bymonthday,
             :description
         )
         """
@@ -859,6 +862,7 @@ class ServiceCreator(BaseReconciler):
                 "count": count,
                 "interval": interval,
                 "byday": byday,
+                "bymonthday": bymonthday,
                 "description": description,
             },
         )
@@ -913,6 +917,7 @@ class ServiceCreator(BaseReconciler):
         count: str | None = None,
         interval: int | None = None,
         byday: str | None = None,
+        bymonthday: str | None = None,
         description: str | None = None,
     ) -> tuple[uuid.UUID, bool]:
         """Update existing schedule or create new one with versioning.
@@ -945,7 +950,8 @@ class ServiceCreator(BaseReconciler):
         # Check for existing schedule with same entity relationship
         existing_query = text(
             """
-            SELECT id, freq, wkst, opens_at, closes_at, byday, description,
+            SELECT id, freq, wkst, opens_at, closes_at, byday, bymonthday,
+                   description,
                    valid_from, valid_to, dtstart, until, count, interval, location_id
             FROM schedule
             WHERE (
@@ -980,6 +986,7 @@ class ServiceCreator(BaseReconciler):
                 or existing.opens_at != opens_at_time
                 or existing.closes_at != closes_at_time
                 or existing.byday != byday
+                or existing.bymonthday != bymonthday
                 or existing.description != description
                 or existing.valid_from != valid_from
                 or existing.valid_to != valid_to
@@ -1001,6 +1008,7 @@ class ServiceCreator(BaseReconciler):
                         opens_at = :opens_at,
                         closes_at = :closes_at,
                         byday = :byday,
+                        bymonthday = :bymonthday,
                         description = :description,
                         valid_from = :valid_from,
                         valid_to = :valid_to,
@@ -1022,6 +1030,7 @@ class ServiceCreator(BaseReconciler):
                         "opens_at": opens_at_time,
                         "closes_at": closes_at_time,
                         "byday": byday,
+                        "bymonthday": bymonthday,
                         "description": description,
                         "valid_from": valid_from,
                         "valid_to": valid_to,
@@ -1057,6 +1066,7 @@ class ServiceCreator(BaseReconciler):
                         "count": count,
                         "interval": interval,
                         "byday": byday,
+                        "bymonthday": bymonthday,
                         "description": description,
                         **metadata,
                     },
@@ -1091,6 +1101,7 @@ class ServiceCreator(BaseReconciler):
                 count=count,
                 interval=interval,
                 byday=byday,
+                bymonthday=bymonthday,
                 description=description,
             )
             return schedule_id, False  # False = not updated (newly created)

--- a/app/reconciler/submarine_location_handler.py
+++ b/app/reconciler/submarine_location_handler.py
@@ -156,6 +156,7 @@ class SubmarineLocationHandler:
                 location_id=location_id,
                 service_at_location_id=None,
                 byday=transformed.get("byday"),
+                bymonthday=transformed.get("bymonthday"),
                 description=transformed.get("description"),
             )
             count += 1

--- a/tests/test_reconciler/test_schedule_updates.py
+++ b/tests/test_reconciler/test_schedule_updates.py
@@ -73,6 +73,49 @@ class TestScheduleUpdateOrCreate:
         assert result.byday == "MO,TU,WE,TH,FR"
         assert result.freq == "WEEKLY"
 
+    def test_create_new_schedule_persists_bymonthday(self, service_creator):
+        """SUB-6: a MONTHLY-by-day-of-month schedule's bymonthday must persist.
+
+        Previously create_schedule/update_or_create_schedule had no bymonthday
+        parameter, so a pantry open "the 1st and 15th" lost its recurrence
+        entirely (0 of 15k monthly schedules in prod had bymonthday set).
+        """
+        from app.reconciler.organization_creator import OrganizationCreator
+
+        org_creator = OrganizationCreator(service_creator.db)
+        org_id = org_creator.create_organization(
+            name="Bymonthday Org",
+            description="Test Description",
+            metadata={"source": "test"},
+        )
+        service_id = service_creator.create_service(
+            name="Bymonthday Service",
+            description="Test Description",
+            organization_id=org_id,
+            metadata={"source": "test"},
+        )
+
+        schedule_id, was_updated = service_creator.update_or_create_schedule(
+            freq="MONTHLY",
+            wkst="MO",
+            opens_at="09:00",
+            closes_at="17:00",
+            metadata={"source": "test"},
+            service_id=service_id,
+            bymonthday="1,15",
+            description="1st and 15th of the month",
+        )
+
+        assert was_updated is False
+        result = service_creator.db.execute(
+            text("SELECT bymonthday, byday, freq FROM schedule WHERE id = :id"),
+            {"id": str(schedule_id)},
+        ).first()
+        assert result is not None
+        assert result.bymonthday == "1,15"
+        assert result.byday is None
+        assert result.freq == "MONTHLY"
+
     def test_update_existing_schedule_with_changes(
         self, service_creator, sample_schedule_data
     ):


### PR DESCRIPTION
## Audit finding SUB-6 (Tier 1)

`create_schedule` and `update_or_create_schedule` had a `byday` parameter but **no `bymonthday`**. `_transform_schedule` already normalizes and carries `bymonthday`, but every persistence path dropped it — so a MONTHLY-by-day-of-month schedule (e.g. a pantry open "the 1st and 15th") lost its recurrence entirely.

**Production blast radius (verified):** **0 of 15,144** MONTHLY schedules have `bymonthday` set; **515** monthly rows have neither `byday` nor `bymonthday` (broken recurrence — users can't tell when those pantries are open). Monthly-by-weekday (e.g. "2nd Saturday" = `2SA` in `byday`) was unaffected.

## Change

Thread `bymonthday` end-to-end:
- `create_schedule`: new `bymonthday` param + INSERT column + value.
- `update_or_create_schedule`: new param + `SELECT` lookup + change-detection compare + `UPDATE SET` + version snapshot + pass-through to `create_schedule`.
- `job_processor`: both schedule-persistence call sites pass `bymonthday=schedule.get("bymonthday")`.
- submarine `persist_schedules`: passes `bymonthday=transformed.get("bymonthday")`.

## Tests

New real-DB test: a MONTHLY schedule created with `bymonthday="1,15"` reads back with `bymonthday="1,15"` and `byday` NULL (previously `bymonthday` was always NULL). 416 reconciler+submarine tests pass; `black`/`ruff` clean.

Scope: this PR is the **persistence** half. The separate REC-2 (multiple schedules collapsing on the `LIMIT 1` lookup) and REC-5 (unparseable hours → NULL) findings touch the same functions and will follow as their own PRs. Touches `submarine_location_handler.py` (`persist_schedules`) — a different method than #499 (`update_location`), so no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)