### PR TITLE
fix(llm): raise on OpenAI/OpenRouter API errors instead of returning as success (LLM-5)

### DIFF
--- a/app/llm/providers/openai.py
+++ b/app/llm/providers/openai.py
@@ -444,17 +444,18 @@ class OpenAIProvider(BaseLLMProvider[AsyncOpenAI, OpenAIConfig]):
         Returns:
             LLMResponse: Processed response
         """
-        # Handle API errors
+        # Handle API errors: RAISE rather than returning the error string as a
+        # successful response. generate() wraps this and
+        # processor.process_llm_job retries ValueError with backoff (up to 3x),
+        # then fails the job. Previously the error message was returned as a
+        # "successful" LLMResponse, so transient OpenRouter errors (rate limit,
+        # provider error, content filter) were never retried and got routed
+        # downstream as garbage "HSDS data" — the pantry silently produced no
+        # records while the job reported success.
         error = getattr(result, "error", None)
         if error:
             error_msg = _extract_error_message(error)
-            base_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-            usage = _validate_usage(result.usage) if result.usage else base_usage
-            return LLMResponse(
-                text=error_msg,
-                model=self.config.model_name,
-                usage=usage,
-            )
+            raise ValueError(f"LLM API returned an error: {error_msg}")
 
         # Handle empty response
         if not result.choices or not result.choices[0].message:

--- a/tests/test_llm/test_openai.py
+++ b/tests/test_llm/test_openai.py
@@ -101,6 +101,40 @@ async def test_openai_generate_text(
     assert len(response.text) > 0
 
 
+def test_process_api_response_raises_on_api_error(
+    openai_provider: OpenAIProvider,
+) -> None:
+    """LLM-5: an API error must RAISE, not return the error text as success.
+
+    Returning it as a successful LLMResponse routed transient OpenRouter errors
+    downstream as garbage and never retried.
+    """
+    result = MagicMock()
+    result.error = {"message": "rate limit exceeded", "code": 429}
+    result.usage = None
+
+    with pytest.raises(ValueError, match="error"):
+        openai_provider._process_api_response(result, None)
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_raises_on_api_error(
+    openai_provider: OpenAIProvider, mock_openai_client
+) -> None:
+    """generate() surfaces an API error as a raised exception (→ retried by the
+    processor / job fails), instead of returning the error string as success."""
+    mock_response = MagicMock()
+    mock_response.error = {"message": "provider temporarily unavailable"}
+    mock_response.choices = []
+    mock_response.usage = None
+    mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    with patch.object(OpenAIProvider, "model", new_callable=PropertyMock) as mock_model:
+        mock_model.return_value = mock_openai_client
+        with pytest.raises(ValueError):
+            await openai_provider.generate("Say hello.")
+
+
 @pytest.mark.asyncio
 async def test_openai_generate_structured(
     openai_provider: OpenAIProvider, mock_openai_client


### PR DESCRIPTION
## Audit finding LLM-5 (Tier 1)

`OpenAIProvider._process_api_response` returned the API error message as a **successful** `LLMResponse` when `result.error` was set:

```python
if error:
    error_msg = _extract_error_message(error)
    return LLMResponse(text=error_msg, ...)
```

Because the text is non-empty and not an empty-response sentinel, `processor.process_llm_job` treats the job as **COMPLETED**. So transient OpenRouter errors (rate limit, provider error, content filter) were **never retried**, and the error string was routed downstream as the job's "HSDS data" — the pantry silently produced no records while the job reported success (a Principle XI data-loss path).

## Change

Raise `ValueError` on `result.error`. `generate()` already wraps provider exceptions, and `processor.process_llm_job` retries `ValueError` with exponential backoff (up to 3×) before failing the job — so the error is retried and, if persistent, surfaced as a real failure instead of silent garbage.

## Tests

- `_process_api_response` raises on an error result.
- `generate()` raises end-to-end on an error response (instead of returning the error text).

Full `tests/test_llm` suite green except one **pre-existing, unrelated** failure (`test_process_llm_job_no_print_calls` — fails on `main` too, confirmed by stashing this change). `black`/`ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)