### PR TITLE
fix(reconciler): broaden _parse_time so common hour formats aren't NULLed (REC-5)

### DIFF
--- a/app/reconciler/service_creator.py
+++ b/app/reconciler/service_creator.py
@@ -738,17 +738,51 @@ class ServiceCreator(BaseReconciler):
         return language_id
 
     def _parse_time(self, time_str: str | None) -> "datetime.time | None":
-        """Parse time string in various formats. Returns None for unparseable values."""
+        """Parse a time string in the formats real scrapers emit.
+
+        Returns None for unparseable values (the caller then stores NULL hours).
+        Beyond the strptime formats, handles the common real-world cases that
+        previously fell through to NULL — losing a pantry's hours: the words
+        "noon"/"midnight", periods in "a.m."/"p.m.", and bare HHMM ("0900").
+        """
         import datetime as dt_module
 
         if not time_str:
             return None
-        time_str = time_str.strip()
-        for fmt in ["%H:%M", "%H:%M:%S", "%I:%M %p", "%I:%M%p", "%I%p", "%I %p"]:
-            try:
-                return dt_module.datetime.strptime(time_str, fmt).time()
-            except ValueError:
-                continue
+        raw = time_str.strip()
+        if not raw:
+            return None
+
+        # Word forms that strptime can't handle.
+        lowered = raw.lower()
+        if lowered in ("noon", "12 noon", "12noon"):
+            return dt_module.time(12, 0)
+        if lowered in ("midnight", "12 midnight", "12midnight"):
+            return dt_module.time(0, 0)
+
+        # Try the raw string and a period-stripped variant ("9 a.m." -> "9 am")
+        # so the %p formats match (%p is case-insensitive in strptime).
+        candidates = [raw]
+        stripped = raw.replace(".", "").strip()
+        if stripped != raw:
+            candidates.append(stripped)
+
+        formats = [
+            "%H:%M",
+            "%H:%M:%S",
+            "%I:%M %p",
+            "%I:%M%p",
+            "%I%p",
+            "%I %p",
+            "%H%M",  # bare HHMM, e.g. "0900"
+        ]
+        for candidate in candidates:
+            for fmt in formats:
+                try:
+                    return dt_module.datetime.strptime(candidate, fmt).time()
+                except ValueError:
+                    continue
+
         self.logger.warning(f"Could not parse time string: '{time_str}'")
         return None
 

--- a/tests/test_reconciler/test_time_parsing.py
+++ b/tests/test_reconciler/test_time_parsing.py
@@ -18,6 +18,14 @@ class TestTimeParsing:
             ("09:00:00", 9, 0),
             ("9AM", 9, 0),
             ("12:30 PM", 12, 30),
+            # REC-5: real-world forms that previously NULLed the hours.
+            ("noon", 12, 0),
+            ("midnight", 0, 0),
+            ("0900", 9, 0),
+            ("1700", 17, 0),
+            ("9 a.m.", 9, 0),
+            ("5 p.m.", 17, 0),
+            ("9:00 a.m.", 9, 0),
         ],
     )
     def test_parse_time_various_formats(self, time_str, expected_hour, expected_minute):


### PR DESCRIPTION
## Audit finding REC-5 (Tier 1, parse-coverage portion)

`ServiceCreator._parse_time` tried only six `strptime` formats and returned `None` on anything else. The caller then stores **NULL `opens_at`/`closes_at`** — so the pantry shows a schedule entry with no usable hours (a food-insecure user can't tell when to go). Common real-world strings fell through:
- the words **"noon"/"midnight"**
- **"a.m."/"p.m." with periods** ("9 a.m.")
- bare **HHMM** ("0900")

## Change

Before giving up, `_parse_time` now: maps the word forms directly; tries a period-stripped variant ("9 a.m." → "9 am") so the `%p` formats match; and adds `%H%M` for "0900". Existing formats and the `None`/garbage/empty behavior are unchanged.

## Tests

Extended the parametrized regression test with `noon`, `midnight`, `0900`, `1700`, `9 a.m.`, `5 p.m.`, `9:00 a.m.`; "whenever" still returns `None`. 274 reconciler tests pass; `black`/`ruff` clean.

Scope: the `opens_at < closes_at` validation and drop-on-unparseable (also part of REC-5) are deferred to keep this focused on parse coverage. Independent of the schedule-persistence PR #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)