### PR TITLE
fix(validator): don't let a coarse ZIP lookup override a claimed state (VAL-4)

### DIFF
--- a/app/core/zip_state_mapping.py
+++ b/app/core/zip_state_mapping.py
@@ -244,8 +244,16 @@ def resolve_state_conflict(
     if coord_state and city_state and coord_state == city_state:
         return coord_state, "coord_city_agreement"
 
-    # Trust ZIP if it exists (most specific)
+    # Trust ZIP if it exists (most specific) — but do NOT override a non-empty
+    # claimed state on the strength of the ZIP lookup alone. get_state_from_zip
+    # is a coarse 3-digit-prefix table with known gaps/collisions, so a bare
+    # ZIP-vs-claimed conflict (no coord/city agreement reached the checks
+    # above) is not enough evidence to rewrite a state the source asserted —
+    # doing so corrupted correct addresses. Require corroboration; otherwise
+    # keep the claimed state.
     if zip_state:
+        if claimed_state and zip_state != claimed_state.upper():
+            return claimed_state.upper(), "zip_conflict_unverified_kept_claimed"
         return zip_state, "zip_primary"
 
     # Trust coordinates next

--- a/tests/test_validator/test_zip_state_conflict.py
+++ b/tests/test_validator/test_zip_state_conflict.py
@@ -1,0 +1,61 @@
+"""VAL-4 regression guard: a coarse ZIP lookup must not unilaterally override
+a source-asserted state.
+
+resolve_state_conflict previously returned the ZIP-derived state ("zip_primary")
+whenever a ZIP mapped to a state, overwriting a non-empty claimed state with no
+corroboration. get_state_from_zip is a coarse 3-digit-prefix table with gaps and
+collisions, so this corrupted correct addresses. The fix keeps the claimed state
+unless coordinates or city corroborate the ZIP.
+"""
+
+from app.core.zip_state_mapping import get_state_from_zip, resolve_state_conflict
+
+
+def test_zip_does_not_override_claimed_without_corroboration():
+    zip_state = get_state_from_zip("07102")  # Newark, NJ
+    assert zip_state and zip_state != "NY"  # sanity: ZIP resolves, differs from claim
+
+    resolved, reason = resolve_state_conflict(
+        claimed_state="NY",
+        postal_code="07102",
+        city_name=None,
+        coord_state=None,
+    )
+    assert resolved == "NY"  # claimed kept — not overwritten by the coarse ZIP
+    assert reason == "zip_conflict_unverified_kept_claimed"
+
+
+def test_zip_used_when_no_claimed_state():
+    resolved, reason = resolve_state_conflict(
+        claimed_state=None,
+        postal_code="07102",
+        city_name=None,
+        coord_state=None,
+    )
+    assert resolved == get_state_from_zip("07102")
+    assert reason == "zip_primary"
+
+
+def test_coordinate_corroboration_still_corrects_claimed():
+    """When coordinates agree with the ZIP, the correction still happens."""
+    zip_state = get_state_from_zip("07102")
+    resolved, reason = resolve_state_conflict(
+        claimed_state="NY",
+        postal_code="07102",
+        city_name=None,
+        coord_state=zip_state,
+    )
+    assert resolved == zip_state
+    assert reason == "zip_coord_agreement"
+
+
+def test_matching_claimed_and_zip_unchanged():
+    zip_state = get_state_from_zip("07102")
+    resolved, reason = resolve_state_conflict(
+        claimed_state=zip_state,
+        postal_code="07102",
+        city_name=None,
+        coord_state=None,
+    )
+    assert resolved == zip_state
+    assert reason == "zip_primary"


### PR DESCRIPTION
## Audit finding VAL-4 (Tier 1)

`resolve_state_conflict` returned the ZIP-derived state (`"zip_primary"`) whenever a ZIP mapped to a state, **overwriting a non-empty claimed state with no corroboration**:

```python
if zip_state:
    return zip_state, "zip_primary"
```

`get_state_from_zip` is a coarse **3-digit-prefix** table with known gaps/collisions, so a bare ZIP-vs-claimed conflict was enough to rewrite a state the source asserted — corrupting correct addresses and mis-filing locations in state-scoped searches.

## Change

Require corroboration: when the ZIP-derived state disagrees with a non-empty claimed state and no coordinate/city agreement was reached by the earlier checks, **keep the claimed state** (new reason `zip_conflict_unverified_kept_claimed`). ZIP is still used when there's no claimed state, and corroborated corrections (zip+coord / zip+city / coord+city, handled earlier in the function) are unchanged.

This change can only *decline to override* — it never introduces a new state value, so it cannot corrupt data (safe-by-construction).

## Tests

New `tests/test_validator/test_zip_state_conflict.py`: ZIP doesn't override claimed without corroboration; ZIP used when no claim; coordinate corroboration still corrects; matching claim/ZIP unchanged. `black`/`ruff`/`mypy` clean; 256 validator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)