### PR TITLE
fix(llm): detect truncated (max_tokens) responses and retry instead of dropping locations (LLM-1)

### DIFF
--- a/app/llm/providers/bedrock.py
+++ b/app/llm/providers/bedrock.py
@@ -262,6 +262,8 @@ def parse_converse_response(
         "text": text,
         "model": model_id,
         "usage": usage,
+        "stop_reason": stop_reason or None,
+        "was_truncated": stop_reason == "max_tokens",
     }
     if parsed is not None:
         response_data["parsed"] = parsed

--- a/app/llm/providers/bedrock_batch.py
+++ b/app/llm/providers/bedrock_batch.py
@@ -161,6 +161,8 @@ def parse_messages_api_response(
         "text": text,
         "model": model_id,
         "usage": usage,
+        "stop_reason": stop_reason or None,
+        "was_truncated": stop_reason == "max_tokens",
     }
     if parsed is not None:
         response_data["parsed"] = parsed

--- a/app/llm/providers/openai.py
+++ b/app/llm/providers/openai.py
@@ -477,10 +477,19 @@ class OpenAIProvider(BaseLLMProvider[AsyncOpenAI, OpenAIConfig]):
         base_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         usage = _validate_usage(result.usage) if result.usage else base_usage
 
+        # finish_reason="length" means the model hit max_tokens and the JSON is
+        # truncated — parseable but may silently drop locations. Flag it so the
+        # worker retries rather than accepting partial output. Coerce to
+        # str-or-None: the SDK may return None, and stop_reason is typed str|None.
+        raw_finish = getattr(result.choices[0], "finish_reason", None)
+        finish_reason = raw_finish if isinstance(raw_finish, str) else None
+
         response_data: dict[str, Any] = {
             "text": processed_content,
             "model": self.config.model_name,
             "usage": usage,
+            "stop_reason": finish_reason,
+            "was_truncated": finish_reason == "length",
         }
         if parsed is not None:
             response_data["parsed"] = parsed

--- a/app/llm/providers/types.py
+++ b/app/llm/providers/types.py
@@ -97,6 +97,19 @@ class LLMResponse(BaseModel):
     validation_details: ValidationDetails | None = Field(
         default=None, description="Validation details if validation was performed"
     )
+    stop_reason: str | None = Field(
+        default=None,
+        description="Provider finish/stop reason (e.g. end_turn, max_tokens, length)",
+    )
+    was_truncated: bool = Field(
+        default=False,
+        description=(
+            "True when the model stopped because it hit the token limit "
+            "(stop_reason max_tokens / finish_reason length). A truncated "
+            "response is parseable but may silently omit locations, so the "
+            "worker retries it rather than accepting partial data."
+        ),
+    )
 
     @field_validator("text")
     @classmethod

--- a/app/llm/queue/processor.py
+++ b/app/llm/queue/processor.py
@@ -180,12 +180,19 @@ def process_llm_job(job: LLMJob, provider: BaseLLMProvider[Any, Any]) -> LLMResp
                     gen = cast(AsyncGenerator[LLMResponse, None], result)
                     llm_result = loop.run_until_complete(anext(gen))
 
-                # Validate the response — retry only on truly empty responses
-                if not llm_result.text or llm_result.text.strip() == "":
+                # Validate the response — retry on truly empty responses AND on
+                # truncated output (finish_reason "length" / stopReason
+                # "max_tokens"). A truncated response is parseable but silently
+                # omits locations, so accepting it drops pantries; retry, then
+                # fail rather than persist partial data.
+                is_empty = not llm_result.text or llm_result.text.strip() == ""
+                is_truncated = getattr(llm_result, "was_truncated", False)
+                if is_empty or is_truncated:
                     retry_count += 1
-                    last_error = "Received empty response from LLM"
+                    reason = "empty" if is_empty else "truncated (hit token limit)"
+                    last_error = f"Received {reason} response from LLM"
                     logger.warning(
-                        f"LLM returned empty response for job {job.id}, "
+                        f"LLM returned {reason} response for job {job.id}, "
                         f"retry {retry_count}/{max_retries}"
                     )
                     if retry_count < max_retries:
@@ -197,7 +204,8 @@ def process_llm_job(job: LLMJob, provider: BaseLLMProvider[Any, Any]) -> LLMResp
                     else:
                         # Max retries reached, fail the job
                         raise ValueError(
-                            f"LLM consistently returned empty response after {max_retries} attempts"
+                            f"LLM consistently returned {reason} response "
+                            f"after {max_retries} attempts"
                         )
 
                 # Response is valid, break out of retry loop

--- a/tests/test_llm/test_bedrock.py
+++ b/tests/test_llm/test_bedrock.py
@@ -409,6 +409,24 @@ class TestParseConverseResponse:
         assert result.usage["prompt_tokens"] == 10
         assert result.usage["completion_tokens"] == 5
         assert result.usage["total_tokens"] == 15
+        # Normal completion is not truncated.
+        assert result.was_truncated is False
+        assert result.stop_reason == "end_turn"
+
+    def test_parse_converse_response_truncated_flags_max_tokens(self):
+        """LLM-1: stopReason 'max_tokens' marks the response truncated so the
+        worker retries instead of accepting a partial (location-dropping) JSON."""
+        response = {
+            "output": {"message": {"content": [{"text": '{"organization": [{"na'}]}},
+            "stopReason": "max_tokens",
+            "usage": {"inputTokens": 10, "outputTokens": 4096},
+        }
+        result = parse_converse_response(
+            response=response,
+            model_id="anthropic.claude-haiku-4-5-20251001-v1:0",
+        )
+        assert result.was_truncated is True
+        assert result.stop_reason == "max_tokens"
 
     def test_parse_converse_response_tool_use(self):
         """Structured output from tool_use blocks is parsed correctly."""

--- a/tests/test_llm/test_openai.py
+++ b/tests/test_llm/test_openai.py
@@ -135,6 +135,36 @@ async def test_openai_generate_raises_on_api_error(
             await openai_provider.generate("Say hello.")
 
 
+def test_process_api_response_flags_truncation(openai_provider: OpenAIProvider) -> None:
+    """LLM-1: finish_reason='length' marks the response truncated so the worker
+    retries instead of accepting partial (location-dropping) output."""
+    result = MagicMock()
+    result.error = None
+    result.choices = [MagicMock(message=MagicMock(content='{"organization": [{"na'))]
+    result.choices[0].finish_reason = "length"
+    result.usage = MagicMock(
+        prompt_tokens=10, completion_tokens=4096, total_tokens=4106
+    )
+
+    resp = openai_provider._process_api_response(result, None)
+    assert resp.was_truncated is True
+    assert resp.stop_reason == "length"
+
+
+def test_process_api_response_not_truncated_on_stop(
+    openai_provider: OpenAIProvider,
+) -> None:
+    result = MagicMock()
+    result.error = None
+    result.choices = [MagicMock(message=MagicMock(content="done"))]
+    result.choices[0].finish_reason = "stop"
+    result.usage = MagicMock(prompt_tokens=5, completion_tokens=2, total_tokens=7)
+
+    resp = openai_provider._process_api_response(result, None)
+    assert resp.was_truncated is False
+    assert resp.stop_reason == "stop"
+
+
 @pytest.mark.asyncio
 async def test_openai_generate_structured(
     openai_provider: OpenAIProvider, mock_openai_client


### PR DESCRIPTION
## Audit finding LLM-1 (Tier 1)

A long location list that hit the model's token limit produced **parseable-but-partial** JSON with fewer locations than the page actually had. No code inspected the model's finish reason, so the worker accepted it as a successful job and **silently dropped pantries** (a Principle XI data-loss path) — no error, no retry.

## Change

- `LLMResponse` gains `stop_reason` + `was_truncated` (`providers/types.py`).
- Parse layers populate them: Bedrock Converse / Messages `stopReason == 'max_tokens'` (`bedrock.py`, `bedrock_batch.py`) and OpenAI `finish_reason == 'length'` (`openai.py`, coerced to str-or-None since the SDK can return `None`).
- `processor.process_llm_job` treats `was_truncated` like an empty response: **retry with backoff, then fail the job** rather than persist partial data.

## Tests

Bedrock + OpenAI parse layers flag `max_tokens`/`length` as truncated and leave normal completions untruncated. Full `tests/test_llm` suite green **except one pre-existing, unrelated failure** (`test_process_llm_job_no_print_calls` — fails on `main`). `black`/`ruff`/`mypy` clean.

Note: the Claude-CLI provider exposes no stop-reason signal, but that path is being deprecated; AWS uses Bedrock (covered here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)