### PR TITLE
fix(llm): reconcile missing Bedrock batch records on Completed, not just PartiallyCompleted (LLM-3)

### DIFF
--- a/app/llm/queue/batch_result_processor.py
+++ b/app/llm/queue/batch_result_processor.py
@@ -478,9 +478,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 failed_requeue_count=failed_requeue_count,
             )
 
-        # For PartiallyCompleted, re-enqueue missing jobs
+        # Re-enqueue any input record that produced no usable output line, for
+        # EVERY terminal status that produced output (Completed AND
+        # PartiallyCompleted). Previously this ran only for PartiallyCompleted,
+        # so on a "Completed" batch any record whose output line was missing or
+        # unparseable (it never made it into output_record_ids) was silently
+        # dropped. The set difference catches all such records regardless of why
+        # they're missing — no need to parse recordIds out of malformed lines.
+        # (Failed batches are fully requeued earlier and return before here.)
         requeued = 0
-        if status == "PartiallyCompleted":
+        if status in ("PartiallyCompleted", "Completed"):
             missing_ids = original_jobs_keys_set - output_record_ids
             partial_failed_requeue_count = 0
             for missing_id in missing_ids:
@@ -506,8 +513,9 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 )
             if missing_ids:
                 logger.warning(
-                    "batch_partially_completed_requeued_missing",
+                    "batch_requeued_missing_records",
                     batch_job_arn=job_arn,
+                    batch_status=status,
                     missing_count=len(missing_ids),
                     missing_record_ids=sorted(missing_ids),
                 )

--- a/tests/test_llm/test_batch_result_processor.py
+++ b/tests/test_llm/test_batch_result_processor.py
@@ -506,6 +506,60 @@ class TestFailureHandling:
         ]
         assert len(llm_calls) == 1
 
+    @patch("app.llm.queue.batch_result_processor._get_clients")
+    @patch("app.llm.queue.batch_result_processor.send_to_sqs")
+    @patch("app.llm.queue.batch_result_processor.settings")
+    def test_completed_requeues_record_missing_from_output(
+        self, mock_settings, mock_send, mock_get_clients
+    ):
+        """LLM-3: a 'Completed' batch missing an output line for an input record
+        must requeue that record. Previously reconciliation ran only for
+        PartiallyCompleted, so on Completed the dropped record was lost."""
+        mock_settings.VALIDATOR_ENABLED = True
+        mock_s3 = MagicMock()
+        mock_dynamodb = MagicMock()
+        mock_get_clients.return_value = (mock_s3, mock_dynamodb)
+        mock_send.return_value = "msg-id"
+
+        original_jobs = {
+            "job-1": _make_original_job("job-1"),
+            "job-2": _make_original_job("job-2"),  # no output line below
+        }
+        mock_dynamodb.get_item.return_value = {
+            "Item": {
+                "output_key_prefix": {"S": "output/exec-123/"},
+                "original_jobs_key": {"S": "input/exec-123/original_jobs.jsonl"},
+            }
+        }
+        # Output contains ONLY job-1; job-2's output line is missing.
+        _mock_s3_for_streaming(
+            mock_s3,
+            original_jobs,
+            [_make_batch_output_record("job-1", success=True)],
+        )
+
+        event = _make_event("Completed")
+        with patch.dict(
+            "os.environ",
+            {
+                "VALIDATOR_QUEUE_URL": "https://sqs/validator.fifo",
+                "RECONCILER_QUEUE_URL": "https://sqs/reconciler.fifo",
+                "RECORDER_QUEUE_URL": "https://sqs/recorder.fifo",
+                "LLM_QUEUE_URL": "https://sqs/llm.fifo",
+                "BATCH_BUCKET": "batch-bucket",
+                "SQS_JOBS_TABLE": "jobs-table",
+            },
+        ):
+            result = handler(event, None)
+
+        assert result["requeued"] == 1
+        llm_calls = [
+            c
+            for c in mock_send.call_args_list
+            if c[1].get("queue_url") == "https://sqs/llm.fifo"
+        ]
+        assert len(llm_calls) == 1
+
 
 class TestMissingOriginalJob:
     """Tests for records with missing original jobs."""


### PR DESCRIPTION
## Audit finding LLM-3 (Tier 1)

`batch_result_processor` requeued input records that produced no usable output line (`missing_ids = original_jobs_keys_set − output_record_ids`) **only when status == `PartiallyCompleted`**. On a `Completed` batch, any record whose output line was missing or unparseable never entered `output_record_ids` and was **silently dropped** — the pantry never reached validator/reconciler and was never retried (Principle XI data loss).

## Change

Run the same set-difference reconciliation for **every terminal status that produced output** (`Completed` *and* `PartiallyCompleted`). `Failed` batches are fully requeued earlier and return before this block. No fragile recordId-extraction-from-malformed-JSON is needed — the set difference catches a record regardless of *why* its output is missing. Requeue already uses a UUID-suffixed dedup id (idempotent, so requeueing is safe).

## Tests

New test: a `Completed` batch whose output omits one of two input records requeues **exactly that record** to the LLM queue (`requeued == 1`). `black`/`ruff`/`mypy` clean; batch-processor suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)