### PR TITLE
fix(content-store): recover SQS-mode jobs that failed before writing a result (content-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ DATA_REPO_TOKEN=github_pat_xxx  # GitHub PAT with repo access
 # Content Store
 CONTENT_STORE_PATH=/path/to/content-store
 CONTENT_STORE_BACKEND=file  # Backend type: "file" (default) or "s3" (AWS deployment)
+CONTENT_STORE_STALE_JOB_THRESHOLD_HOURS=72  # SQS-mode: age after which a result-less job link is re-enqueued (default 72)
 
 # Submarine Enrichment
 SUBMARINE_ENABLED=false  # Enable/disable submarine enrichment (default: false)
@@ -771,6 +772,7 @@ routing is entirely infrastructure (CDK env var override for `SQS_QUEUE_URL`).
   - **Sample Scraper**: Example implementation available for all contributors
 - **Content Store**: SHA-256 deduplication preventing duplicate processing
   - **Backend Abstraction**: Pluggable `ContentStoreBackend` protocol supports local filesystem (`file`) or AWS S3+DynamoDB (`s3`)
+  - **Stale job-link recovery (SQS mode)**: `index_set_job_id` stamps a `job_linked_at` timestamp (SQLite column / DynamoDB attribute). In SQS mode (no Redis to probe RQ liveness) `store_content` clears a result-less `job_id` once it is older than `CONTENT_STORE_STALE_JOB_THRESHOLD_HOURS` (default 72) so a terminally-failed record re-enqueues instead of dedup-skipping forever. Recent (in-flight) links and legacy links with no timestamp are left alone, avoiding the historic 124k re-enqueue storm. Grep CloudWatch for `content_store_stale_job_link_cleared`.
 - **LLM Workers**: HSDS schema alignment with OpenAI/Claude/Bedrock providers
 - **Validator Service**: Confidence scoring, data enrichment, and quality control
 - **Reconciler**: Creates canonical records with version tracking

--- a/app/content_store/backend.py
+++ b/app/content_store/backend.py
@@ -7,7 +7,7 @@ to be plugged in without changing the ContentStore logic.
 
 import json
 import sqlite3
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional, Protocol, TypedDict, runtime_checkable
 
@@ -183,6 +183,22 @@ class ContentStoreBackend(Protocol):
         """
         ...
 
+    def index_get_job_linked_at(self, content_hash: str) -> Optional[datetime]:
+        """Get the timestamp a job was last linked to this content.
+
+        Used by SQS-mode stale-link recovery: a job linked longer ago than the
+        safe processing threshold without a result is treated as terminally
+        failed and re-enqueued.
+
+        Args:
+            content_hash: SHA-256 hash
+
+        Returns:
+            Link timestamp, or None if no job is linked / the link predates
+            timestamp tracking (legacy rows).
+        """
+        ...
+
     def index_get_statistics(self) -> ContentStoreStatistics:
         """Get index statistics.
 
@@ -254,10 +270,19 @@ class FileContentStoreBackend:
                     result_path TEXT,
                     job_id TEXT,
                     created_at TIMESTAMP NOT NULL,
-                    processed_at TIMESTAMP
+                    processed_at TIMESTAMP,
+                    job_linked_at TIMESTAMP
                 )
             """
             )
+            # Migrate pre-existing indexes that lack the job_linked_at column
+            # (content-1 stale-link recovery). Idempotent: ignore if present.
+            try:
+                conn.execute(
+                    "ALTER TABLE content_index ADD COLUMN job_linked_at TIMESTAMP"
+                )
+            except sqlite3.OperationalError:
+                pass  # column already exists
             conn.commit()
 
     def _get_content_path(self, content_hash: str) -> Path:
@@ -389,15 +414,38 @@ class FileContentStoreBackend:
 
     @with_connection_retry
     def index_set_job_id(self, content_hash: str, job_id: str) -> None:
-        """Set job ID for content in index."""
+        """Set job ID for content in index, stamping the link time."""
         db_path = self._content_store_path / "index.db"
+        linked_at = datetime.now(UTC).isoformat()
 
         with sqlite3.connect(db_path) as conn:
             conn.execute(
-                "UPDATE content_index SET job_id = ? WHERE hash = ?",
-                (job_id, content_hash),
+                "UPDATE content_index SET job_id = ?, job_linked_at = ? "
+                "WHERE hash = ?",
+                (job_id, linked_at, content_hash),
             )
             conn.commit()
+
+    def index_get_job_linked_at(self, content_hash: str) -> Optional[datetime]:
+        """Get the timestamp a job was last linked to this content."""
+        db_path = self._content_store_path / "index.db"
+
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.execute(
+                "SELECT job_linked_at FROM content_index WHERE hash = ?",
+                (content_hash,),
+            )
+            row = cursor.fetchone()
+
+        if not row or not row[0]:
+            return None
+        value = row[0]
+        if isinstance(value, datetime):
+            return value
+        try:
+            return datetime.fromisoformat(str(value))
+        except ValueError:
+            return None
 
     @with_connection_retry
     def index_clear_job_id(self, content_hash: str) -> None:

--- a/app/content_store/backend_s3.py
+++ b/app/content_store/backend_s3.py
@@ -4,7 +4,7 @@ This module provides an S3-based storage backend with DynamoDB for indexing,
 enabling cloud-native deployment of the content store.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Optional
 
 import structlog
@@ -398,9 +398,32 @@ class S3ContentStoreBackend:
         dynamodb.update_item(
             TableName=self.dynamodb_table,
             Key={"content_hash": {"S": content_hash}},
-            UpdateExpression="SET job_id = :jid",
-            ExpressionAttributeValues={":jid": {"S": job_id}},
+            UpdateExpression="SET job_id = :jid, job_linked_at = :linked",
+            ExpressionAttributeValues={
+                ":jid": {"S": job_id},
+                ":linked": {"S": datetime.now(UTC).isoformat()},
+            },
         )
+
+    @with_aws_retry
+    def index_get_job_linked_at(self, content_hash: str) -> Optional[datetime]:
+        """Get the timestamp a job was last linked to this content."""
+        self._ensure_initialized()
+        dynamodb = self._get_dynamodb_client()
+
+        response = dynamodb.get_item(
+            TableName=self.dynamodb_table,
+            Key={"content_hash": {"S": content_hash}},
+            ProjectionExpression="job_linked_at",
+        )
+
+        item = response.get("Item")
+        if item and "job_linked_at" in item:
+            try:
+                return datetime.fromisoformat(item["job_linked_at"]["S"])
+            except ValueError:
+                return None
+        return None
 
     @with_aws_retry
     def index_delete_entry(self, content_hash: str) -> None:

--- a/app/content_store/store.py
+++ b/app/content_store/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -30,11 +31,19 @@ class ContentStore:
     # SHA-256 produces 64 hex characters
     _HASH_PATTERN = re.compile(r"^[a-f0-9]{64}$")
 
+    # Default age (hours) after which a result-less SQS job link is treated as
+    # a terminal failure and cleared. Must comfortably exceed the longest
+    # realistic end-to-end processing time (incl. Bedrock batch inference, which
+    # can run for hours) yet stay under the weekly scrape cadence so genuinely
+    # failed records recover on the next run.
+    _DEFAULT_STALE_JOB_THRESHOLD_HOURS = 72.0
+
     def __init__(
         self,
         store_path: Optional[Path] = None,
         redis_url: Optional[str] = "redis://cache:6379",
         backend: Optional[ContentStoreBackend] = None,
+        stale_job_threshold_hours: Optional[float] = None,
     ):
         """Initialize content store.
 
@@ -42,6 +51,9 @@ class ContentStore:
             store_path: Base path for content store (backward compat, creates FileBackend)
             redis_url: Redis connection URL for checking job status (None to skip Redis)
             backend: Storage backend (if None, FileContentStoreBackend is created from store_path)
+            stale_job_threshold_hours: SQS-mode age threshold for clearing a
+                result-less job link (defaults to the
+                CONTENT_STORE_STALE_JOB_THRESHOLD_HOURS env var or 72h).
 
         Raises:
             ValueError: If neither store_path nor backend is provided
@@ -53,6 +65,15 @@ class ContentStore:
             self._backend.initialize()
         else:
             raise ValueError("Either store_path or backend must be provided")
+
+        if stale_job_threshold_hours is None:
+            stale_job_threshold_hours = float(
+                os.getenv(
+                    "CONTENT_STORE_STALE_JOB_THRESHOLD_HOURS",
+                    str(self._DEFAULT_STALE_JOB_THRESHOLD_HOURS),
+                )
+            )
+        self._stale_job_threshold_hours = stale_job_threshold_hours
 
         self.redis_conn: Optional[redis.Redis[bytes]] = None
         if redis_url:
@@ -146,6 +167,24 @@ class ContentStore:
             )
             raise
 
+    def _is_job_link_stale(self, content_hash: str) -> bool:
+        """Whether a result-less SQS job link has outlived the safe threshold.
+
+        Used only in SQS mode, where we cannot probe RQ for liveness. A link
+        older than ``stale_job_threshold_hours`` is treated as a terminal
+        failure (the caller has already returned for content with a result).
+        Links with no recorded timestamp (legacy rows, pre-timestamp tracking)
+        are treated as NOT stale, so we never re-enqueue the entire historical
+        backlog at once (the 124k storm).
+        """
+        linked_at = self._backend.index_get_job_linked_at(content_hash)
+        if linked_at is None:
+            return False
+        if linked_at.tzinfo is None:
+            linked_at = linked_at.replace(tzinfo=UTC)
+        age_seconds = (datetime.now(UTC) - linked_at).total_seconds()
+        return age_seconds > self._stale_job_threshold_hours * 3600
+
     def has_content(self, content_hash: str) -> bool:
         """Check if content exists in store.
 
@@ -207,13 +246,26 @@ class ContentStore:
 
         # Read the persisted job_id (if any). In Redis mode we additionally
         # probe RQ to see if the job is still alive, and clear stale ids so
-        # dead jobs don't dedup-skip forever. In SQS mode we cannot query
-        # job status, so a previously-enqueued job_id stays — accept that
-        # silently-failed records may need operator recovery rather than
-        # re-enqueueing them on every scraper run.
+        # dead jobs don't dedup-skip forever. In SQS mode we cannot query job
+        # status, so we fall back to an age-based heuristic: a job linked
+        # longer ago than the safe processing threshold without producing a
+        # result (we returned above if a result existed) is a terminal failure
+        # — clear it so the content re-enqueues. Recent (in-flight) links and
+        # legacy links without a timestamp are left alone, so this never
+        # reproduces the historic 124k re-enqueue storm.
         existing_job_id = self.get_job_id(content_hash)
         if existing_job_id and not self._is_sqs_mode():
             if not self._is_job_active(existing_job_id):
+                self.clear_job_id(content_hash)
+                existing_job_id = None
+        elif existing_job_id and self._is_sqs_mode():
+            if self._is_job_link_stale(content_hash):
+                logger.info(
+                    "content_store_stale_job_link_cleared",
+                    content_hash=content_hash,
+                    job_id=existing_job_id,
+                    threshold_hours=self._stale_job_threshold_hours,
+                )
                 self.clear_job_id(content_hash)
                 existing_job_id = None
 

--- a/tests/test_content_store/test_backend_file.py
+++ b/tests/test_content_store/test_backend_file.py
@@ -246,6 +246,31 @@ class TestFileContentStoreBackend:
 
         assert backend.index_get_job_id(valid_hash) is None
 
+    def test_index_get_job_linked_at_none_before_set(self, backend, valid_hash: str):
+        """content-1: linked-at is None for content with no linked job."""
+        backend.index_insert_content(
+            valid_hash, "/path/content.json", datetime.utcnow()
+        )
+
+        assert backend.index_get_job_linked_at(valid_hash) is None
+
+    def test_index_set_job_id_records_linked_at(self, backend, valid_hash: str):
+        """content-1: index_set_job_id stamps a recent job_linked_at timestamp."""
+        from datetime import UTC, datetime
+
+        backend.index_insert_content(
+            valid_hash, "/path/content.json", datetime.utcnow()
+        )
+
+        backend.index_set_job_id(valid_hash, "job-new-123")
+
+        linked_at = backend.index_get_job_linked_at(valid_hash)
+        assert linked_at is not None
+        if linked_at.tzinfo is None:
+            linked_at = linked_at.replace(tzinfo=UTC)
+        age = (datetime.now(UTC) - linked_at).total_seconds()
+        assert 0 <= age < 60
+
     # --- Statistics Tests ---
 
     def test_index_get_statistics_empty_store(self, backend):

--- a/tests/test_content_store/test_s3_backend_index.py
+++ b/tests/test_content_store/test_s3_backend_index.py
@@ -115,6 +115,50 @@ class TestS3ContentStoreBackendIndexOperations:
 
         mock_dynamodb.update_item.assert_called_once()
 
+    def test_index_set_job_id_records_linked_at(self, backend):
+        """content-1: index_set_job_id should also persist a job_linked_at stamp."""
+        from datetime import datetime
+
+        mock_dynamodb = MagicMock()
+        content_hash = "abc123" + "0" * 58
+
+        with patch.object(backend, "_get_dynamodb_client", return_value=mock_dynamodb):
+            backend.index_set_job_id(content_hash, "job-123")
+
+        kwargs = mock_dynamodb.update_item.call_args.kwargs
+        values = kwargs["ExpressionAttributeValues"]
+        assert ":linked" in values
+        # Must be a parseable ISO-8601 timestamp.
+        datetime.fromisoformat(values[":linked"]["S"])
+        assert "job_linked_at" in kwargs["UpdateExpression"]
+
+    def test_index_get_job_linked_at_returns_datetime(self, backend):
+        """content-1: index_get_job_linked_at parses the stored ISO timestamp."""
+        from datetime import datetime, timezone
+
+        stamp = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        mock_dynamodb = MagicMock()
+        content_hash = "abc123" + "0" * 58
+        mock_dynamodb.get_item.return_value = {
+            "Item": {"job_linked_at": {"S": stamp.isoformat()}}
+        }
+
+        with patch.object(backend, "_get_dynamodb_client", return_value=mock_dynamodb):
+            result = backend.index_get_job_linked_at(content_hash)
+
+        assert result == stamp
+
+    def test_index_get_job_linked_at_none_when_absent(self, backend):
+        """content-1: missing job_linked_at attribute → None (legacy rows)."""
+        mock_dynamodb = MagicMock()
+        content_hash = "abc123" + "0" * 58
+        mock_dynamodb.get_item.return_value = {"Item": {"job_id": {"S": "j"}}}
+
+        with patch.object(backend, "_get_dynamodb_client", return_value=mock_dynamodb):
+            result = backend.index_get_job_linked_at(content_hash)
+
+        assert result is None
+
     def test_index_clear_job_id_removes_job_id(self, backend):
         """index_clear_job_id() should remove job_id from item."""
         mock_dynamodb = MagicMock()

--- a/tests/test_content_store/test_s3_backend_index.py
+++ b/tests/test_content_store/test_s3_backend_index.py
@@ -4,7 +4,7 @@ Tests for DynamoDB index operations: index_has_content, index_insert_content,
 index_update_result, index_get_job_id, index_set_job_id, index_clear_job_id.
 """
 
-from datetime import datetime
+from datetime import datetime, UTC
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -136,7 +136,7 @@ class TestS3ContentStoreBackendIndexOperations:
         """content-1: index_get_job_linked_at parses the stored ISO timestamp."""
         from datetime import datetime, timezone
 
-        stamp = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+        stamp = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
         mock_dynamodb = MagicMock()
         content_hash = "abc123" + "0" * 58
         mock_dynamodb.get_item.return_value = {

--- a/tests/test_content_store/test_store.py
+++ b/tests/test_content_store/test_store.py
@@ -249,6 +249,57 @@ class TestContentStore:
         assert entry2.status == "pending"
         assert entry2.job_id == "sqs-job-456"
 
+    def test_sqs_link_records_timestamp(self, temp_store_path):
+        """content-1: link_job stamps a job_linked_at timestamp (round-trip)."""
+        from datetime import UTC, datetime
+
+        store = ContentStore(store_path=temp_store_path, redis_url=None)
+        content = '{"name": "Timestamped Pantry"}'
+        entry = store.store_content(content, {"scraper_id": "test_scraper"})
+
+        assert store.backend.index_get_job_linked_at(entry.hash) is None
+        store.link_job(entry.hash, "sqs-job-789")
+
+        linked_at = store.backend.index_get_job_linked_at(entry.hash)
+        assert linked_at is not None
+        if linked_at.tzinfo is None:
+            linked_at = linked_at.replace(tzinfo=UTC)
+        age = (datetime.now(UTC) - linked_at).total_seconds()
+        assert 0 <= age < 60
+
+    def test_stale_sqs_job_link_is_cleared_end_to_end(self, temp_store_path):
+        """content-1: a job linked past the threshold with no result re-enqueues."""
+        # Zero-hour threshold → the link (stamped a moment earlier) is stale.
+        store = ContentStore(
+            store_path=temp_store_path,
+            redis_url=None,
+            stale_job_threshold_hours=0,
+        )
+        content = '{"name": "Stale Job Pantry"}'
+        metadata = {"scraper_id": "test_scraper"}
+
+        entry1 = store.store_content(content, metadata)
+        store.link_job(entry1.hash, "stale-job-456")
+        assert store.get_job_id(entry1.hash) == "stale-job-456"
+
+        entry2 = store.store_content(content, metadata)
+        assert entry2.hash == entry1.hash
+        assert entry2.status == "pending"
+        assert entry2.job_id is None  # cleared → scraper will re-enqueue
+        assert store.get_job_id(entry1.hash) is None
+
+    def test_recent_sqs_job_link_survives_default_threshold(self, temp_store_path):
+        """content-1: a fresh link is preserved under the default threshold."""
+        store = ContentStore(store_path=temp_store_path, redis_url=None)
+        content = '{"name": "Fresh Job Pantry"}'
+        metadata = {"scraper_id": "test_scraper"}
+
+        entry1 = store.store_content(content, metadata)
+        store.link_job(entry1.hash, "fresh-job-456")
+
+        entry2 = store.store_content(content, metadata)
+        assert entry2.job_id == "fresh-job-456"  # in-flight → still skipped
+
     def test_should_cleanup_failed_job_and_allow_reprocessing(self, content_store):
         """Should clear failed job IDs and allow reprocessing."""
         content = '{"name": "Failed Job Pantry"}'

--- a/tests/test_content_store_audit_fixes.py
+++ b/tests/test_content_store_audit_fixes.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.content_store.store import ContentStore
+from datetime import UTC
 
 
 class TestH2SqsModeDedup:
@@ -127,7 +128,7 @@ class TestContent1StaleJobLink:
         """A job linked longer ago than the threshold is cleared → re-enqueue."""
         from datetime import datetime, timedelta, timezone
 
-        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        old = datetime.now(UTC) - timedelta(hours=200)
         mock_backend = self._pending_backend(old)
         store = self._make_store(redis_url=None, backend=mock_backend)  # 72h default
 
@@ -141,7 +142,7 @@ class TestContent1StaleJobLink:
         """A recently-linked (in-flight) job is preserved → still dedup-skipped."""
         from datetime import datetime, timedelta, timezone
 
-        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        recent = datetime.now(UTC) - timedelta(hours=1)
         mock_backend = self._pending_backend(recent)
         store = self._make_store(redis_url=None, backend=mock_backend)  # 72h default
 
@@ -164,7 +165,7 @@ class TestContent1StaleJobLink:
         """An explicit threshold overrides the default."""
         from datetime import datetime, timedelta, timezone
 
-        linked = datetime.now(timezone.utc) - timedelta(hours=10)
+        linked = datetime.now(UTC) - timedelta(hours=10)
         mock_backend = self._pending_backend(linked)
         # 5h threshold → a 10h-old link is stale.
         store = self._make_store(
@@ -181,7 +182,7 @@ class TestContent1StaleJobLink:
         import json
         from datetime import datetime, timedelta, timezone
 
-        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        old = datetime.now(UTC) - timedelta(hours=200)
         mock_backend = self._pending_backend(old)
         mock_backend.read_result.return_value = json.dumps(
             {"result": "processed data", "job_id": "old-job-123"}
@@ -198,7 +199,7 @@ class TestContent1StaleJobLink:
         """In Redis mode staleness is decided by RQ liveness, not link age."""
         from datetime import datetime, timedelta, timezone
 
-        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        old = datetime.now(UTC) - timedelta(hours=200)
         mock_backend = self._pending_backend(old)
         store = self._make_store(redis_url=None, backend=mock_backend)
         store.redis_conn = MagicMock()  # simulate Redis present

--- a/tests/test_content_store_audit_fixes.py
+++ b/tests/test_content_store_audit_fixes.py
@@ -29,6 +29,8 @@ class TestH2SqsModeDedup:
         mock_backend.content_store_path = "/tmp/test/content_store"  # noqa: S108
         mock_backend.read_result.return_value = None
         mock_backend.index_get_job_id.return_value = "old-job-123"
+        # Legacy link (no timestamp) → not stale → never cleared in SQS mode.
+        mock_backend.index_get_job_linked_at.return_value = None
         mock_backend.content_exists.return_value = False
         mock_backend.write_content.return_value = (
             "/tmp/test/content/ab/abc.json"  # noqa: S108
@@ -91,3 +93,120 @@ class TestH2SqsModeDedup:
 
         assert result.status == "completed"
         assert result.result == "processed data"
+
+
+class TestContent1StaleJobLink:
+    """content-1: SQS-mode stale job-link clearing.
+
+    In SQS mode we can't probe RQ for job liveness, so a job that failed
+    before writing a result used to dedup-skip its content forever. The fix
+    clears a job_id once it has outlived a safe processing threshold without a
+    result (age-based), while leaving recent (in-flight) links alone so the
+    124k re-enqueue storm is never reproduced.
+    """
+
+    def _make_store(self, *, redis_url=None, backend=None, **kwargs):
+        mock_backend = backend or MagicMock()
+        mock_backend.store_path = "/tmp/test"  # noqa: S108
+        mock_backend.content_store_path = "/tmp/test/content_store"  # noqa: S108
+        return ContentStore(backend=mock_backend, redis_url=redis_url, **kwargs)
+
+    @staticmethod
+    def _pending_backend(linked_at):
+        """A mock backend with a pending (no-result) job linked at `linked_at`."""
+        mock_backend = MagicMock()
+        mock_backend.store_path = "/tmp/test"  # noqa: S108
+        mock_backend.content_store_path = "/tmp/test/content_store"  # noqa: S108
+        mock_backend.read_result.return_value = None
+        mock_backend.index_get_job_id.return_value = "old-job-123"
+        mock_backend.index_get_job_linked_at.return_value = linked_at
+        mock_backend.content_exists.return_value = True
+        return mock_backend
+
+    def test_stale_sqs_link_with_no_result_is_cleared(self):
+        """A job linked longer ago than the threshold is cleared → re-enqueue."""
+        from datetime import datetime, timedelta, timezone
+
+        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        mock_backend = self._pending_backend(old)
+        store = self._make_store(redis_url=None, backend=mock_backend)  # 72h default
+
+        result = store.store_content("test content", {"scraper_id": "test"})
+
+        mock_backend.index_clear_job_id.assert_called_once()
+        assert result.job_id is None
+        assert result.status == "pending"
+
+    def test_recent_sqs_link_is_not_cleared(self):
+        """A recently-linked (in-flight) job is preserved → still dedup-skipped."""
+        from datetime import datetime, timedelta, timezone
+
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        mock_backend = self._pending_backend(recent)
+        store = self._make_store(redis_url=None, backend=mock_backend)  # 72h default
+
+        result = store.store_content("test content", {"scraper_id": "test"})
+
+        mock_backend.index_clear_job_id.assert_not_called()
+        assert result.job_id == "old-job-123"
+
+    def test_missing_linked_at_is_not_cleared(self):
+        """Legacy links with no timestamp are NOT cleared (storm-safe)."""
+        mock_backend = self._pending_backend(None)
+        store = self._make_store(redis_url=None, backend=mock_backend)
+
+        result = store.store_content("test content", {"scraper_id": "test"})
+
+        mock_backend.index_clear_job_id.assert_not_called()
+        assert result.job_id == "old-job-123"
+
+    def test_configurable_threshold(self):
+        """An explicit threshold overrides the default."""
+        from datetime import datetime, timedelta, timezone
+
+        linked = datetime.now(timezone.utc) - timedelta(hours=10)
+        mock_backend = self._pending_backend(linked)
+        # 5h threshold → a 10h-old link is stale.
+        store = self._make_store(
+            redis_url=None, backend=mock_backend, stale_job_threshold_hours=5
+        )
+
+        result = store.store_content("test content", {"scraper_id": "test"})
+
+        mock_backend.index_clear_job_id.assert_called_once()
+        assert result.job_id is None
+
+    def test_stale_link_with_result_returns_completed(self):
+        """A result short-circuits before any staleness check."""
+        import json
+        from datetime import datetime, timedelta, timezone
+
+        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        mock_backend = self._pending_backend(old)
+        mock_backend.read_result.return_value = json.dumps(
+            {"result": "processed data", "job_id": "old-job-123"}
+        )
+        store = self._make_store(redis_url=None, backend=mock_backend)
+
+        result = store.store_content("test content", {"scraper_id": "test"})
+
+        assert result.status == "completed"
+        mock_backend.index_clear_job_id.assert_not_called()
+        mock_backend.index_get_job_linked_at.assert_not_called()
+
+    def test_redis_mode_ignores_link_age(self):
+        """In Redis mode staleness is decided by RQ liveness, not link age."""
+        from datetime import datetime, timedelta, timezone
+
+        old = datetime.now(timezone.utc) - timedelta(hours=200)
+        mock_backend = self._pending_backend(old)
+        store = self._make_store(redis_url=None, backend=mock_backend)
+        store.redis_conn = MagicMock()  # simulate Redis present
+
+        with patch.object(store, "_is_job_active", return_value=True):
+            result = store.store_content("test content", {"scraper_id": "test"})
+
+        # Live RQ job → not cleared; link-age path must not be consulted.
+        mock_backend.index_clear_job_id.assert_not_called()
+        mock_backend.index_get_job_linked_at.assert_not_called()
+        assert result.job_id == "old-job-123"


### PR DESCRIPTION
## Finding (content-1, Tier 1)

In SQS mode there is no Redis/RQ to probe for job liveness, so a job that **failed before writing a result** left a permanent `job_id` linkage in the content store. The scraper-side dedup (`app/scraper/utils.py:226` — `if content_entry.job_id and not force_reextract: skip`) then dropped that pantry on **every future scrape** — silent data loss (Constitution **Principle XI**: "Data loss during processing is unacceptable because re-scraping may not yield the same content").

The naive fix (gate dedup on result-presence) would re-enqueue **in-flight** jobs too and re-trigger the documented **124k re-enqueue storm** (`store.py` already carries the comment explaining why returning `None` here was the original bug).

## Fix — age-based stale-link recovery

- **Stamp a link timestamp.** `index_set_job_id` now records `job_linked_at` — a new SQLite column (with a guarded `ALTER TABLE` migration for existing local indexes) and a DynamoDB attribute. New protocol method `index_get_job_linked_at`.
- **SQS-mode only:** `store_content` clears a result-less `job_id` once it is older than `CONTENT_STORE_STALE_JOB_THRESHOLD_HOURS` (default **72h** — comfortably beyond the longest Bedrock batch inference run, under the weekly scrape cadence so failed records recover on the next run). The result short-circuit at the top of `store_content` still wins, so anything already processed is untouched.
- **Storm-safe:** recent (in-flight) links stay, and **legacy links with no timestamp are treated as not-stale**, so the entire historical backlog is never re-enqueued at once. Redis mode is unchanged (still uses RQ liveness).
- Emits `content_store_stale_job_link_cleared` (Principle XII).

## Tests (TDD)

- **Unit** (`tests/test_content_store_audit_fixes.py`, mock backend, deterministic): stale→cleared, recent→preserved, missing-timestamp→preserved, configurable threshold, result short-circuits before staleness, Redis-mode ignores link age.
- **End-to-end** (`tests/test_content_store/test_store.py`, real FileBackend/SQLite): timestamp round-trip, stale link cleared & re-enqueued, fresh link survives default threshold.
- **DynamoDB backend** (`tests/test_content_store/test_s3_backend_index.py`): `index_set_job_id` writes `job_linked_at`, `index_get_job_linked_at` parses it / returns None when absent.

`215 passed` across the content-store suites. black ✓ ruff ✓ mypy ✓ bandit ✓.

## Notes
- One pre-existing failure in the scrapers-submodule test `test_scraper_utils_content_store.py` (`module 'app.scraper.utils' has no attribute 'llm_queue'`) reproduces on clean `main` — unrelated to this change.
- CLAUDE.md updated (env var + component note) per Principle XIII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)