### PR TITLE
fix(batcher): checkpoint drained batches to S3 before SQS delete + crash recovery (LLM-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,6 +763,31 @@ Batch results are routed by a **Result Processor Lambda** (triggered by EventBri
 through the same validator/reconciler pipeline. No scraper code is changed — the
 routing is entirely infrastructure (CDK env var override for `SQS_QUEUE_URL`).
 
+**Durable drain (LLM-2, `app/llm/queue/batcher.py`):** the staging queue is FIFO, so
+`_drain_staging_queue` must delete each 10-message batch immediately to unlock the
+message group. To avoid losing scraped records if the Lambda crashes after delete but
+before the batch is handed off (Bedrock submit / on-demand re-enqueue), each batch's
+**raw message bodies are checkpointed to S3 verbatim** (`recovery/{source}/{recovery_id}/{seq}.jsonl`,
+single `put_object`) **before** the SQS delete. If the checkpoint put fails, that batch's
+delete is skipped and the drain continues (messages return via visibility timeout — no
+loss, no wedge). The checkpoint prefix is deleted only at the **commit point** — batch
+path after the DynamoDB metadata write; on-demand path only when every re-enqueue
+succeeded — so a surviving checkpoint always means the handoff did not complete. At the
+start of every invocation, `_recover_orphaned_checkpoints` replays orphaned checkpoints
+(from a prior crashed run) **verbatim via raw `send_message`** back to the staging queue
+(never `send_to_sqs`, which would re-wrap the envelope and corrupt the job). Recovery is
+**age-gated**: a prefix is replayed only when its newest object is older than
+`_ORPHAN_MIN_AGE_S` (1200s > the 900s Lambda timeout), so an in-flight prefix from a
+concurrent pipeline execution is never grabbed. `recovery_id` is derived from
+`context.aws_request_id` (globally unique per invocation), not the second-granularity
+`s3_safe_id`, so drain-loop re-invocations and retries can't overwrite each other's
+checkpoints. The 7-day S3 lifecycle on the batch bucket is the final backstop. Grep
+CloudWatch for `checkpoint_put_failed`, `batcher_recovery_replayed`, `batcher_recovery_scan_failed`,
+`checkpoint_cleanup_failed`. **Residual (documented, downstream-idempotent):** if a crash
+lands between a successful Bedrock submit+DynamoDB write and the checkpoint-prefix delete,
+a later run replays those records → a second Bedrock job; the result processor is per-record
+idempotent, so this is bounded waste, not loss or duplication of canonical data.
+
 ### Key Components
 
 #### Pantry Pirate Radio Core Services

--- a/app/llm/queue/batcher.py
+++ b/app/llm/queue/batcher.py
@@ -38,6 +38,199 @@ logger = structlog.get_logger(__name__)
 
 _DEFAULT_BATCH_THRESHOLD = 100
 
+# LLM-2: durable-checkpoint constants.
+# Each drained batch is mirrored to S3 under recovery/{source}/{recovery_id}/
+# BEFORE it is deleted from the staging queue, so a Lambda crash between drain
+# and durable handoff (Bedrock submit / on-demand re-enqueue) can be recovered.
+_RECOVERY_PREFIX = "recovery"
+# An orphaned checkpoint prefix is only replayed once it is older than this.
+# The batcher Lambda timeout is 900s, so a prefix whose newest object is younger
+# than this CANNOT belong to a crashed run — it belongs to a still-running
+# (possibly concurrent) execution mid-handoff, which must not be replayed.
+_ORPHAN_MIN_AGE_S = 1200
+
+
+def _checkpoint_batch(
+    s3_client: Any,
+    bucket: str,
+    source: str,
+    recovery_id: str,
+    batch_seq: int,
+    raw_bodies: list[str],
+) -> None:
+    """Durably persist one drained batch to S3 BEFORE deleting it from SQS.
+
+    Stores the raw SQS message Body strings VERBATIM (one per line) so recovery
+    can replay byte-identical staging messages — never re-serialized through a
+    different envelope. A single put_object is atomic and durable on return
+    (the batch is ~10 messages, far under the multipart floor).
+
+    Raises on failure so the caller can skip the SQS delete (messages then
+    return via visibility timeout — no loss).
+    """
+    key = f"{_RECOVERY_PREFIX}/{source}/{recovery_id}/{batch_seq:06d}.jsonl"
+    body = ("\n".join(raw_bodies) + "\n").encode("utf-8")
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/x-ndjson",
+    )
+
+
+def _delete_checkpoint_prefix(
+    s3_client: Any, bucket: str, source: str, recovery_id: str
+) -> None:
+    """Delete this invocation's checkpoint objects after a durable handoff.
+
+    Best-effort: a leftover checkpoint only causes a bounded, idempotent replay
+    on a later run (never loss), and the bucket's 7-day lifecycle rule is the
+    final backstop. Never raises — cleanup must not fail the handler.
+    """
+    prefix = f"{_RECOVERY_PREFIX}/{source}/{recovery_id}/"
+    try:
+        token: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = s3_client.list_objects_v2(**kwargs)
+            contents = resp.get("Contents") or []
+            keys = [{"Key": obj["Key"]} for obj in contents if obj.get("Key")]
+            for i in range(0, len(keys), 1000):
+                s3_client.delete_objects(
+                    Bucket=bucket, Delete={"Objects": keys[i : i + 1000]}
+                )
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+            else:
+                break
+    except Exception as e:
+        logger.warning(
+            "checkpoint_cleanup_failed",
+            bucket=bucket,
+            prefix=prefix,
+            error=str(e),
+        )
+
+
+def _replay_group_id(source: str, raw_body: str) -> str:
+    """Derive the FIFO MessageGroupId for a verbatim replay of a staged body.
+
+    Scraper records group by their scraper_id (nested at job.metadata.scraper_id
+    — NOT a top-level field; a wrong path collapses all replays into one FIFO
+    group and serializes the whole replay). Submarine uses a single group.
+    """
+    if source == "submarine":
+        return "submarine"
+    try:
+        parsed = json.loads(raw_body)
+        group = parsed.get("job", {}).get("metadata", {}).get("scraper_id")
+        return group or "default"
+    except (json.JSONDecodeError, AttributeError):
+        return "default"
+
+
+def _recover_orphaned_checkpoints(
+    s3_client: Any,
+    sqs_client: Any,
+    bucket: str,
+    staging_queue_url: str,
+    source: str,
+    current_recovery_id: str,
+) -> int:
+    """Replay orphaned checkpoints from prior crashed runs back to staging.
+
+    Lists recovery/{source}/ prefixes (scoped to this source so it never
+    mis-routes another pipeline's records), groups by recovery_id, and replays
+    a prefix ONLY when (a) it is not the current invocation and (b) its newest
+    object is older than _ORPHAN_MIN_AGE_S — so an in-flight prefix from a
+    concurrent execution mid-handoff is never grabbed. Each record is re-sent
+    VERBATIM via raw send_message (no envelope wrapping), then its checkpoint
+    object is deleted. Best-effort: never raises (records stay in the
+    checkpoint for the next attempt if anything fails); never aborts the drain.
+
+    Returns the number of records replayed.
+    """
+    prefix = f"{_RECOVERY_PREFIX}/{source}/"
+    replayed = 0
+    try:
+        # Group objects by recovery_id with the newest LastModified per group.
+        groups: dict[str, dict[str, Any]] = {}
+        token: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = s3_client.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents") or []:
+                key = obj.get("Key", "")
+                # key = recovery/{source}/{recovery_id}/{seq}.jsonl
+                parts = key[len(prefix) :].split("/")
+                if len(parts) < 2 or not parts[1]:
+                    continue
+                rid = parts[0]
+                g = groups.setdefault(rid, {"keys": [], "newest": None})
+                g["keys"].append(key)
+                lm = obj.get("LastModified")
+                if lm is not None and (g["newest"] is None or lm > g["newest"]):
+                    g["newest"] = lm
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+            else:
+                break
+
+        now = datetime.now(UTC)
+        for rid, g in groups.items():
+            if rid == current_recovery_id:
+                continue
+            newest = g["newest"]
+            if newest is not None:
+                age = (now - newest).total_seconds()
+                if age < _ORPHAN_MIN_AGE_S:
+                    # Too young — belongs to a still-running invocation.
+                    continue
+            for key in sorted(g["keys"]):
+                obj = s3_client.get_object(Bucket=bucket, Key=key)
+                payload = obj["Body"].read()
+                if isinstance(payload, bytes):
+                    payload = payload.decode("utf-8")
+                for line in payload.splitlines():
+                    if not line.strip():
+                        continue
+                    send_kwargs: dict[str, Any] = {
+                        "QueueUrl": staging_queue_url,
+                        "MessageBody": line,
+                        "MessageGroupId": _replay_group_id(source, line),
+                    }
+                    if staging_queue_url.endswith(".fifo"):
+                        try:
+                            jid = json.loads(line).get("job_id") or str(uuid4())
+                        except (json.JSONDecodeError, AttributeError):
+                            jid = str(uuid4())
+                        send_kwargs["MessageDeduplicationId"] = jid
+                    sqs_client.send_message(**send_kwargs)
+                    replayed += 1
+                # Delete each object only after its records are re-sent, so a
+                # mid-recovery crash leaves the not-yet-replayed objects intact.
+                s3_client.delete_object(Bucket=bucket, Key=key)
+
+        if replayed:
+            logger.warning(
+                "batcher_recovery_replayed",
+                source=source,
+                replayed=replayed,
+                orphan_prefixes=len([r for r in groups if r != current_recovery_id]),
+            )
+    except Exception as e:
+        logger.error(
+            "batcher_recovery_scan_failed",
+            source=source,
+            error=str(e),
+            replayed=replayed,
+        )
+    return replayed
+
 
 def _get_clients() -> tuple:
     """Create and return AWS service clients."""
@@ -92,21 +285,31 @@ def _forward_to_dlq(
 def _drain_staging_queue(
     sqs_client: Any,
     queue_url: str,
+    *,
+    s3_client: Any,
+    bucket: str,
+    recovery_id: str,
+    source: str,
     dlq_url: str = "",
     remaining_time_fn: Any = None,
     drain_budget_ms: int = 720_000,
 ) -> tuple[int, str, bool]:
     """Drain messages from the staging queue to a temp file.
 
-    **DATA LOSS RISK**: Messages are deleted from SQS during drain to unlock
-    the FIFO message group. If this Lambda crashes after drain but before the
-    batch is submitted to Bedrock, the drained records are unrecoverable.
-    A future improvement could checkpoint records to S3 before deleting from SQS.
-
     Receives messages in batches of 10. Each batch is deleted immediately
     after parsing to unlock the FIFO message group for subsequent receives.
     Without immediate deletion, in-flight messages block the entire group
     and the drain stalls after the first batch.
+
+    **Durable checkpoint (LLM-2):** before deleting each batch from SQS, the
+    batch's raw message bodies are written VERBATIM to a durable S3 checkpoint
+    (recovery/{source}/{recovery_id}/{seq}.jsonl). The delete still happens
+    per-batch (FIFO group keeps progressing) — just AFTER the durable put. If a
+    crash occurs after delete but before the batch is handed off to Bedrock /
+    on-demand, the next invocation replays the checkpoint (no loss). If the
+    checkpoint put itself fails, this batch's delete is SKIPPED and the loop
+    continues — the messages return via visibility timeout and are retried
+    (one transient S3 error degrades throughput, it never loses or wedges).
 
     Records are written one-per-line as JSONL to a temp file so memory stays
     constant regardless of queue depth.
@@ -120,6 +323,10 @@ def _drain_staging_queue(
     Args:
         sqs_client: boto3 SQS client
         queue_url: SQS queue URL
+        s3_client: boto3 S3 client for durable checkpointing
+        bucket: S3 bucket for checkpoints (BATCH_BUCKET)
+        recovery_id: globally-unique-per-invocation id for the checkpoint prefix
+        source: "scraper" or "submarine" — scopes the checkpoint prefix
         dlq_url: DLQ URL for poison pill forwarding
         remaining_time_fn: Callable returning remaining Lambda time in ms
             (typically context.get_remaining_time_in_millis)
@@ -135,10 +342,10 @@ def _drain_staging_queue(
     # Reserve 120s (2 min) for batch build + S3 upload + Bedrock submission
     _RESERVE_MS = 120_000
 
-    logger.warning(
+    logger.info(
         "staging_queue_drain_starting",
         queue_url=queue_url,
-        note="Messages deleted during drain are unrecoverable if Lambda crashes before batch submission",
+        note="Each batch is checkpointed to S3 before SQS delete (recoverable)",
     )
 
     tmp = tempfile.NamedTemporaryFile(
@@ -149,6 +356,7 @@ def _drain_staging_queue(
     record_count = 0
     poison_pill_count = 0
     queue_empty = False
+    batch_seq = 0
 
     try:
         while True:
@@ -179,12 +387,20 @@ def _drain_staging_queue(
                 break
 
             batch_delete_entries: list[dict[str, str]] = []
+            # Raw, verbatim message bodies for the durable checkpoint — stored
+            # exactly as received so recovery can replay byte-identical messages.
+            checkpoint_bodies: list[str] = []
+            # Parsed bodies buffered for the temp file. Written only AFTER the
+            # checkpoint succeeds, so a failed checkpoint (skipped delete) never
+            # leaves records in the working file that this invocation would hand
+            # off while they remain on the queue.
+            parsed_for_tmp: list[dict[str, Any]] = []
 
             for idx, msg in enumerate(messages):
                 try:
                     body = json.loads(msg["Body"])
-                    tmp.write(json.dumps(body) + "\n")
-                    record_count += 1
+                    parsed_for_tmp.append(body)
+                    checkpoint_bodies.append(msg["Body"])
                     batch_delete_entries.append(
                         {"Id": str(idx), "ReceiptHandle": msg["ReceiptHandle"]}
                     )
@@ -216,6 +432,38 @@ def _drain_staging_queue(
                         QueueUrl=queue_url,
                         ReceiptHandle=msg["ReceiptHandle"],
                     )
+
+            # Durably checkpoint this batch to S3 BEFORE deleting from SQS, so
+            # a crash after delete (but before handoff) is recoverable. If the
+            # put fails, SKIP the delete and CONTINUE — the messages return via
+            # visibility timeout and a later invocation retries them (no loss,
+            # no FIFO wedge from aborting the whole drain). The temp-file write
+            # and record_count happen only on a successful checkpoint, so a
+            # skipped batch is never handed off while still on the queue.
+            if checkpoint_bodies:
+                try:
+                    _checkpoint_batch(
+                        s3_client,
+                        bucket,
+                        source,
+                        recovery_id,
+                        batch_seq,
+                        checkpoint_bodies,
+                    )
+                    batch_seq += 1
+                except Exception as e:
+                    logger.error(
+                        "checkpoint_put_failed",
+                        recovery_id=recovery_id,
+                        batch_seq=batch_seq,
+                        records=len(checkpoint_bodies),
+                        error=str(e),
+                    )
+                    continue
+
+                for body in parsed_for_tmp:
+                    tmp.write(json.dumps(body) + "\n")
+                record_count += len(parsed_for_tmp)
 
             # Batch-delete valid messages to unlock the FIFO message group
             if batch_delete_entries:
@@ -304,6 +552,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     batch_ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     s3_safe_id = f"{base_id}_{batch_ts}"
 
+    # LLM-2: a GLOBALLY-unique-per-invocation id for the durable checkpoint
+    # prefix. The Lambda request id is unique across drain-loop re-invocations,
+    # same-second invocations, and Step Functions retries (which get a fresh id)
+    # — unlike the second-granularity s3_safe_id, which can collide and let one
+    # invocation overwrite another's checkpoint.
+    recovery_id = f"{base_id}_{getattr(context, 'aws_request_id', None) or uuid4().hex}"
+
     # Source-specific queue routing
     if source == "submarine":
         from app.llm.queue.submarine_batch import get_submarine_batcher_config
@@ -334,12 +589,30 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     sqs, s3, bedrock, dynamodb = _get_clients()
 
-    # 1. Drain staging queue to a temp file — messages are deleted immediately
-    #    per batch to unlock FIFO message groups for subsequent receives
+    # 0. LLM-2: recover any orphaned checkpoints from a prior crashed run by
+    #    replaying them (verbatim) back onto the staging queue BEFORE draining,
+    #    so this invocation's drain picks them up. Best-effort and age-gated so
+    #    it never grabs an in-flight prefix from a concurrent execution.
+    _recover_orphaned_checkpoints(
+        s3,
+        sqs,
+        batch_bucket,
+        staging_queue_url,
+        source,
+        recovery_id,
+    )
+
+    # 1. Drain staging queue to a temp file. Each batch is checkpointed to S3
+    #    (recovery/{source}/{recovery_id}/) BEFORE its SQS delete, then deleted
+    #    per batch to unlock FIFO message groups for subsequent receives.
     remaining_time_fn = context.get_remaining_time_in_millis if context else None
     record_count, staging_file, queue_empty = _drain_staging_queue(
         sqs,
         staging_queue_url,
+        s3_client=s3,
+        bucket=batch_bucket,
+        recovery_id=recovery_id,
+        source=source,
         dlq_url=staging_dlq_url,
         remaining_time_fn=remaining_time_fn,
     )
@@ -361,6 +634,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
 
         if record_count == 0:
+            # Nothing drained this invocation; clear any checkpoints defensively.
+            _delete_checkpoint_prefix(s3, batch_bucket, source, recovery_id)
             return {
                 "mode": "on-demand",
                 "record_count": 0,
@@ -414,6 +689,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                     failed=failed_count,
                     execution_id=execution_id,
                 )
+                # LLM-2: a failed re-enqueue means those records are NOT durably
+                # handed off. Leave the checkpoint so a later invocation replays
+                # them (byte-identical, downstream-deduped). Only a fully clean
+                # re-enqueue is a completed handoff.
+            else:
+                _delete_checkpoint_prefix(s3, batch_bucket, source, recovery_id)
 
             return {
                 "mode": "on-demand",
@@ -529,7 +810,13 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 },
             )
 
-            # 6. Staging messages were already deleted during drain
+            # 6. LLM-2 commit point: the batch is now durably handed off
+            #    (input in S3, Bedrock job submitted, metadata in DynamoDB).
+            #    Deleting the checkpoint prefix is the LAST step — a surviving
+            #    checkpoint therefore always means the handoff did NOT complete,
+            #    which is what makes recovery-replay safe.
+            _delete_checkpoint_prefix(s3, batch_bucket, source, recovery_id)
+
             return {
                 "mode": "batch",
                 "job_arn": job_arn,

--- a/tests/test_llm/test_batcher.py
+++ b/tests/test_llm/test_batcher.py
@@ -88,7 +88,12 @@ class TestDrainStagingQueue:
         ]
 
         count, filepath, _queue_empty = _drain_staging_queue(
-            mock_sqs, "https://sqs/staging.fifo"
+            mock_sqs,
+            "https://sqs/staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-batch-bucket",
+            recovery_id="exec-1_req-1",
+            source="scraper",
         )
         try:
             assert count == 3
@@ -106,7 +111,12 @@ class TestDrainStagingQueue:
         mock_sqs.receive_message.return_value = {"Messages": []}
 
         count, filepath, _queue_empty = _drain_staging_queue(
-            mock_sqs, "https://sqs/staging.fifo"
+            mock_sqs,
+            "https://sqs/staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-batch-bucket",
+            recovery_id="exec-1_req-1",
+            source="scraper",
         )
         try:
             assert count == 0
@@ -124,7 +134,12 @@ class TestDrainStagingQueue:
         ]
 
         count, filepath, _queue_empty = _drain_staging_queue(
-            mock_sqs, "https://sqs/staging.fifo"
+            mock_sqs,
+            "https://sqs/staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-batch-bucket",
+            recovery_id="exec-1_req-1",
+            source="scraper",
         )
         try:
             mock_sqs.delete_message_batch.assert_called_once()
@@ -149,7 +164,12 @@ class TestDrainStagingQueue:
         ]
 
         count, filepath, _queue_empty = _drain_staging_queue(
-            mock_sqs, "https://sqs/staging.fifo"
+            mock_sqs,
+            "https://sqs/staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-batch-bucket",
+            recovery_id="exec-1_req-1",
+            source="scraper",
         )
         try:
             assert count == 1
@@ -183,6 +203,7 @@ class TestHandlerBatchPath:
         """With >= threshold records, should create batch job."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -206,6 +227,7 @@ class TestHandlerBatchPath:
         """Each JSONL line should have recordId and modelInput with Messages API format."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -246,6 +268,7 @@ class TestHandlerBatchPath:
         """Should store batch job ARN in DynamoDB for tracking."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -267,6 +290,7 @@ class TestHandlerBatchPath:
         """original_jobs.jsonl should be valid JSONL with k/v pairs."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -308,6 +332,7 @@ class TestHandlerOnDemandPath:
         """With < threshold records, should re-enqueue to LLM queue."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -334,6 +359,7 @@ class TestHandlerEmptyQueue:
         """0 messages should result in graceful no-op."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -357,6 +383,7 @@ class TestHandlerLogging:
         """Should log the batch decision with structured context."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -385,6 +412,7 @@ class TestHandlerMessageDeletion:
         """When ALL re-enqueue attempts fail, should report 0 count and N failures."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -415,6 +443,7 @@ class TestHandlerOnDemandPartialFailure:
         """Partial re-enqueue failure should report correct success/failure counts."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -445,6 +474,7 @@ class TestHandlerOnDemandPartialFailure:
         """All successful re-enqueue should return full count with 0 failures."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -471,6 +501,7 @@ class TestHandlerOnDemandPartialFailure:
         """A failure on one record should not stop processing of remaining records."""
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_get_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)
@@ -534,3 +565,521 @@ class TestHandlerMissingEnvVars:
         ):
             with pytest.raises(ValueError, match="LLM_QUEUE_URL"):
                 handler({"execution_id": "exec-123", "scrapers": []}, None)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# LLM-2: durable checkpoint-before-delete + crash recovery
+# ──────────────────────────────────────────────────────────────────────────
+
+from datetime import timedelta  # noqa: E402
+
+from botocore.exceptions import ClientError  # noqa: E402
+
+from app.llm.queue.batcher import (  # noqa: E402
+    _ORPHAN_MIN_AGE_S,
+    _recover_orphaned_checkpoints,
+)
+
+_DRAIN_KW = {
+    "s3_client": None,  # overridden per-test
+    "bucket": "test-batch-bucket",
+    "recovery_id": "exec-1_req-aaa",
+    "source": "scraper",
+}
+
+
+def _fake_s3_body(text: str) -> MagicMock:
+    """A StreamingBody-like object whose .read() returns the encoded text."""
+    body = MagicMock()
+    body.read.return_value = text.encode("utf-8")
+    return body
+
+
+class TestDrainCheckpoint:
+    """LLM-2: each drained batch is checkpointed to S3 before the SQS delete."""
+
+    def test_checkpoints_before_delete(self):
+        """put_object(recovery/...) must be recorded BEFORE delete_message_batch."""
+        mock_sqs = MagicMock()
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        calls: list[str] = []
+        mock_s3.put_object.side_effect = lambda **k: calls.append(f"put:{k['Key']}")
+
+        def _record_delete(**k):
+            calls.append("delete")
+            return {"Failed": []}
+
+        mock_sqs.delete_message_batch.side_effect = _record_delete
+        mock_sqs.receive_message.side_effect = [
+            {"Messages": [_make_sqs_message(f"job-{i}") for i in range(3)]},
+            {"Messages": []},
+        ]
+
+        kw = {**_DRAIN_KW, "s3_client": mock_s3}
+        count, filepath, _ = _drain_staging_queue(
+            mock_sqs, "https://sqs/staging.fifo", **kw
+        )
+        try:
+            assert count == 3
+            assert calls == [
+                "put:recovery/scraper/exec-1_req-aaa/000000.jsonl",
+                "delete",
+            ], calls
+        finally:
+            os.unlink(filepath)
+
+    def test_checkpoint_stores_raw_body_verbatim(self):
+        """The checkpoint object stores the original msg['Body'] strings verbatim."""
+        mock_sqs = MagicMock()
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        captured: dict[str, bytes] = {}
+        mock_s3.put_object.side_effect = lambda **k: captured.update(
+            {k["Key"]: k["Body"]}
+        )
+        messages = [_make_sqs_message(f"job-{i}") for i in range(2)]
+        mock_sqs.receive_message.side_effect = [
+            {"Messages": messages},
+            {"Messages": []},
+        ]
+
+        kw = {**_DRAIN_KW, "s3_client": mock_s3}
+        _, filepath, _ = _drain_staging_queue(
+            mock_sqs, "https://sqs/staging.fifo", **kw
+        )
+        try:
+            key = "recovery/scraper/exec-1_req-aaa/000000.jsonl"
+            lines = captured[key].decode("utf-8").splitlines()
+            assert lines == [messages[0]["Body"], messages[1]["Body"]]
+        finally:
+            os.unlink(filepath)
+
+    def test_poison_pill_excluded_from_checkpoint(self):
+        """Malformed messages are DLQ'd, not checkpointed (never replayed)."""
+        mock_sqs = MagicMock()
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        captured: dict[str, bytes] = {}
+        mock_s3.put_object.side_effect = lambda **k: captured.update(
+            {k["Key"]: k["Body"]}
+        )
+        valid = _make_sqs_message("job-valid")
+        bad = {"MessageId": "bad", "ReceiptHandle": "r-bad", "Body": "NOT JSON {{{"}
+        mock_sqs.receive_message.side_effect = [
+            {"Messages": [valid, bad]},
+            {"Messages": []},
+        ]
+
+        kw = {**_DRAIN_KW, "s3_client": mock_s3}
+        count, filepath, _ = _drain_staging_queue(
+            mock_sqs, "https://sqs/staging.fifo", **kw
+        )
+        try:
+            assert count == 1
+            key = "recovery/scraper/exec-1_req-aaa/000000.jsonl"
+            lines = captured[key].decode("utf-8").splitlines()
+            assert lines == [valid["Body"]]  # poison pill not present
+        finally:
+            os.unlink(filepath)
+
+    def test_no_delete_when_checkpoint_fails_and_loop_continues(self):
+        """A failed checkpoint put must skip that batch's delete and continue.
+
+        The records are neither counted nor deleted (they return via visibility
+        timeout) — no loss, and the drain does not abort/wedge.
+        """
+        mock_sqs = MagicMock()
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        # First batch put fails; second batch put succeeds.
+        mock_s3.put_object.side_effect = [
+            ClientError({"Error": {"Code": "Slow"}}, "PutObject"),
+            None,
+        ]
+        batch1 = [_make_sqs_message("job-a")]
+        batch2 = [_make_sqs_message("job-b")]
+        mock_sqs.receive_message.side_effect = [
+            {"Messages": batch1},
+            {"Messages": batch2},
+            {"Messages": []},
+        ]
+
+        kw = {**_DRAIN_KW, "s3_client": mock_s3}
+        count, filepath, _ = _drain_staging_queue(
+            mock_sqs, "https://sqs/staging.fifo", **kw
+        )
+        try:
+            # Only batch2 was checkpointed+counted+deleted; batch1 skipped.
+            assert count == 1
+            assert mock_sqs.delete_message_batch.call_count == 1
+            records = _read_drain_file(filepath)
+            assert [r["job_id"] for r in records] == ["job-b"]
+        finally:
+            os.unlink(filepath)
+
+    def test_drain_requires_checkpoint_kwargs(self):
+        """The checkpoint params are required — no silent loss-reintroducing no-op."""
+        mock_sqs = MagicMock()
+        mock_sqs.receive_message.return_value = {"Messages": []}
+        with pytest.raises(TypeError):
+            _drain_staging_queue(mock_sqs, "https://sqs/staging.fifo")
+
+
+class TestRecoverOrphanedCheckpoints:
+    """LLM-2: orphaned checkpoints from crashed runs are replayed verbatim."""
+
+    def _list_resp(self, key: str, age_s: int) -> dict:
+        lm = datetime.now(UTC) - timedelta(seconds=age_s)
+        return {"Contents": [{"Key": key, "LastModified": lm}], "IsTruncated": False}
+
+    def test_replays_orphan_verbatim_via_raw_send_message(self):
+        """An aged orphan checkpoint replays each stored body verbatim to staging
+        via raw send_message (NOT send_to_sqs, which would double-wrap it)."""
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_sqs = MagicMock()
+        key = "recovery/scraper/old-rid/000000.jsonl"
+        body_line = _make_sqs_message("job-x")["Body"]
+        mock_s3.list_objects_v2.return_value = self._list_resp(
+            key, _ORPHAN_MIN_AGE_S + 60
+        )
+        mock_s3.get_object.return_value = {"Body": _fake_s3_body(body_line + "\n")}
+
+        with patch("app.llm.queue.batcher.send_to_sqs") as mock_send_to_sqs:
+            replayed = _recover_orphaned_checkpoints(
+                mock_s3,
+                mock_sqs,
+                "test-batch-bucket",
+                "https://sqs/staging.fifo",
+                "scraper",
+                "exec-1_req-current",
+            )
+
+        assert replayed == 1
+        mock_send_to_sqs.assert_not_called()  # must NOT re-wrap
+        mock_sqs.send_message.assert_called_once()
+        sent = mock_sqs.send_message.call_args.kwargs
+        assert sent["MessageBody"] == body_line  # byte-identical
+        # Group id from nested job.metadata.scraper_id, not a top-level field.
+        assert sent["MessageGroupId"] == "test_scraper"
+        # FIFO dedup id is the replayed body's job_id.
+        assert sent["MessageDeduplicationId"] == "job-x"
+        mock_s3.delete_object.assert_called_once_with(
+            Bucket="test-batch-bucket", Key=key
+        )
+
+    def test_replays_all_objects_and_lines_in_order(self):
+        """A recovery_id with multiple checkpoint objects, each multi-line, must
+        replay EVERY line across ALL objects (sorted), then delete each object."""
+        mock_s3 = MagicMock()
+        mock_sqs = MagicMock()
+        lm = datetime.now(UTC) - timedelta(seconds=_ORPHAN_MIN_AGE_S + 60)
+        k0 = "recovery/scraper/old-rid/000000.jsonl"
+        k1 = "recovery/scraper/old-rid/000001.jsonl"
+        # Return keys out of order to prove sorting.
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": k1, "LastModified": lm},
+                {"Key": k0, "LastModified": lm},
+            ],
+            "IsTruncated": False,
+        }
+        b = [_make_sqs_message(f"job-{i}")["Body"] for i in range(3)]
+        bodies = {
+            k0: _fake_s3_body(b[0] + "\n" + b[1] + "\n"),
+            k1: _fake_s3_body(b[2] + "\n"),
+        }
+        mock_s3.get_object.side_effect = lambda **kw: {"Body": bodies[kw["Key"]]}
+
+        with patch("app.llm.queue.batcher.send_to_sqs"):
+            replayed = _recover_orphaned_checkpoints(
+                mock_s3,
+                mock_sqs,
+                "test-batch-bucket",
+                "https://sqs/staging.fifo",
+                "scraper",
+                "exec-1_req-current",
+            )
+
+        assert replayed == 3
+        sent_bodies = [
+            c.kwargs["MessageBody"] for c in mock_sqs.send_message.call_args_list
+        ]
+        # 000000's two lines first (sorted), then 000001's line.
+        assert sent_bodies == [b[0], b[1], b[2]]
+        assert mock_s3.delete_object.call_count == 2
+
+    def test_submarine_orphan_replays_under_single_group(self):
+        """A submarine-source orphan replays under the constant 'submarine'
+        FIFO group (not a scraper_id)."""
+        mock_s3 = MagicMock()
+        mock_sqs = MagicMock()
+        lm = datetime.now(UTC) - timedelta(seconds=_ORPHAN_MIN_AGE_S + 60)
+        key = "recovery/submarine/old-rid/000000.jsonl"
+        body_line = _make_sqs_message("sub-job")["Body"]
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": key, "LastModified": lm}],
+            "IsTruncated": False,
+        }
+        mock_s3.get_object.return_value = {"Body": _fake_s3_body(body_line + "\n")}
+
+        replayed = _recover_orphaned_checkpoints(
+            mock_s3,
+            mock_sqs,
+            "test-batch-bucket",
+            "https://sqs/submarine-staging.fifo",
+            "submarine",
+            "exec-1_req-current",
+        )
+
+        assert replayed == 1
+        assert mock_sqs.send_message.call_args.kwargs["MessageGroupId"] == "submarine"
+
+    def test_recovery_scan_paginates(self):
+        """The recovery scan must follow IsTruncated/NextContinuationToken across
+        pages (orphans on page 2 are not missed)."""
+        mock_s3 = MagicMock()
+        mock_sqs = MagicMock()
+        lm = datetime.now(UTC) - timedelta(seconds=_ORPHAN_MIN_AGE_S + 60)
+        mock_s3.list_objects_v2.side_effect = [
+            {
+                "Contents": [
+                    {"Key": "recovery/scraper/rid-a/000000.jsonl", "LastModified": lm}
+                ],
+                "IsTruncated": True,
+                "NextContinuationToken": "tok-1",
+            },
+            {
+                "Contents": [
+                    {"Key": "recovery/scraper/rid-b/000000.jsonl", "LastModified": lm}
+                ],
+                "IsTruncated": False,
+            },
+        ]
+        body_line = _make_sqs_message("job-p")["Body"]
+        mock_s3.get_object.return_value = {"Body": _fake_s3_body(body_line + "\n")}
+
+        replayed = _recover_orphaned_checkpoints(
+            mock_s3,
+            mock_sqs,
+            "test-batch-bucket",
+            "https://sqs/staging.fifo",
+            "scraper",
+            "exec-1_req-current",
+        )
+
+        # Both pages' orphans replayed (one record each).
+        assert replayed == 2
+        second_call = mock_s3.list_objects_v2.call_args_list[1]
+        assert second_call.kwargs.get("ContinuationToken") == "tok-1"
+
+    def test_skips_in_flight_prefix_by_age(self):
+        """A checkpoint younger than _ORPHAN_MIN_AGE_S belongs to a live run and
+        must NOT be replayed (prevents grabbing a concurrent execution's batch)."""
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_sqs = MagicMock()
+        mock_s3.list_objects_v2.return_value = self._list_resp(
+            "recovery/scraper/young-rid/000000.jsonl", _ORPHAN_MIN_AGE_S - 60
+        )
+
+        replayed = _recover_orphaned_checkpoints(
+            mock_s3,
+            mock_sqs,
+            "test-batch-bucket",
+            "https://sqs/staging.fifo",
+            "scraper",
+            "exec-1_req-current",
+        )
+
+        assert replayed == 0
+        mock_sqs.send_message.assert_not_called()
+        mock_s3.delete_object.assert_not_called()
+
+    def test_excludes_current_recovery_id(self):
+        """This invocation's own (current) prefix is never replayed."""
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_sqs = MagicMock()
+        mock_s3.list_objects_v2.return_value = self._list_resp(
+            "recovery/scraper/exec-1_req-current/000000.jsonl", _ORPHAN_MIN_AGE_S + 999
+        )
+
+        replayed = _recover_orphaned_checkpoints(
+            mock_s3,
+            mock_sqs,
+            "test-batch-bucket",
+            "https://sqs/staging.fifo",
+            "scraper",
+            "exec-1_req-current",
+        )
+
+        assert replayed == 0
+        mock_sqs.send_message.assert_not_called()
+
+    def test_noop_when_no_orphans(self):
+        """Empty recovery prefix → nothing replayed, no errors."""
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_sqs = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+
+        replayed = _recover_orphaned_checkpoints(
+            mock_s3,
+            mock_sqs,
+            "test-batch-bucket",
+            "https://sqs/staging.fifo",
+            "scraper",
+            "exec-1_req-current",
+        )
+
+        assert replayed == 0
+
+
+class TestHandlerCheckpointLifecycle:
+    """LLM-2: checkpoint prefix is deleted only on a completed durable handoff."""
+
+    def _clients(self, mock_get_clients):
+        mock_sqs, mock_s3, mock_bedrock, mock_dynamodb = (
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        # No orphans to recover; cleanup list returns the invocation's objects.
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_get_clients.return_value = (
+            mock_sqs,
+            mock_s3,
+            mock_bedrock,
+            mock_dynamodb,
+        )
+        return mock_sqs, mock_s3, mock_bedrock, mock_dynamodb
+
+    @patch("app.llm.queue.batcher._get_clients")
+    def test_batch_path_deletes_prefix_after_dynamodb(self, mock_get_clients):
+        """On the batch path, the checkpoint cleanup list happens AFTER the
+        DynamoDB metadata write (the commit point)."""
+        _, mock_s3, mock_bedrock, mock_dynamodb = self._clients(mock_get_clients)
+        order: list[str] = []
+        mock_dynamodb.put_item.side_effect = lambda **k: order.append("dynamodb")
+
+        def _list(**k):
+            # Distinguish the per-invocation cleanup list (prefix carries the
+            # recovery_id, i.e. 4 path segments) from the recovery scan at
+            # handler start (prefix recovery/scraper/, 3 segments).
+            prefix = k.get("Prefix", "")
+            depth = len([p for p in prefix.split("/") if p])
+            order.append("cleanup_list" if depth >= 3 else "recovery_scan")
+            return {"Contents": [], "IsTruncated": False}
+
+        mock_s3.list_objects_v2.side_effect = _list
+        mock_bedrock.create_model_invocation_job.return_value = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123:model-invocation-job/t"
+        }
+
+        with patch("app.llm.queue.batcher._drain_staging_queue") as mock_drain:
+            mock_drain.return_value = _make_drain_file(BATCH_THRESHOLD)
+            with patch.dict("os.environ", _HANDLER_ENV, clear=False):
+                handler({"execution_id": "exec-123", "scrapers": []}, None)
+
+        # The cleanup list call for the recovery prefix comes after put_item.
+        assert "dynamodb" in order
+        assert "cleanup_list" in order
+        assert order.index("dynamodb") < order.index("cleanup_list")
+
+    @patch("app.llm.queue.batcher._get_clients")
+    def test_crash_before_bedrock_leaves_checkpoint(self, mock_get_clients):
+        """If Bedrock submit raises, the checkpoint prefix is NOT deleted."""
+        _, mock_s3, mock_bedrock, _ = self._clients(mock_get_clients)
+        mock_bedrock.create_model_invocation_job.side_effect = RuntimeError("boom")
+
+        with patch("app.llm.queue.batcher._drain_staging_queue") as mock_drain:
+            mock_drain.return_value = _make_drain_file(BATCH_THRESHOLD)
+            with patch.dict("os.environ", _HANDLER_ENV, clear=False):
+                with pytest.raises(RuntimeError):
+                    handler({"execution_id": "exec-123", "scrapers": []}, None)
+
+        # No delete_objects on the recovery prefix — checkpoint survives.
+        mock_s3.delete_objects.assert_not_called()
+
+    @patch("app.llm.queue.batcher._get_clients")
+    @patch("app.llm.queue.batcher.send_to_sqs")
+    def test_on_demand_deletes_prefix_only_when_all_succeed(
+        self, mock_send, mock_get_clients
+    ):
+        """On-demand cleanup deletes the prefix only on a fully-clean re-enqueue."""
+        _, mock_s3, _, _ = self._clients(mock_get_clients)
+        # Make cleanup actually call delete_objects when it lists something.
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": "recovery/scraper/rid/000000.jsonl"}],
+            "IsTruncated": False,
+        }
+
+        # All succeed → prefix deleted.
+        mock_send.return_value = "msg"
+        with patch("app.llm.queue.batcher._drain_staging_queue") as mock_drain:
+            mock_drain.return_value = _make_drain_file(3)
+            with patch.dict("os.environ", _HANDLER_ENV, clear=False):
+                handler({"execution_id": "e", "scrapers": []}, None)
+        assert mock_s3.delete_objects.called
+
+        # Reset; one failure → prefix NOT deleted.
+        mock_s3.delete_objects.reset_mock()
+        mock_send.side_effect = [RuntimeError("x"), "msg", "msg"]
+        with patch("app.llm.queue.batcher._drain_staging_queue") as mock_drain:
+            mock_drain.return_value = _make_drain_file(3)
+            with patch.dict("os.environ", _HANDLER_ENV, clear=False):
+                handler({"execution_id": "e", "scrapers": []}, None)
+        mock_s3.delete_objects.assert_not_called()
+
+
+class TestCheckpointHelpers:
+    """LLM-2: unit-level invariants for the checkpoint helpers."""
+
+    def test_delete_checkpoint_prefix_swallows_s3_errors(self):
+        """Cleanup is best-effort — an S3 error must not propagate (a leftover
+        checkpoint only causes a bounded, idempotent replay, never a failure)."""
+        from app.llm.queue.batcher import _delete_checkpoint_prefix
+
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.side_effect = RuntimeError("S3 down")
+        # Must not raise.
+        _delete_checkpoint_prefix(mock_s3, "bucket", "scraper", "rid")
+
+    def test_recovery_id_uses_aws_request_id_not_timestamp(self):
+        """The checkpoint recovery_id must derive from context.aws_request_id
+        (globally unique per invocation), NOT the second-granularity s3_safe_id
+        — otherwise drain-loop re-invocations / retries collide and overwrite
+        each other's checkpoints, reintroducing the loss this fix closes."""
+        captured = {}
+
+        def _capture_drain(*args, **kwargs):
+            captured["recovery_id"] = kwargs["recovery_id"]
+            return _make_drain_file(0)
+
+        ctx = MagicMock()
+        ctx.aws_request_id = "req-UNIQUE-123"
+        ctx.get_remaining_time_in_millis.return_value = 900_000
+
+        with patch("app.llm.queue.batcher._get_clients") as mock_get_clients:
+            mock_s3 = MagicMock()
+            mock_s3.list_objects_v2.return_value = {
+                "Contents": [],
+                "IsTruncated": False,
+            }
+            mock_get_clients.return_value = (
+                MagicMock(),
+                mock_s3,
+                MagicMock(),
+                MagicMock(),
+            )
+            with patch(
+                "app.llm.queue.batcher._drain_staging_queue",
+                side_effect=_capture_drain,
+            ):
+                with patch.dict("os.environ", _HANDLER_ENV, clear=False):
+                    handler({"execution_id": "arn:...:exec:name:exec-uuid"}, ctx)
+
+        assert "req-UNIQUE-123" in captured["recovery_id"]

--- a/tests/test_llm/test_batcher_audit_fixes.py
+++ b/tests/test_llm/test_batcher_audit_fixes.py
@@ -35,6 +35,10 @@ class TestC2PoisonPillDlqForwarding:
         count, filepath, _queue_empty = _drain_staging_queue(
             mock_sqs,
             "https://sqs.../staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-bucket",
+            recovery_id="exec_req-aaa",
+            source="scraper",
             dlq_url=dlq_url,
         )
 
@@ -74,6 +78,10 @@ class TestC2PoisonPillDlqForwarding:
         count, filepath, _queue_empty = _drain_staging_queue(
             mock_sqs,
             "https://sqs.../staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-bucket",
+            recovery_id="exec_req-aaa",
+            source="scraper",
             dlq_url="",  # No DLQ
         )
 
@@ -106,6 +114,10 @@ class TestC2PoisonPillDlqForwarding:
         count, filepath, _queue_empty = _drain_staging_queue(
             mock_sqs,
             "https://sqs.../staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-bucket",
+            recovery_id="exec_req-aaa",
+            source="scraper",
             dlq_url="https://sqs.../staging-dlq.fifo",
         )
 
@@ -141,6 +153,10 @@ class TestC2PoisonPillDlqForwarding:
         count, filepath, _queue_empty = _drain_staging_queue(
             mock_sqs,
             "https://sqs.../staging.fifo",
+            s3_client=MagicMock(),
+            bucket="test-bucket",
+            recovery_id="exec_req-aaa",
+            source="scraper",
             dlq_url="https://sqs.../staging-dlq.fifo",
         )
 
@@ -178,7 +194,9 @@ class TestM4BatchThresholdPerInvocation:
         tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
         tmp.close()
         mock_drain.return_value = (0, tmp.name, True)
-        mock_clients.return_value = (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        _mock_s3 = MagicMock()
+        _mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
+        mock_clients.return_value = (MagicMock(), _mock_s3, MagicMock(), MagicMock())
 
         result = handler({"execution_id": "test-exec"}, None)
 
@@ -270,6 +288,7 @@ class TestOriginalJobsJsonlFormat:
 
         mock_sqs = MagicMock()
         mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [], "IsTruncated": False}
         mock_bedrock = MagicMock()
         mock_dynamodb = MagicMock()
         mock_clients.return_value = (mock_sqs, mock_s3, mock_bedrock, mock_dynamodb)


### PR DESCRIPTION
## Finding (LLM-2, Tier 1 — CRITICAL) — the deferred one, now closed

The Bedrock batcher drains the **FIFO** staging queue by deleting each 10-message batch *immediately* (required to unlock the FIFO message group) into an **ephemeral Lambda `/tmp` file**. The durable handoff — stream to S3 `input.jsonl` + `bedrock.create_model_invocation_job` + DynamoDB metadata, or on-demand re-enqueue — happens only **after** the full drain. A Lambda crash in that window **permanently lost a whole batch of scraped food-pantry records** (Constitution **Principle XI**; the code's own docstring admitted it).

Because the queue is FIFO, the originally-sketched "delete after submit" is **wrong** — deferring the delete stalls the drain. The correct fix is **checkpoint-before-delete + crash recovery**.

## Design (multi-agent verified, then adversarially reviewed)

Two workflows bracketed the implementation. The understand pass verified the load-bearing facts (single sequential batcher per execution, Step Functions retries the same state, 7-day S3 lifecycle, `put_object` durability) and the adversarial design review caught a would-be **critical bug**: replaying via `send_to_sqs` would re-wrap the body in a `{"data": ...}` envelope and corrupt every record into an empty-prompt job. The diff review confirmed all 9 spec items satisfied; its findings were all test-coverage gaps (production code correct), which this PR closes.

## Fix (`app/llm/queue/batcher.py`)

- **Checkpoint before delete:** `_drain_staging_queue` writes each batch's **raw message bodies verbatim** to a durable S3 object (`recovery/{source}/{recovery_id}/{seq}.jsonl`, single `put_object`) **before** `delete_message_batch`. Delete is still per-batch — **FIFO unlock preserved**. On checkpoint-put failure: skip that batch's delete and **continue** (messages return via visibility timeout — no loss, no wedge); the temp-file write + `record_count` happen only after a successful checkpoint.
- **Recovery at handler start:** `_recover_orphaned_checkpoints` replays orphaned checkpoints from a prior crashed run **verbatim via raw `sqs.send_message`** (never `send_to_sqs` — that would re-wrap and corrupt). MessageGroupId = nested `job.metadata.scraper_id` for scrapers / `"submarine"` for submarine; dedup id = `job_id`. Deletes each object only after its records re-send; best-effort (never raises, never aborts the drain).
- **Age-gated recovery:** a prefix is replayed only when its newest object is older than `_ORPHAN_MIN_AGE_S` (1200s > the 900s Lambda timeout), so an **in-flight prefix from a concurrent pipeline execution is never grabbed**. Excludes the current invocation.
- **Globally-unique `recovery_id`** from `context.aws_request_id` (not the second-granularity `s3_safe_id`) — drain-loop re-invocations, same-second invocations, and retries can't overwrite each other's checkpoints.
- **Commit-point cleanup:** the checkpoint prefix is deleted only after a *completed* durable handoff — batch path after `dynamodb.put_item`; on-demand **only when `failed_count == 0`** (a partial re-enqueue leaves the checkpoint for replay); `record_count == 0` cleans up defensively. A surviving checkpoint therefore always means the handoff did not complete → safe to replay. The 7-day S3 lifecycle is the backstop.

## Residual (documented, downstream-idempotent)
If a crash lands *between* a successful Bedrock submit + DynamoDB write and the checkpoint-prefix delete, a later run replays those records → a second Bedrock job. The result processor is **per-record idempotent**, so this is **bounded waste, never loss or duplicate canonical data**. Fully closing it needs a content-hash submit marker — scoped as a follow-up, since this PR's mandate (the data-**loss** window) is fully closed.

## Tests (TDD)
17 new tests across `TestDrainCheckpoint`, `TestRecoverOrphanedCheckpoints`, `TestHandlerCheckpointLifecycle`, `TestCheckpointHelpers`: checkpoint-before-delete ordering, verbatim storage, poison-pill exclusion, no-delete-on-put-failure + loop-continue, required kwargs, age-gated / current-id / multi-object-ordered / multi-page / submarine recovery, verbatim raw `send_message` (not `send_to_sqs`), dedup id, commit-point cleanup ordering, crash-before-Bedrock leaves checkpoint, on-demand cleanup only on full success, best-effort cleanup swallows S3 errors, `recovery_id` from `aws_request_id`.

`34 passed` (full `tests/test_llm/test_batcher.py`). black ✓ ruff ✓ mypy ✓ bandit ✓. CLAUDE.md updated (Principle XIII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)