### PR TITLE
chore(backfill): recover NULL-org canonical locations from record_version (SUB-1)

### DIFF
--- a/scripts/backfill_null_org_from_record_version.py
+++ b/scripts/backfill_null_org_from_record_version.py
@@ -1,0 +1,475 @@
+"""One-shot backfill: recover `organization_id` for canonical locations
+whose org link was NULLed, from the latest `record_version` snapshot.
+
+Counterpart to the code fixes that STOP the org-wipe — SUB-1 (#499, submarine
+stops NULLing `organization_id`) and REC-4 (#510, matched-update path is org
+fill-only, never wipes). This script cleans up the ~6,906 canonical rows whose
+org link was already lost before those fixes landed.
+
+**ORDERING (critical):** apply in prod only AFTER #499 and #510 are merged and
+deployed. The wipe came from the submarine/scraper update paths; if this
+backfill runs while those still NULL the org on the next pass, the restored
+links get wiped again. Dry-run is safe any time.
+
+Recovery source: `record_version.data->>'organization_id'`. The reconciler
+versions every canonical write, so a location whose org was later NULLed still
+carries its last non-NULL org in an older version. `location_source` does NOT
+store organization_id, so `record_version` is the only recovery source
+(verified against prod). For each NULL-org canonical row we take the
+highest-`version_num` location version whose `organization_id` is non-empty AND
+still points to an existing `organization` row.
+
+Owner protection (Principle VI): rows with `verified_by IN ('admin','source',
+'claimed')` are exempt — never touched. The candidate query filters them out
+and the UPDATE carries the same guard as defense-in-depth.
+
+Reversibility: this script only ever runs `UPDATE location SET
+organization_id = <recovered> WHERE organization_id IS NULL ...` — pure
+fill-only UPDATEs, no deletes. Every change is logged to `org_backfill_audit`
+keyed by `run_id`, and `--undo-run-id` reverses a run exactly (re-NULLing only
+rows that still hold the value this run wrote and are still not human-curated).
+
+Dry-run by default. Pass `--apply` to commit.
+
+Usage:
+    ./bouy exec app python scripts/backfill_null_org_from_record_version.py
+    ./bouy exec app python scripts/backfill_null_org_from_record_version.py --apply
+    ./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py
+    ./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --apply
+    # staged rollout:
+    ./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --max-rows 50 --apply
+    # reverse a run:
+    ./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --undo-run-id <uuid> --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import uuid
+from typing import Any
+
+from sqlalchemy import bindparam, create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# Human-curated tiers that must never be overwritten by an automated backfill
+# (kept in sync with app/validator/scoring.py:HUMAN_VERIFIED_SOURCES).
+_HUMAN_VERIFIED = ("admin", "source", "claimed")
+
+
+# Append-only audit table. Created lazily on first --apply (CREATE TABLE
+# IF NOT EXISTS) so this script ships without a cross-repo migration — same
+# pattern as dedup_run_audit / the Write API's ingest_audit (per CLAUDE.md).
+_AUDIT_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS org_backfill_audit (
+    id BIGSERIAL PRIMARY KEY,
+    run_id UUID NOT NULL,
+    location_id UUID NOT NULL,
+    old_organization_id UUID,
+    new_organization_id UUID NOT NULL,
+    source_version_num INTEGER,
+    action TEXT NOT NULL DEFAULT 'org_fill'
+        CHECK (action IN ('org_fill', 'undo')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_org_backfill_audit_run_id
+    ON org_backfill_audit(run_id);
+"""
+
+
+def ensure_audit_table(db: Session) -> None:
+    """Create `org_backfill_audit` on first --apply if absent (idempotent)."""
+    db.execute(text(_AUDIT_TABLE_DDL))
+
+
+def check_haarrrvest_freshness(db: Session, *, max_age_hours: int = 12) -> bool:
+    """Verify a recent `record_version` row exists (HAARRRvest publishes one
+    per export). A stale newest row means the latest known-good rollback
+    target is stale. Heuristic pre-flight — the real safety net is a manual
+    Aurora snapshot (see CLAUDE.md runbook). Mirrors the dedup script's check.
+    """
+    result = db.execute(
+        text(
+            """
+            SELECT MAX(created_at) AS most_recent
+            FROM record_version
+            WHERE created_at > NOW() - (:max_age_hours || ' hours')::interval
+            LIMIT 1
+            """
+        ),
+        {"max_age_hours": str(max_age_hours)},
+    ).first()
+    return not (result is None or result[0] is None)
+
+
+def candidate_sql() -> str:
+    """SQL selecting (location_id, recovered org, source version) for every
+    recoverable NULL-org canonical row.
+
+    A LATERAL subquery picks the highest-`version_num` location version with a
+    non-empty `organization_id`; the `record_version (record_id, version_num)`
+    unique index makes each lookup an indexed scan. The JOIN to `organization`
+    drops orgs that no longer exist (stale FK), and the `verified_by` guard
+    excludes human-curated rows.
+
+    Type note: `location.id`/`organization.id` are varchar but
+    `record_version.record_id` is uuid, so the LATERAL casts the single outer
+    `l.id::uuid` (index on `rv.record_id` stays usable; all location ids are
+    valid uuids). The org join is varchar=text, no cast needed.
+    """
+    return """
+    SELECT l.id AS location_id,
+           lo.org_id AS recovered_org_id,
+           lo.version_num AS source_version_num
+    FROM location l
+    CROSS JOIN LATERAL (
+        SELECT rv.data->>'organization_id' AS org_id,
+               rv.version_num
+        FROM record_version rv
+        WHERE rv.record_id = l.id::uuid
+          AND rv.record_type = 'location'
+          AND COALESCE(rv.data->>'organization_id', '') <> ''
+        ORDER BY rv.version_num DESC
+        LIMIT 1
+    ) lo
+    JOIN organization o ON o.id = lo.org_id
+    WHERE l.organization_id IS NULL
+      AND l.is_canonical = TRUE
+      AND (l.verified_by IS NULL OR l.verified_by NOT IN :human_verified)
+    ORDER BY l.id
+    """
+
+
+def find_candidates(db: Session) -> list[dict[str, Any]]:
+    """Return all recoverable NULL-org canonical rows (deterministic order)."""
+    rows = db.execute(
+        text(candidate_sql()).bindparams(bindparam("human_verified", expanding=True)),
+        {"human_verified": list(_HUMAN_VERIFIED)},
+    ).fetchall()
+    return [
+        {
+            "location_id": str(r.location_id),
+            "recovered_org_id": str(r.recovered_org_id),
+            "source_version_num": (
+                int(r.source_version_num) if r.source_version_num is not None else None
+            ),
+        }
+        for r in rows
+    ]
+
+
+def total_null_org_canonical(db: Session) -> int:
+    """Count all NULL-org canonical rows (recoverable or not) for diagnostics."""
+    row = db.execute(
+        text(
+            """
+            SELECT COUNT(*) FROM location
+            WHERE organization_id IS NULL AND is_canonical = TRUE
+            """
+        )
+    ).first()
+    if row is None:
+        raise RuntimeError(
+            "null-org count returned no row — COUNT always returns one, so the "
+            "query failed to execute. Check DB connectivity before retrying."
+        )
+    return int(row[0])
+
+
+def _log_audit(
+    db: Session,
+    *,
+    run_id: str,
+    location_id: str,
+    old_org: str | None,
+    new_org: str,
+    source_version_num: int | None,
+    action: str = "org_fill",
+) -> None:
+    """Append one audit row BEFORE the mutation, so a failed mutation rolls the
+    audit row back with it inside the same savepoint."""
+    db.execute(
+        text(
+            """
+            INSERT INTO org_backfill_audit (
+                run_id, location_id, old_organization_id,
+                new_organization_id, source_version_num, action
+            )
+            VALUES (:run_id, :location_id, :old_org, :new_org, :ver, :action)
+            """
+        ),
+        {
+            "run_id": run_id,
+            "location_id": location_id,
+            "old_org": old_org,
+            "new_org": new_org,
+            "ver": source_version_num,
+            "action": action,
+        },
+    )
+
+
+def fill_org(db: Session, candidate: dict[str, Any], run_id: str) -> bool:
+    """Fill one location's org link (guarded). Returns True if a row changed.
+
+    The UPDATE re-checks `organization_id IS NULL` and the `verified_by` guard,
+    so a row that gained an org or human curation between candidate selection
+    and now is left untouched (rowcount 0)."""
+    loc_id = candidate["location_id"]
+    new_org = candidate["recovered_org_id"]
+    _log_audit(
+        db,
+        run_id=run_id,
+        location_id=loc_id,
+        old_org=None,
+        new_org=new_org,
+        source_version_num=candidate["source_version_num"],
+    )
+    result = db.execute(
+        text(
+            """
+            UPDATE location
+            SET organization_id = :new_org
+            WHERE id = :loc_id
+              AND organization_id IS NULL
+              AND is_canonical = TRUE
+              AND (verified_by IS NULL OR verified_by NOT IN :human_verified)
+            """
+        ).bindparams(bindparam("human_verified", expanding=True)),
+        {
+            "new_org": new_org,
+            "loc_id": loc_id,
+            "human_verified": list(_HUMAN_VERIFIED),
+        },
+    )
+    return result.rowcount > 0
+
+
+def undo_run(db: Session, run_id: str, apply: bool) -> int:
+    """Reverse a backfill run: re-NULL only the rows that still hold the org
+    this run wrote AND are still not human-curated (so a human edit made after
+    the backfill is never clobbered). Returns the count reverted (or that would
+    be reverted in dry-run)."""
+    audit_rows = db.execute(
+        text(
+            """
+            SELECT location_id, new_organization_id
+            FROM org_backfill_audit
+            WHERE run_id = :run_id AND action = 'org_fill'
+            """
+        ),
+        {"run_id": run_id},
+    ).fetchall()
+    if not audit_rows:
+        logger.warning("No 'org_fill' audit rows for run_id=%s", run_id)
+        return 0
+
+    reverted = 0
+    for ar in audit_rows:
+        loc_id = str(ar.location_id)
+        org = str(ar.new_organization_id)
+        result = db.execute(
+            text(
+                """
+                UPDATE location
+                SET organization_id = NULL
+                WHERE id = :loc_id
+                  AND organization_id = :org
+                  AND (verified_by IS NULL OR verified_by NOT IN :human_verified)
+                """
+            ).bindparams(bindparam("human_verified", expanding=True)),
+            {"loc_id": loc_id, "org": org, "human_verified": list(_HUMAN_VERIFIED)},
+        )
+        if result.rowcount > 0:
+            reverted += 1
+            if apply:
+                _log_audit(
+                    db,
+                    run_id=run_id,
+                    location_id=loc_id,
+                    old_org=org,
+                    new_org=org,
+                    source_version_num=None,
+                    action="undo",
+                )
+    return reverted
+
+
+def _dump_sample(db: Session, candidates: list[dict[str, Any]], n: int) -> None:
+    """Print N random candidates' before-state for the operator to eyeball.
+    Dry-run only — never commits."""
+    sample = random.sample(candidates, min(n, len(candidates)))  # noqa: S311
+    for cand in sample:
+        row = db.execute(
+            text(
+                """
+                SELECT id, name, organization_id, confidence_score,
+                       verified_by, is_canonical
+                FROM location WHERE id = :id
+                """
+            ),
+            {"id": cand["location_id"]},
+        ).first()
+        org = db.execute(
+            text("SELECT id, name FROM organization WHERE id = :id"),
+            {"id": cand["recovered_org_id"]},
+        ).first()
+        payload = {
+            "location": dict(row._mapping) if row else None,
+            "would_set_org": dict(org._mapping) if org else cand["recovered_org_id"],
+            "source_version_num": cand["source_version_num"],
+        }
+        print(json.dumps(payload, default=str, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="Commit changes (default: dry-run)."
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=None,
+        help=(
+            "Cap the number of rows touched (staged rollout: 50, then 500, then "
+            "full). Candidates are processed in stable id order so a re-run "
+            "with the same cap touches the same rows."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run-sample",
+        type=int,
+        default=0,
+        help="Print N random candidates' before-state (dry-run only).",
+    )
+    parser.add_argument(
+        "--skip-freshness-check",
+        action="store_true",
+        help="Skip the HAARRRvest freshness pre-flight (emergencies only).",
+    )
+    parser.add_argument(
+        "--undo-run-id",
+        type=str,
+        default=None,
+        help="Reverse a prior run by its run_id instead of running a backfill.",
+    )
+    args = parser.parse_args()
+
+    engine = create_engine(settings.DATABASE_URL)
+    session_local = sessionmaker(bind=engine)
+
+    with session_local() as db:
+        # ---- Undo path ----
+        if args.undo_run_id:
+            if args.apply:
+                ensure_audit_table(db)
+                db.commit()
+            reverted = undo_run(db, args.undo_run_id, args.apply)
+            if args.apply:
+                db.commit()
+                logger.info(
+                    "UNDO committed for run_id=%s: %d rows re-NULLed",
+                    args.undo_run_id,
+                    reverted,
+                )
+            else:
+                logger.info(
+                    "UNDO dry-run for run_id=%s: %d rows WOULD be re-NULLed "
+                    "(pass --apply to commit)",
+                    args.undo_run_id,
+                    reverted,
+                )
+            return 0
+
+        # ---- Backfill path ----
+        # Pre-flight: HAARRRvest freshness (apply only; dry-run is harmless).
+        if args.apply and not args.skip_freshness_check:
+            if not check_haarrrvest_freshness(db):
+                logger.error(
+                    "Pre-flight failed: no record_version rows in the last 12h. "
+                    "The most recent rollback target is stale. Let HAARRRvest "
+                    "publish, take a manual Aurora snapshot, or pass "
+                    "--skip-freshness-check."
+                )
+                return 2
+
+        run_id = str(uuid.uuid4())
+        logger.info("Run id: %s", run_id)
+
+        total_null = total_null_org_canonical(db)
+        candidates = find_candidates(db)
+        logger.info(
+            "Diagnostic: %d NULL-org canonical rows; %d recoverable from "
+            "record_version (%d excluded: no org-carrying version, stale org "
+            "FK, or human-curated)",
+            total_null,
+            len(candidates),
+            total_null - len(candidates),
+        )
+
+        if not candidates:
+            logger.info("Nothing to backfill.")
+            return 0
+
+        if not args.apply and args.dry_run_sample > 0:
+            _dump_sample(db, candidates, args.dry_run_sample)
+
+        if args.max_rows is not None:
+            candidates = candidates[: args.max_rows]
+            logger.info("Capped to first %d candidates via --max-rows", len(candidates))
+
+        if args.apply:
+            ensure_audit_table(db)
+            db.commit()
+
+        filled = 0
+        skipped = 0
+        failed = 0
+        for cand in candidates:
+            if not args.apply:
+                filled += 1  # dry-run: count what WOULD be filled
+                continue
+            # Per-row savepoint so one failure doesn't roll back the run.
+            savepoint = db.begin_nested()
+            try:
+                if fill_org(db, cand, run_id):
+                    filled += 1
+                else:
+                    skipped += 1  # raced: gained org or human curation
+                savepoint.commit()
+            except Exception as e:
+                savepoint.rollback()
+                failed += 1
+                logger.warning(
+                    "fill_failed location_id=%s error=%s",
+                    cand["location_id"],
+                    e,
+                )
+
+        if args.apply:
+            db.commit()
+            logger.info(
+                "APPLY committed (run_id=%s): filled=%d skipped=%d failed=%d",
+                run_id,
+                filled,
+                skipped,
+                failed,
+            )
+        else:
+            logger.info(
+                "DRY-RUN: %d rows WOULD be filled (pass --apply to commit)",
+                filled,
+            )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_null_org_from_record_version.py
+++ b/tests/test_backfill_null_org_from_record_version.py
@@ -1,0 +1,428 @@
+"""Tests for scripts/backfill_null_org_from_record_version.py.
+
+Recovers organization_id for NULL-org canonical locations from the latest
+record_version snapshot. These run against the real Postgres test DB (mirrors
+tests/test_dedupe_near_duplicate_locations.py)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+# Top-level tests/conftest provides the async db_session; we need the sync one.
+from tests.fixtures.db import db_session_sync as db_session  # noqa: F401
+
+from scripts.backfill_null_org_from_record_version import (
+    ensure_audit_table,
+    fill_org,
+    find_candidates,
+    total_null_org_canonical,
+    undo_run,
+)
+
+
+@pytest.fixture
+def clean_tables(
+    db_session: Session,  # noqa: F811
+) -> Generator[Session, None, None]:
+    """Wipe the tables this backfill touches before each test."""
+    db_session.execute(text("TRUNCATE TABLE record_version CASCADE"))
+    db_session.execute(text("TRUNCATE TABLE location CASCADE"))
+    db_session.execute(text("TRUNCATE TABLE organization CASCADE"))
+    db_session.commit()
+    ensure_audit_table(db_session)
+    db_session.execute(text("TRUNCATE TABLE org_backfill_audit"))
+    db_session.commit()
+    yield db_session
+
+
+def _seed_org(db: Session, org_id: str, name: str = "Org") -> str:
+    db.execute(
+        text(
+            """
+            INSERT INTO organization (id, name, description)
+            VALUES (:id, :name, 'backfill-test org')
+            ON CONFLICT (id) DO NOTHING
+            """
+        ),
+        {"id": org_id, "name": name},
+    )
+    return org_id
+
+
+def _seed_location(
+    db: Session,
+    *,
+    loc_id: str,
+    org_id: str | None,
+    is_canonical: bool = True,
+    verified_by: str | None = None,
+) -> None:
+    db.execute(
+        text(
+            """
+            INSERT INTO location (
+                id, organization_id, name, latitude, longitude,
+                location_type, validation_status, confidence_score,
+                is_canonical, verified_by
+            )
+            VALUES (:id, :org, 'Pantry', 40.0, -75.0,
+                    'physical', 'verified', 70, :canon, :verified_by)
+            """
+        ),
+        {
+            "id": loc_id,
+            "org": org_id,
+            "canon": is_canonical,
+            "verified_by": verified_by,
+        },
+    )
+
+
+def _seed_version(
+    db: Session,
+    *,
+    loc_id: str,
+    version_num: int,
+    org_in_data: str | None,
+) -> None:
+    """Insert one record_version row for a location, optionally carrying an
+    organization_id in its data jsonb."""
+    data: dict[str, object] = {"name": "Pantry"}
+    if org_in_data is not None:
+        data["organization_id"] = org_in_data
+    db.execute(
+        text(
+            """
+            INSERT INTO record_version (
+                id, record_id, record_type, version_num, data, created_by
+            )
+            VALUES (:id, :rid, 'location', :ver, CAST(:data AS jsonb), 'reconciler')
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "rid": loc_id,
+            "ver": version_num,
+            "data": json.dumps(data),
+        },
+    )
+
+
+def _org_of(db: Session, loc_id: str) -> str | None:
+    row = db.execute(
+        text("SELECT organization_id FROM location WHERE id = :id"),
+        {"id": loc_id},
+    ).first()
+    return str(row[0]) if row and row[0] else None
+
+
+class TestFindCandidates:
+    def test_recoverable_null_org_is_a_candidate(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+
+        cands = find_candidates(db)
+        assert len(cands) == 1
+        assert cands[0]["location_id"] == loc
+        assert cands[0]["recovered_org_id"] == org
+        assert cands[0]["source_version_num"] == 1
+
+    def test_picks_latest_version_org(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org_a = _seed_org(db, str(uuid.uuid4()), "A")
+        org_b = _seed_org(db, str(uuid.uuid4()), "B")
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org_a)
+        _seed_version(db, loc_id=loc, version_num=2, org_in_data=org_b)
+        db.commit()
+
+        cands = find_candidates(db)
+        assert len(cands) == 1
+        # Highest version_num wins.
+        assert cands[0]["recovered_org_id"] == org_b
+        assert cands[0]["source_version_num"] == 2
+
+    def test_no_version_with_org_excluded(self, clean_tables: Session) -> None:
+        db = clean_tables
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=None)
+        db.commit()
+
+        assert find_candidates(db) == []
+
+    def test_org_no_longer_exists_excluded(self, clean_tables: Session) -> None:
+        db = clean_tables
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        # Version references an org id that was never inserted (stale FK).
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=str(uuid.uuid4()))
+        db.commit()
+
+        assert find_candidates(db) == []
+
+    def test_human_verified_excluded(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None, verified_by="admin")
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+
+        assert find_candidates(db) == []
+
+    def test_noncanonical_excluded(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None, is_canonical=False)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+
+        assert find_candidates(db) == []
+
+    def test_already_has_org_excluded(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=org)  # already linked
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+
+        assert find_candidates(db) == []
+        assert total_null_org_canonical(db) == 0
+
+
+class TestFillOrg:
+    def test_fill_sets_org_and_writes_audit(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+
+        run_id = str(uuid.uuid4())
+        cand = find_candidates(db)[0]
+        changed = fill_org(db, cand, run_id)
+        db.commit()
+
+        assert changed is True
+        assert _org_of(db, loc) == org
+        audit = db.execute(
+            text(
+                """
+                SELECT location_id, old_organization_id, new_organization_id, action
+                FROM org_backfill_audit WHERE run_id = :rid
+                """
+            ),
+            {"rid": run_id},
+        ).fetchall()
+        assert len(audit) == 1
+        assert str(audit[0].location_id) == loc
+        assert audit[0].old_organization_id is None
+        assert str(audit[0].new_organization_id) == org
+        assert audit[0].action == "org_fill"
+
+    def test_fill_guard_skips_row_that_gained_org(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        other = _seed_org(db, str(uuid.uuid4()), "Other")
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+        cand = find_candidates(db)[0]
+
+        # Simulate a concurrent writer linking the org before we apply.
+        db.execute(
+            text("UPDATE location SET organization_id = :o WHERE id = :id"),
+            {"o": other, "id": loc},
+        )
+        db.commit()
+
+        changed = fill_org(db, cand, str(uuid.uuid4()))
+        db.commit()
+        assert changed is False
+        assert _org_of(db, loc) == other  # untouched
+
+    def test_fill_guard_skips_human_verified(self, clean_tables: Session) -> None:
+        db = clean_tables
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        # Candidate selection would exclude this, but fill_org's own guard is
+        # defense-in-depth — verify it independently.
+        _seed_location(db, loc_id=loc, org_id=None, verified_by="claimed")
+        db.commit()
+
+        cand = {
+            "location_id": loc,
+            "recovered_org_id": org,
+            "source_version_num": 1,
+        }
+        changed = fill_org(db, cand, str(uuid.uuid4()))
+        db.commit()
+        assert changed is False
+        assert _org_of(db, loc) is None
+
+
+class TestUndo:
+    def _fill_one(self, db: Session) -> tuple[str, str, str]:
+        org = _seed_org(db, str(uuid.uuid4()))
+        loc = str(uuid.uuid4())
+        _seed_location(db, loc_id=loc, org_id=None)
+        _seed_version(db, loc_id=loc, version_num=1, org_in_data=org)
+        db.commit()
+        run_id = str(uuid.uuid4())
+        fill_org(db, find_candidates(db)[0], run_id)
+        db.commit()
+        return run_id, loc, org
+
+    def test_undo_renulls_filled_rows(self, clean_tables: Session) -> None:
+        db = clean_tables
+        run_id, loc, org = self._fill_one(db)
+        assert _org_of(db, loc) == org
+
+        reverted = undo_run(db, run_id, apply=True)
+        db.commit()
+        assert reverted == 1
+        assert _org_of(db, loc) is None
+
+    def test_undo_dry_run_changes_nothing(self, clean_tables: Session) -> None:
+        db = clean_tables
+        run_id, loc, org = self._fill_one(db)
+
+        reverted = undo_run(db, run_id, apply=False)
+        db.rollback()
+        assert reverted == 1  # would-revert count
+        assert _org_of(db, loc) == org  # unchanged
+
+    def test_undo_skips_if_human_curated_after_fill(
+        self, clean_tables: Session
+    ) -> None:
+        db = clean_tables
+        run_id, loc, org = self._fill_one(db)
+        # A human curates the row after the backfill.
+        db.execute(
+            text("UPDATE location SET verified_by = 'admin' WHERE id = :id"),
+            {"id": loc},
+        )
+        db.commit()
+
+        reverted = undo_run(db, run_id, apply=True)
+        db.commit()
+        assert reverted == 0
+        assert _org_of(db, loc) == org  # human-curated row preserved
+
+    def test_undo_skips_if_org_changed_after_fill(self, clean_tables: Session) -> None:
+        db = clean_tables
+        run_id, loc, _org = self._fill_one(db)
+        other = _seed_org(db, str(uuid.uuid4()), "Other")
+        db.execute(
+            text("UPDATE location SET organization_id = :o WHERE id = :id"),
+            {"o": other, "id": loc},
+        )
+        db.commit()
+
+        reverted = undo_run(db, run_id, apply=True)
+        db.commit()
+        assert reverted == 0
+        assert _org_of(db, loc) == other  # not clobbered back to NULL
+
+    def test_undo_writes_undo_audit_row(self, clean_tables: Session) -> None:
+        db = clean_tables
+        run_id, loc, org = self._fill_one(db)
+        undo_run(db, run_id, apply=True)
+        db.commit()
+
+        row = db.execute(
+            text(
+                """
+                SELECT location_id, old_organization_id, new_organization_id
+                FROM org_backfill_audit
+                WHERE run_id = :rid AND action = 'undo'
+                """
+            ),
+            {"rid": run_id},
+        ).fetchall()
+        assert len(row) == 1
+        assert str(row[0].location_id) == loc
+        # By design the undo audit row records old==new==the reverted org.
+        assert str(row[0].old_organization_id) == org
+        assert str(row[0].new_organization_id) == org
+
+    def test_undo_unknown_run_id_is_noop(self, clean_tables: Session) -> None:
+        db = clean_tables
+        _run_id, loc, org = self._fill_one(db)
+        reverted = undo_run(db, str(uuid.uuid4()), apply=True)  # never used
+        db.commit()
+        assert reverted == 0
+        assert _org_of(db, loc) == org  # the real fill untouched
+
+    def test_undo_only_affects_its_own_run(self, clean_tables: Session) -> None:
+        db = clean_tables
+        run_a, loc_a, org_a = self._fill_one(db)
+        run_b, loc_b, org_b = self._fill_one(db)
+
+        reverted = undo_run(db, run_a, apply=True)
+        db.commit()
+        assert reverted == 1
+        assert _org_of(db, loc_a) is None  # run A reverted
+        assert _org_of(db, loc_b) == org_b  # run B untouched
+
+
+class TestStableOrderAndCap:
+    """The --max-rows staged rollout relies on find_candidates returning a
+    stable id order so a re-run with the same cap touches the same rows."""
+
+    def test_candidates_returned_in_stable_id_order(
+        self, clean_tables: Session
+    ) -> None:
+        db = clean_tables
+        # Controlled, sortable ids so the ORDER BY l.id contract is assertable.
+        ids = [f"00000000-0000-0000-0000-0000000000{n:02d}" for n in (3, 1, 2)]
+        for i in ids:
+            org = _seed_org(db, str(uuid.uuid4()))
+            _seed_location(db, loc_id=i, org_id=None)
+            _seed_version(db, loc_id=i, version_num=1, org_in_data=org)
+        db.commit()
+
+        cands = find_candidates(db)
+        returned = [c["location_id"] for c in cands]
+        assert returned == sorted(ids)  # deterministic ascending id order
+        # The --max-rows 2 slice is the first 2 in that stable order.
+        assert returned[:2] == sorted(ids)[:2]
+
+
+class TestFreshnessPreflight:
+    def test_freshness_false_when_no_recent_version(
+        self, clean_tables: Session
+    ) -> None:
+        from scripts.backfill_null_org_from_record_version import (
+            check_haarrrvest_freshness,
+        )
+
+        db = clean_tables  # record_version truncated by the fixture
+        assert check_haarrrvest_freshness(db) is False
+
+    def test_freshness_true_with_recent_version(self, clean_tables: Session) -> None:
+        from scripts.backfill_null_org_from_record_version import (
+            check_haarrrvest_freshness,
+        )
+
+        db = clean_tables
+        # A freshly-inserted record_version (created_at defaults to NOW()).
+        _seed_version(db, loc_id=str(uuid.uuid4()), version_num=1, org_in_data=None)
+        db.commit()
+        assert check_haarrrvest_freshness(db) is True


### PR DESCRIPTION
## What

One-shot backfill that restores `organization_id` on the ~**6,906** canonical locations whose org link was NULLed by the historical SUB-1 bug class, recovering each org from `record_version`.

This is the **data cleanup** counterpart to the **code fixes** that stop the bleeding — #499 (submarine stops NULLing org) and #510 (reconciler matched path is org fill-only). One PR per concern, per the audit's delivery workflow.

> ## ⚠️ Operational ordering
> **Apply in prod only AFTER #499 and #510 merge + deploy.** The wipe came from the submarine/scraper update paths; if this runs while those still NULL the org on the next pass, the restored links get wiped again. **Dry-run is safe any time.**

## Blast radius (re-verified against prod, DB 166)
- **6,906** NULL-org canonical rows (matches the audit figure exactly).
- `record_version.data` carries org in 121k location versions; **`location_source` has no org column** → record_version is the *only* recovery source.
- Recovery verified on a live row: `00085306…` → org `200943ca…`, which **still exists** (valid FK).
- **Not all 6,906 are recoverable** — a 5-row prod sample had only 1 with an org in any version. Unrecoverable rows are skipped and reported; the **dry-run prints the exact recoverable count**.

## How it works
Recovers each row's org from the **highest-`version_num`** location `record_version` whose `organization_id` is non-empty **and still exists** in `organization` (no stale FK), excluding human-curated rows. Then a guarded `UPDATE`:

- **Fill-only:** `WHERE organization_id IS NULL` — never overwrites or flips an existing link.
- **Owner-protected (defense in depth):** `verified_by NOT IN (admin,source,claimed)` in **both** the candidate query and the UPDATE.
- **Per-row savepoint** so one failure can't roll back the run.
- **Parameterized SQL only**; the LATERAL casts `l.id::uuid` (location.id is varchar, record_version.record_id is uuid) to keep the `record_version(record_id,version_num)` index usable.

Mirrors the dedup-backfill runbook: **dry-run by default**, `--apply` to commit, `--max-rows` for staged rollout (stable id order), HAARRRvest freshness pre-flight, lazy `org_backfill_audit` table, and **`--undo-run-id`** for exact reversal (re-NULLs only rows that still hold the value this run wrote AND are still not human-curated — never clobbers a later human edit or a different org).

```
# staged rollout (after #499 + #510 deploy):
./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py            # dry-run
./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --max-rows 50 --apply
./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --max-rows 500 --apply
./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --apply
# reverse a run:
./bouy run-script --aws --prod scripts/backfill_null_org_from_record_version.py --undo-run-id <uuid> --apply
```

## Verification & tests
Designed and adversarially reviewed via multi-agent workflows (blast radius re-verified against prod; all data-safety invariants confirmed — fill-only, owner-protection in both query and UPDATE, latest-version recovery, stale-FK exclusion, exact reversibility).

**TDD: 20 tests** — candidate selection (recoverable; latest-version pick; stale-FK / human-curated / non-canonical / already-linked exclusions), fill guard (concurrent-org and human-curated skips + audit row), undo (revert / dry-run / skip-after-human-edit / skip-after-org-change / undo-audit-row / unknown-run no-op / own-run isolation), stable id order for `--max-rows`, and the HAARRRvest freshness pre-flight.

`20 passed`. black ✓ ruff ✓. `scripts/` is out of CI mypy + bandit scope (consistent with the sibling `dedupe_near_duplicate_locations.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)