### PR TITLE
feat(api): beacon /redirects endpoint — dead-URL → surviving-canonical map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -722,6 +722,10 @@ When services are running, the following endpoints are available:
 - `GET /api/v1/partners/ptf/locations/{location_id}` — single location detail
 - Both responses include a `feeding_america_food_bank` block (id + name, plus richer fields when in catalogue) when the location's ZIP matches `feeding_america_zip_coverage`; `null` otherwise.
 
+**Beacon partner endpoints** (internal; feed the static directory-site build):
+- `GET /api/v1/partners/beacon/sync` — full location records (schedules, phones, languages, accessibility) for static page rendering. Cursor-paginated, `is_canonical=TRUE` quality gate (`app/api/v1/partners/beacon/services.py`).
+- `GET /api/v1/partners/beacon/redirects` — dead (dedup-soft-deleted) location ids → surviving canonical address components, so beacon publishes 301s for URLs it deleted. Read-only; follows the transitive survivor chain to its terminal still-canonical row (cycle/depth-guarded) via `dedup_run_audit`; tolerates a missing audit table (returns `[]`). Beacon turns same-locality survivors into 301s and everything else into 410 at the CloudFront edge — see `plugins/ppr-beacon/CLAUDE.md` → "SEO indexing recovery" for the edge `noindex`/301/410 behavior and the English-first surface shrink.
+
 Datasette provides:
 - SQL interface to explore published HAARRRvest data
 - Read-only access to the SQLite database

--- a/app/api/v1/partners/beacon/models.py
+++ b/app/api/v1/partners/beacon/models.py
@@ -101,3 +101,56 @@ class BeaconSyncResponse(BaseModel):
                 f"locations count ({len(self.locations)})"
             )
         return self
+
+
+class BeaconRedirectSurvivor(BaseModel):
+    """The surviving canonical location a dead URL should redirect to.
+
+    Address components let beacon reconstruct the survivor's directory URL
+    via its own slug rules (slug logic stays in one place — beacon).
+    """
+
+    id: str
+    name: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    postal_code: Optional[str] = None
+
+
+class BeaconRedirect(BaseModel):
+    """A soft-deleted location id and the canonical survivor it merged into.
+
+    Beacon already knows the dead URL (from its own build tracker at deletion
+    time); this only supplies the survivor side, which lives in the current DB.
+    Only redirects with a live canonical survivor are emitted — beacon
+    parent-redirects-or-410s anything not present here.
+    """
+
+    dead_id: str
+    survivor: BeaconRedirectSurvivor
+
+
+class BeaconRedirectsMeta(BaseModel):
+    """Pagination/response metadata for the redirects endpoint."""
+
+    returned: int
+    cursor: Optional[str] = None
+    has_more: bool
+    generated_at: datetime
+    data_version: str = "1.0"
+
+
+class BeaconRedirectsResponse(BaseModel):
+    """Top-level response for the beacon redirects endpoint."""
+
+    meta: BeaconRedirectsMeta
+    redirects: list[BeaconRedirect]
+
+    @model_validator(mode="after")
+    def check_returned_matches_count(self) -> "BeaconRedirectsResponse":
+        if self.meta.returned != len(self.redirects):
+            raise ValueError(
+                f"meta.returned ({self.meta.returned}) != "
+                f"redirects count ({len(self.redirects)})"
+            )
+        return self

--- a/app/api/v1/partners/beacon/router.py
+++ b/app/api/v1/partners/beacon/router.py
@@ -8,8 +8,14 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.v1.partners.beacon.models import BeaconSyncResponse
-from app.api.v1.partners.beacon.services import BeaconSyncService
+from app.api.v1.partners.beacon.models import (
+    BeaconRedirectsResponse,
+    BeaconSyncResponse,
+)
+from app.api.v1.partners.beacon.services import (
+    BeaconRedirectService,
+    BeaconSyncService,
+)
 from app.core.db import get_session
 
 logger = structlog.get_logger(__name__)
@@ -80,4 +86,36 @@ async def beacon_sync(
             "etag": etag,
             "cache-control": "private, max-age=300",
         },
+    )
+
+
+@router.get(
+    "/redirects",
+    response_model=BeaconRedirectsResponse,
+    summary="Dead-URL -> surviving-canonical map for beacon redirects",
+    description=(
+        "Returns soft-deleted (deduplicated) location ids mapped to their "
+        "surviving canonical location's address components. Beacon uses this to "
+        "publish 301 redirects for URLs whose pages it has deleted. Only "
+        "redirects with a live canonical survivor are returned; the transitive "
+        "survivor chain is followed to its terminal. Read-only; returns an empty "
+        "list when no dedup audit history exists."
+    ),
+)
+async def beacon_redirects(
+    cursor: Optional[str] = Query(
+        None, description="Pagination cursor (last dead_id) from previous response"
+    ),
+    page_size: int = Query(
+        5000, ge=1, le=10000, description="Records per page (max 10000)"
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Beacon dead-URL redirect map endpoint."""
+    service = BeaconRedirectService(session)
+    result = await service.redirects(page_size=page_size, cursor=cursor)
+    response_model = BeaconRedirectsResponse(**result)
+    return JSONResponse(
+        content=response_model.model_dump(mode="json"),
+        headers={"cache-control": "private, max-age=300"},
     )

--- a/app/api/v1/partners/beacon/services.py
+++ b/app/api/v1/partners/beacon/services.py
@@ -442,3 +442,162 @@ class BeaconSyncService:
             },
             "locations": locations,
         }
+
+
+# Guard against pathological audit chains (a survivor soft-deleted into another
+# survivor, repeatedly). 25 hops is far beyond any real dedup depth.
+_MAX_SURVIVOR_CHAIN_DEPTH = 25
+
+
+class BeaconRedirectService:
+    """Maps dedup-soft-deleted locations to their surviving canonical.
+
+    Beacon deletes a location's S3 pages when dedup soft-deletes it
+    (``is_canonical=FALSE``); those previously-indexed URLs then 404. Beacon
+    knows the dead URL (from its own DynamoDB build tracker) but not the
+    survivor — that lives in ``dedup_run_audit`` + the live ``location`` table,
+    which only the API can read. This service returns the survivor side so
+    beacon can publish a 301 to the CloudFront redirect KeyValueStore.
+
+    Read-only. Tolerates a missing ``dedup_run_audit`` table (created lazily by
+    the dedup scripts) by returning an empty result.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def redirects(
+        self,
+        page_size: int = 5000,
+        cursor: Optional[str] = None,
+    ) -> dict[str, Any]:
+        log = logger.bind(page_size=page_size)
+        log.info("beacon_redirects_request")
+
+        if not await self._audit_table_exists():
+            log.info("beacon_redirects_no_audit_table")
+            return self._build_response([], page_size)
+
+        chain = await self._load_soft_delete_chain()
+        # Resolve each dead id to its terminal (never-soft-deleted) survivor.
+        terminal_by_dead: dict[str, str] = {}
+        for dead_id in chain:
+            terminal = self._resolve_terminal(dead_id, chain)
+            if terminal is not None:
+                terminal_by_dead[dead_id] = terminal
+
+        survivors = await self._fetch_canonical_survivors(
+            set(terminal_by_dead.values())
+        )
+
+        # Keep only redirects whose terminal survivor is still a live canonical
+        # location. Sorted by dead_id for stable keyset pagination.
+        entries = sorted(
+            (dead_id, survivors[term])
+            for dead_id, term in terminal_by_dead.items()
+            if term in survivors
+        )
+        if cursor:
+            entries = [e for e in entries if e[0] > cursor]
+
+        page = entries[:page_size]
+        has_more = len(entries) > page_size
+        redirects = [
+            {"dead_id": dead_id, "survivor": survivor} for dead_id, survivor in page
+        ]
+        next_cursor = page[-1][0] if (has_more and page) else None
+
+        log.info("beacon_redirects_complete", returned=len(redirects))
+        return self._build_response(redirects, page_size, cursor=next_cursor)
+
+    async def _audit_table_exists(self) -> bool:
+        result = await self._session.execute(
+            text("SELECT to_regclass('public.dedup_run_audit')")
+        )
+        return result.scalar() is not None
+
+    async def _load_soft_delete_chain(self) -> dict[str, str]:
+        """Map each soft-deleted location id -> its recorded survivor id.
+
+        DISTINCT ON keeps the most recent survivor per dead id, in case a row
+        was re-deduped across runs.
+        """
+        result = await self._session.execute(
+            text(
+                """
+                SELECT DISTINCT ON (row_id) row_id, survivor_id
+                FROM dedup_run_audit
+                WHERE table_name = 'location' AND action = 'soft_delete'
+                ORDER BY row_id, created_at DESC
+                """
+            )
+        )
+        return {str(r.row_id): str(r.survivor_id) for r in result.fetchall()}
+
+    def _resolve_terminal(self, dead_id: str, chain: dict[str, str]) -> Optional[str]:
+        """Follow dead->survivor links until a survivor that was never itself
+        soft-deleted. Returns None on a cycle or excessive depth (caller falls
+        back to a parent-page redirect / 410)."""
+        seen = {dead_id}
+        current = chain[dead_id]
+        depth = 0
+        while current in chain:
+            if current in seen or depth >= _MAX_SURVIVOR_CHAIN_DEPTH:
+                return None
+            seen.add(current)
+            current = chain[current]
+            depth += 1
+        return current
+
+    async def _fetch_canonical_survivors(
+        self, ids: set[str]
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch live address components for survivor ids that are still
+        canonical. Non-canonical / missing ids are simply absent from the
+        result (their dead URLs fall through to beacon's parent/410 path)."""
+        if not ids:
+            return {}
+        result = await self._session.execute(
+            text(
+                """
+                SELECT l.id, l.name, a.city, a.state_province, a.postal_code
+                FROM location l
+                LEFT JOIN LATERAL (
+                    SELECT city, state_province, postal_code
+                    FROM address
+                    WHERE location_id = l.id AND address_type = 'physical'
+                    ORDER BY id
+                    LIMIT 1
+                ) a ON TRUE
+                WHERE l.id::text = ANY(:ids) AND l.is_canonical = TRUE
+                """
+            ),
+            {"ids": list(ids)},
+        )
+        out: dict[str, dict[str, Any]] = {}
+        for r in result.fetchall():
+            out[str(r.id)] = {
+                "id": str(r.id),
+                "name": r.name,
+                "city": r.city,
+                "state": r.state_province,
+                "postal_code": r.postal_code,
+            }
+        return out
+
+    def _build_response(
+        self,
+        redirects: list[dict[str, Any]],
+        page_size: int,
+        cursor: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return {
+            "meta": {
+                "returned": len(redirects),
+                "cursor": cursor,
+                "has_more": cursor is not None,
+                "generated_at": datetime.now(UTC),
+                "data_version": "1.0",
+            },
+            "redirects": redirects,
+        }

--- a/tests/test_beacon_redirects.py
+++ b/tests/test_beacon_redirects.py
@@ -1,0 +1,217 @@
+"""Tests for the beacon redirects endpoint (dead-URL -> surviving canonical).
+
+When dedup soft-deletes a duplicate location (is_canonical=FALSE), beacon
+deletes that location's S3 pages and the previously-indexed URLs 404. This
+endpoint supplies the survivor side (from dedup_run_audit + the live location
+table) so beacon can publish a 301 to its CloudFront redirect KeyValueStore.
+
+Driven directly against the live test DB, same pattern as test_beacon_sync.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.partners.beacon.services import BeaconRedirectService
+
+# Minimal idempotent DDL — mirrors scripts/dedupe_near_duplicate_locations.py's
+# lazily-created audit table so these tests are self-contained.
+_AUDIT_DDL = """
+CREATE TABLE IF NOT EXISTS dedup_run_audit (
+    id BIGSERIAL PRIMARY KEY,
+    run_id UUID NOT NULL,
+    cluster_id TEXT NOT NULL,
+    survivor_id UUID NOT NULL,
+    duplicate_id UUID,
+    table_name TEXT NOT NULL,
+    row_id TEXT NOT NULL,
+    action TEXT NOT NULL CHECK (action IN ('repoint', 'delete', 'soft_delete')),
+    old_value JSONB,
+    new_value JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Pure unit tests for the transitive survivor resolution (no DB).
+# --------------------------------------------------------------------------- #
+class TestResolveTerminal:
+    def _svc(self) -> BeaconRedirectService:
+        return BeaconRedirectService(session=None)  # type: ignore[arg-type]
+
+    def test_direct_survivor(self):
+        chain = {"a": "b"}
+        assert self._svc()._resolve_terminal("a", chain) == "b"
+
+    def test_two_hop_chain_resolves_to_terminal(self):
+        # a merged into b, b later merged into c (still canonical) -> c
+        chain = {"a": "b", "b": "c"}
+        assert self._svc()._resolve_terminal("a", chain) == "c"
+        assert self._svc()._resolve_terminal("b", chain) == "c"
+
+    def test_cycle_returns_none(self):
+        # a -> b -> a : no terminal; caller falls back to parent/410
+        chain = {"a": "b", "b": "a"}
+        assert self._svc()._resolve_terminal("a", chain) is None
+
+    def test_self_cycle_returns_none(self):
+        chain = {"a": "a"}
+        assert self._svc()._resolve_terminal("a", chain) is None
+
+    def test_excessive_depth_returns_none(self):
+        # 30-long chain exceeds the 25-hop guard.
+        chain = {str(i): str(i + 1) for i in range(30)}
+        assert self._svc()._resolve_terminal("0", chain) is None
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests against the live test DB.
+# --------------------------------------------------------------------------- #
+pytestmark = pytest.mark.integration
+
+
+async def _seed_location(
+    session: AsyncSession,
+    *,
+    loc_id: str,
+    name: str,
+    is_canonical: bool,
+    city: str = "Springfield",
+    state: str = "IL",
+    postal_code: str = "62701",
+) -> None:
+    org_id = str(uuid.uuid4())
+    await session.execute(
+        text(
+            "INSERT INTO organization (id, name, description, website) "
+            "VALUES (:id, :name, 'redirect-test', '') ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": org_id, "name": name},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO location (id, organization_id, name, latitude, longitude,
+                location_type, validation_status, confidence_score, is_canonical)
+            VALUES (:id, :org, :name, 40.0, -74.0, 'physical', 'verified', 90, :canon)
+            """
+        ),
+        {"id": loc_id, "org": org_id, "name": name, "canon": is_canonical},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO address (id, location_id, address_1, city, state_province,
+                postal_code, country, address_type)
+            VALUES (:id, :loc, '1 Main St', :city, :state, :zip, 'US', 'physical')
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "loc": loc_id,
+            "city": city,
+            "state": state,
+            "zip": postal_code,
+        },
+    )
+
+
+async def _seed_soft_delete(
+    session: AsyncSession, *, dead_id: str, survivor_id: str
+) -> None:
+    await session.execute(text(_AUDIT_DDL))
+    await session.execute(
+        text(
+            """
+            INSERT INTO dedup_run_audit (run_id, cluster_id, survivor_id,
+                duplicate_id, table_name, row_id, action)
+            VALUES (gen_random_uuid(), 'test-cluster', :survivor, :dead_uuid,
+                    'location', :dead_text, 'soft_delete')
+            """
+        ),
+        {"survivor": survivor_id, "dead_uuid": dead_id, "dead_text": dead_id},
+    )
+
+
+async def _redirects_for(session: AsyncSession, dead_id: str):
+    """Return the redirect entry for dead_id, or None."""
+    result = await BeaconRedirectService(session).redirects(page_size=10000)
+    return next((r for r in result["redirects"] if r["dead_id"] == dead_id), None)
+
+
+class TestBeaconRedirects:
+    @pytest.mark.asyncio
+    async def test_soft_deleted_maps_to_canonical_survivor(
+        self, db_session: AsyncSession
+    ) -> None:
+        survivor_id = str(uuid.uuid4())
+        dead_id = str(uuid.uuid4())
+        await _seed_location(
+            db_session,
+            loc_id=survivor_id,
+            name="Survivor Pantry",
+            is_canonical=True,
+            city="Chicago",
+            state="IL",
+            postal_code="60601",
+        )
+        await _seed_location(
+            db_session, loc_id=dead_id, name="Dead Pantry", is_canonical=False
+        )
+        await _seed_soft_delete(db_session, dead_id=dead_id, survivor_id=survivor_id)
+        await db_session.commit()
+
+        entry = await _redirects_for(db_session, dead_id)
+        assert entry is not None
+        assert entry["survivor"]["id"] == survivor_id
+        assert entry["survivor"]["city"] == "Chicago"
+        assert entry["survivor"]["state"] == "IL"
+        assert entry["survivor"]["postal_code"] == "60601"
+
+    @pytest.mark.asyncio
+    async def test_transitive_chain_resolves_to_terminal(
+        self, db_session: AsyncSession
+    ) -> None:
+        # a -> b -> c, c canonical. a and b both redirect to c.
+        a, b, c = (str(uuid.uuid4()) for _ in range(3))
+        await _seed_location(db_session, loc_id=c, name="Terminal", is_canonical=True)
+        await _seed_location(db_session, loc_id=b, name="Mid", is_canonical=False)
+        await _seed_location(db_session, loc_id=a, name="Start", is_canonical=False)
+        await _seed_soft_delete(db_session, dead_id=a, survivor_id=b)
+        await _seed_soft_delete(db_session, dead_id=b, survivor_id=c)
+        await db_session.commit()
+
+        ea = await _redirects_for(db_session, a)
+        eb = await _redirects_for(db_session, b)
+        assert ea is not None and ea["survivor"]["id"] == c
+        assert eb is not None and eb["survivor"]["id"] == c
+
+    @pytest.mark.asyncio
+    async def test_non_canonical_survivor_excluded(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Survivor was itself soft-deleted with no onward survivor recorded ->
+        # no live canonical terminal -> dead id is omitted (beacon parent/410s it).
+        dead_id = str(uuid.uuid4())
+        dead_survivor = str(uuid.uuid4())
+        await _seed_location(
+            db_session, loc_id=dead_survivor, name="Also Dead", is_canonical=False
+        )
+        await _seed_location(
+            db_session, loc_id=dead_id, name="Dead", is_canonical=False
+        )
+        await _seed_soft_delete(db_session, dead_id=dead_id, survivor_id=dead_survivor)
+        await db_session.commit()
+
+        assert await _redirects_for(db_session, dead_id) is None
+
+    @pytest.mark.asyncio
+    async def test_returned_matches_meta(self, db_session: AsyncSession) -> None:
+        result = await BeaconRedirectService(db_session).redirects(page_size=10000)
+        assert result["meta"]["returned"] == len(result["redirects"])


### PR DESCRIPTION
## Why

Companion to **ppr-beacon PR #15** (SEO indexing recovery for the static directory site). When dedup soft-deletes a duplicate location (`is_canonical=FALSE`), beacon deletes that location's S3 pages and the previously-indexed URLs 404. Beacon knows the dead URL (from its own DynamoDB build tracker) but **not the survivor** — that lives in `dedup_run_audit` + the live `location` table, which only the API can read (the beacon sync endpoint filters `is_canonical=TRUE`, so soft-deleted rows never reach the build).

This adds the read-only endpoint that supplies the survivor side, so beacon can publish a real **301** (to the surviving canonical) or **410** at the CloudFront edge — self-healing within an hour of any dedup pass, no one-off script.

## What

`GET /api/v1/partners/beacon/redirects` → soft-deleted location ids mapped to their surviving canonical's address components (`{dead_id, survivor: {id, name, city, state, postal_code}}`).

- **Read-only.** Queries `dedup_run_audit` (`action='soft_delete'`) joined to the live `location`/`address` tables. No writes.
- Follows the **transitive survivor chain** to its terminal still-canonical row (cycle- and depth-guarded, 25-hop cap); emits only redirects with a live canonical survivor (beacon 410s the rest).
- **Tolerates a missing `dedup_run_audit` table** (lazily created by the dedup scripts) — returns `[]`.
- Keyset pagination by `dead_id` (`page_size ≤ 10000`), mirroring `/sync`.
- `BeaconRedirectService` + `BeaconRedirect{,Survivor,sResponse,sMeta}` models.
- Docs: beacon partner endpoints (`/sync` + `/redirects`) added to the endpoints reference, cross-linking the beacon plugin's "SEO indexing recovery" section for the edge `noindex`/301/410 behavior.

## Tests

9 pass — 5 pure-unit (chain/cycle/self-cycle/depth resolution) + 4 integration (survivor map, transitive chain → terminal, non-canonical-survivor excluded, meta consistency). Existing beacon sync tests unaffected (18 pass). ruff + mypy clean on changed files.

## Deploy order

Deploy **this** first (so `/redirects` exists), then the beacon CDK stack (PR #15) which creates the KeyValueStore + edge functions and starts publishing redirects on the next hourly build. PR #15's sitemap + `noindex` are independent and take effect immediately on its deploy.

Companion: For-The-Greater-Good/ppr-beacon#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
