### PR TITLE
fix(batcher): re-enqueue truncated Bedrock batch records instead of accepting partial output (FF-1)

### DIFF
--- a/app/llm/queue/batch_result_processor.py
+++ b/app/llm/queue/batch_result_processor.py
@@ -93,10 +93,14 @@ def _route_success(
     validator_queue_url: str,
     reconciler_queue_url: str,
     recorder_queue_url: str,
-) -> None:
+) -> bool:
     """Route a successful batch result downstream.
 
     Mirrors the routing logic in processor.py lines 242-327.
+
+    Returns True if the result was routed as a completed success; returns
+    False if the response was truncated (hit the token limit) and therefore
+    must NOT be stored/routed — the caller re-enqueues it for on-demand retry.
 
     Args:
         record_id: Job ID / record ID
@@ -117,6 +121,19 @@ def _route_success(
         model_id=model_id,
         format_schema=format_schema,
     )
+
+    # LLM-1 parity with the on-demand worker (processor.py): a truncated
+    # response (stop_reason 'max_tokens') is parseable but silently omits
+    # locations. Do NOT store or route it as complete — signal the caller to
+    # re-enqueue for on-demand retry. Routing it would drop pantries AND cache
+    # the partial output in the content store, dedup-poisoning future scrapes.
+    if getattr(llm_response, "was_truncated", False):
+        logger.warning(
+            "batch_record_truncated",
+            record_id=record_id,
+            stop_reason=getattr(llm_response, "stop_reason", None),
+        )
+        return False
 
     from app.llm.queue.job import LLMJob
 
@@ -197,6 +214,8 @@ def _route_success(
                 job_id=record_id,
                 error=str(e),
             )
+
+    return True
 
 
 def _requeue_to_llm(original_job: dict[str, Any], llm_queue_url: str) -> None:
@@ -376,6 +395,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         processed = 0
         errors = 0
         failed_requeue_count = 0
+        truncated_requeued = 0
         output_record_ids: set[str] = set()
 
         with open(output_path) as f:
@@ -430,27 +450,69 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 try:
                     if source == "submarine":
                         from app.llm.queue.submarine_batch import (
+                            requeue_submarine_on_demand,
                             route_submarine_success,
                         )
 
-                        route_submarine_success(
+                        if route_submarine_success(
                             record_id=record_id,
                             output=model_output,
                             original_record=original_job,
                             model_id=model_id,
                             reconciler_queue_url=reconciler_queue_url,
-                        )
+                        ):
+                            processed += 1
+                        else:
+                            # LLM-1: truncated submarine extraction — re-enqueue
+                            # to the extraction queue instead of accepting partial.
+                            logger.warning(
+                                "batch_record_truncated_requeued",
+                                batch_job_arn=job_arn,
+                                record_id=record_id,
+                                source="submarine",
+                            )
+                            try:
+                                requeue_submarine_on_demand(
+                                    original_job, retry_queue_url
+                                )
+                                truncated_requeued += 1
+                            except Exception as re_err:
+                                failed_requeue_count += 1
+                                logger.error(
+                                    "batch_requeue_failed",
+                                    batch_job_arn=job_arn,
+                                    record_id=record_id,
+                                    error=str(re_err),
+                                )
+                    elif _route_success(
+                        record_id=record_id,
+                        output=model_output,
+                        original_job=original_job,
+                        model_id=model_id,
+                        validator_queue_url=validator_queue_url,
+                        reconciler_queue_url=reconciler_queue_url,
+                        recorder_queue_url=recorder_queue_url,
+                    ):
+                        processed += 1
                     else:
-                        _route_success(
+                        # LLM-1: truncated batch record — re-enqueue for
+                        # on-demand retry instead of accepting partial output.
+                        logger.warning(
+                            "batch_record_truncated_requeued",
+                            batch_job_arn=job_arn,
                             record_id=record_id,
-                            output=model_output,
-                            original_job=original_job,
-                            model_id=model_id,
-                            validator_queue_url=validator_queue_url,
-                            reconciler_queue_url=reconciler_queue_url,
-                            recorder_queue_url=recorder_queue_url,
                         )
-                    processed += 1
+                        try:
+                            _requeue_to_llm(original_job, retry_queue_url)
+                            truncated_requeued += 1
+                        except Exception as re_err:
+                            failed_requeue_count += 1
+                            logger.error(
+                                "batch_requeue_failed",
+                                batch_job_arn=job_arn,
+                                record_id=record_id,
+                                error=str(re_err),
+                            )
                 except Exception as e:
                     errors += 1
                     logger.error(
@@ -552,6 +614,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             processed=processed,
             errors=errors,
             requeued=requeued,
+            truncated_requeued=truncated_requeued,
         )
 
         result: dict[str, Any] = {
@@ -559,6 +622,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "processed": processed,
             "errors": errors,
             "requeued": requeued,
+            "truncated_requeued": truncated_requeued,
             "unparseable_count": unparseable_count,
         }
         if metadata_update_failed:

--- a/app/llm/queue/submarine_batch.py
+++ b/app/llm/queue/submarine_batch.py
@@ -67,12 +67,16 @@ def route_submarine_success(
     original_record: dict[str, Any],
     model_id: str,
     reconciler_queue_url: str,
-) -> None:
+) -> bool:
     """Route a successful submarine batch result to the reconciler.
 
     Parses the Bedrock output, extracts fields using SubmarineExtractor,
     builds a JobResult via SubmarineResultBuilder, and sends to reconciler.
     Submarine bypasses the validator (Constitution v1.5.1).
+
+    Returns True if handled (routed or no-useful-data); returns False if the
+    response was truncated (hit the token limit) and must be re-enqueued for
+    on-demand extraction rather than accepted as partial output.
     """
     from app.llm.providers.bedrock import parse_messages_api_response
     from app.submarine.extractor import SubmarineExtractor
@@ -84,6 +88,16 @@ def route_submarine_success(
         response=output,
         model_id=model_id,
     )
+
+    # LLM-1 parity: a truncated extraction is partial. Re-enqueue for on-demand
+    # retry instead of persisting incomplete enrichment.
+    if getattr(llm_response, "was_truncated", False):
+        logger.warning(
+            "submarine_batch_record_truncated",
+            record_id=record_id,
+            stop_reason=getattr(llm_response, "stop_reason", None),
+        )
+        return False
 
     # Unwrap SQS envelope if present
     data = original_record.get("data", original_record)
@@ -126,7 +140,7 @@ def route_submarine_success(
             location_id=job.location_id,
         )
         _update_location_status(job.location_id, status)
-        return
+        return True
 
     send_to_sqs(
         queue_url=reconciler_queue_url,
@@ -145,6 +159,7 @@ def route_submarine_success(
         status=status.value,
         fields_extracted=list(extracted.keys()),
     )
+    return True
 
 
 def _get_database_url() -> str:

--- a/tests/test_llm/test_batch_result_processor.py
+++ b/tests/test_llm/test_batch_result_processor.py
@@ -50,6 +50,22 @@ def _make_batch_output_record(
         }
 
 
+def _make_truncated_output_record(record_id: str) -> dict:
+    """A Bedrock batch output record that hit the token limit mid-generation.
+
+    Messages API sets stop_reason='max_tokens' and the partial output is a text
+    block (the tool_use never completes), so parse_messages_api_response returns
+    an LLMResponse with was_truncated=True and non-empty (but partial) text."""
+    return {
+        "recordId": record_id,
+        "modelOutput": {
+            "content": [{"type": "text", "text": '{"organization": [{"na'}],
+            "stop_reason": "max_tokens",
+            "usage": {"input_tokens": 100, "output_tokens": 4096},
+        },
+    }
+
+
 def _make_original_job(job_id: str) -> dict:
     """Create a mock original job record (as stored in DynamoDB)."""
     return {
@@ -396,6 +412,97 @@ class TestCompletedRouting:
             or (c[0] and c[0][0] == "https://sqs/recorder.fifo")
         ]
         assert len(recorder_calls) >= 1
+
+
+class TestTruncationHandling:
+    """LLM-1 parity on the batch path: a truncated batch record must be
+    re-enqueued for on-demand retry, never stored/routed as a completed
+    result (which would silently drop locations and poison the content
+    store with partial output)."""
+
+    @patch("app.content_store.config.get_content_store")
+    @patch("app.llm.queue.batch_result_processor._get_clients")
+    @patch("app.llm.queue.batch_result_processor.send_to_sqs")
+    @patch("app.llm.queue.batch_result_processor.settings")
+    def test_truncated_record_requeued_not_routed(
+        self, mock_settings, mock_send, mock_get_clients, mock_get_cs
+    ):
+        mock_settings.VALIDATOR_ENABLED = True
+        mock_s3 = MagicMock()
+        mock_dynamodb = MagicMock()
+        mock_get_clients.return_value = (mock_s3, mock_dynamodb)
+        mock_send.return_value = "msg-id"
+        mock_cs = MagicMock()
+        mock_get_cs.return_value = mock_cs
+
+        job_arn = "arn:aws:bedrock:us-east-1:123:model-invocation-job/test"
+        original_jobs = {"job-1": _make_original_job("job-1")}
+        mock_dynamodb.get_item.return_value = {
+            "Item": {
+                "output_key_prefix": {"S": "output/exec-123/"},
+                "original_jobs_key": {"S": "input/exec-123/original_jobs.jsonl"},
+            }
+        }
+        _mock_s3_for_streaming(
+            mock_s3, original_jobs, [_make_truncated_output_record("job-1")]
+        )
+
+        event = _make_event("Completed", job_arn)
+        with patch.dict(
+            "os.environ",
+            {
+                "VALIDATOR_QUEUE_URL": "https://sqs/validator.fifo",
+                "RECONCILER_QUEUE_URL": "https://sqs/reconciler.fifo",
+                "RECORDER_QUEUE_URL": "https://sqs/recorder.fifo",
+                "LLM_QUEUE_URL": "https://sqs/llm.fifo",
+                "BATCH_BUCKET": "batch-bucket",
+                "SQS_JOBS_TABLE": "jobs-table",
+            },
+        ):
+            result = handler(event, None)
+
+        def _queue_of(call):
+            return call[1].get("queue_url") or (call[0][0] if call[0] else None)
+
+        sent_queues = [_queue_of(c) for c in mock_send.call_args_list]
+        # Truncated record must NOT be routed downstream as a success...
+        assert "https://sqs/validator.fifo" not in sent_queues
+        assert "https://sqs/reconciler.fifo" not in sent_queues
+        # ...and MUST be re-enqueued to the on-demand LLM queue for retry.
+        assert "https://sqs/llm.fifo" in sent_queues
+        # Not counted as a clean success.
+        assert result["processed"] == 0
+        assert result["truncated_requeued"] == 1
+        # Truncated partial output must never be cached as a result.
+        mock_cs.store_result.assert_not_called()
+
+    def test_submarine_route_returns_false_on_truncation(self):
+        """The submarine batch router has the same gate: a truncated extraction
+        signals re-enqueue (False), before any extractor/DB work."""
+        from app.llm.providers.types import LLMResponse
+        from app.llm.queue.submarine_batch import route_submarine_success
+
+        truncated = LLMResponse(
+            text='{"hours": "Mon 9-',
+            model="m",
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            was_truncated=True,
+        )
+        with patch(
+            "app.llm.providers.bedrock.parse_messages_api_response",
+            return_value=truncated,
+        ):
+            routed = route_submarine_success(
+                record_id="sub-1",
+                output={
+                    "content": [{"type": "text", "text": "x"}],
+                    "stop_reason": "max_tokens",
+                },
+                original_record={"data": {"submarine_job": {}, "missing_fields": []}},
+                model_id="m",
+                reconciler_queue_url="https://sqs/reconciler.fifo",
+            )
+        assert routed is False
 
 
 class TestFailureHandling:


### PR DESCRIPTION
Pre-deploy integration review fast-follow #1. LLM-1 truncation was asymmetric: the on-demand worker (processor.py) retries on was_truncated, but the Bedrock BATCH result processor parsed it and ignored it — a truncated batch record (stop_reason 'max_tokens', partial text) passed is_valid_response and was stored + routed as COMPLETED. LLM-3 doesn't catch it (the record has an output line, not 'missing'). Net: truncated responses silently drop locations on the primary AWS path AND cache partial output in the content store (dedup-poisoning future scrapes).

Fix: _route_success (scraper) and route_submarine_success (submarine) now return bool; on was_truncated they return False BEFORE store/route, and the handler re-enqueues the original job to the on-demand queue (LLM queue for scrapers, submarine extraction queue for submarine), mirroring processor.py. The truncated record is already in output_record_ids so LLM-3 won't double-requeue. New truncated_requeued counter; logs batch_record_truncated / batch_record_truncated_requeued.

TDD: handler test (truncated record re-enqueued to LLM queue, NOT routed to validator/reconciler, NOT stored in content store, processed=0, truncated_requeued=1) + unit test route_submarine_success returns False on truncation. 16 batch-processor tests pass; black/ruff/mypy/bandit green. (Pre-existing test_process_llm_job_no_print_calls failure is unrelated — fails on clean main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)