### PR TITLE
fix(reconciler): include bymonthday in in-memory schedule dedup (FF-2)

### DIFF
--- a/app/reconciler/job_processor.py
+++ b/app/reconciler/job_processor.py
@@ -67,6 +67,7 @@ class ScheduleDict(TypedDict):
     opens_at: str
     closes_at: str
     byday: str | None
+    bymonthday: str | None
 
 
 class ServiceDict(TypedDict):
@@ -291,6 +292,27 @@ class JobProcessor:
                 transformed["bymonthday"] = normalized_bymonthday
 
         return transformed
+
+    @staticmethod
+    def _same_recurrence(a: dict, b: dict) -> bool:
+        """Whether two (already-transformed) schedule dicts are the same
+        recurrence for in-memory collection dedup.
+
+        Compares the full recurrence identity — freq, wkst, hours, AND both
+        byday and bymonthday — matching the DB-layer upsert key in
+        ``service_creator.update_or_create_schedule`` (REC-2). Without the
+        bymonthday term, two MONTHLY windows differing only in day-of-month
+        (e.g. the 1st vs the 15th, byday NULL on both) collapse here before
+        ever reaching the upsert, silently dropping the second window.
+        """
+        return (
+            a.get("freq") == b.get("freq")
+            and a.get("wkst") == b.get("wkst")
+            and a.get("opens_at") == b.get("opens_at")
+            and a.get("closes_at") == b.get("closes_at")
+            and a.get("byday") == b.get("byday")
+            and a.get("bymonthday") == b.get("bymonthday")
+        )
 
     def _extract_json_from_markdown(self, text: str) -> str:
         """Extract JSON content from markdown code blocks.
@@ -1139,7 +1161,9 @@ class JobProcessor:
                         )
                         location_id = uuid.UUID(location_id_str)
 
-                        # Create location addresses for both new and existing locations
+                        # Create location addresses (new locations only; this
+                        # block is inside the create-new branch — existing
+                        # locations are handled in the match_id branch above)
                         if location.get("address") and location_id:
                             location_id_str = str(location_id)
 
@@ -1232,7 +1256,8 @@ class JobProcessor:
                                         "from narrative text"
                                     )
 
-                        # Create location phones with languages (for both new and existing locations)
+                        # Create location phones with languages (new locations
+                        # only; this block is inside the create-new branch)
                         if location.get("phones") and location_id:
                             for phone in location["phones"]:
                                 # Use empty strings for missing fields
@@ -1505,24 +1530,15 @@ class JobProcessor:
                                             if not transformed_sched:
                                                 continue
                                             loc_schedule = transformed_sched
-                                            # Check if this schedule already exists
-                                            exists = False
-                                            for existing in schedules_to_create:
-                                                if (
-                                                    existing["freq"]
-                                                    == loc_schedule["freq"]
-                                                    and existing["wkst"]
-                                                    == loc_schedule["wkst"]
-                                                    and existing["opens_at"]
-                                                    == loc_schedule["opens_at"]
-                                                    and existing["closes_at"]
-                                                    == loc_schedule["closes_at"]
-                                                    and existing.get("byday")
-                                                    == loc_schedule.get("byday")
-                                                ):
-                                                    exists = True
-                                                    break
-                                            if not exists:
+                                            # Skip if an identical recurrence is
+                                            # already collected (full identity
+                                            # incl. byday + bymonthday).
+                                            if not any(
+                                                self._same_recurrence(
+                                                    existing, loc_schedule
+                                                )
+                                                for existing in schedules_to_create
+                                            ):
                                                 schedules_to_create.append(loc_schedule)
 
                                     # Add schedules from LLM service_at_location entries
@@ -1539,28 +1555,16 @@ class JobProcessor:
                                                 )
                                                 if not transformed_sched:
                                                     continue
-                                                # Deduplicate against already collected schedules
-                                                exists = False
-                                                for existing in schedules_to_create:
-                                                    if (
-                                                        existing["freq"]
-                                                        == transformed_sched["freq"]
-                                                        and existing["wkst"]
-                                                        == transformed_sched["wkst"]
-                                                        and existing["opens_at"]
-                                                        == transformed_sched["opens_at"]
-                                                        and existing["closes_at"]
-                                                        == transformed_sched[
-                                                            "closes_at"
-                                                        ]
-                                                        and existing.get("byday")
-                                                        == transformed_sched.get(
-                                                            "byday"
-                                                        )
-                                                    ):
-                                                        exists = True
-                                                        break
-                                                if not exists:
+                                                # Dedup against already-collected
+                                                # schedules on full recurrence
+                                                # identity (incl. byday +
+                                                # bymonthday).
+                                                if not any(
+                                                    self._same_recurrence(
+                                                        existing, transformed_sched
+                                                    )
+                                                    for existing in schedules_to_create
+                                                ):
                                                     schedules_to_create.append(
                                                         transformed_sched
                                                     )

--- a/tests/test_reconciler/test_job_processor.py
+++ b/tests/test_reconciler/test_job_processor.py
@@ -464,6 +464,57 @@ class TestTransformScheduleWkstDefault:
         assert result["count"] == 1
 
 
+class TestSameRecurrence:
+    """FF-2: the in-memory schedule-collection dedup key must include
+    bymonthday, so two MONTHLY windows differing only in day-of-month are not
+    collapsed before reaching REC-2's DB upsert."""
+
+    def _base(self, **over):
+        s = {
+            "freq": "MONTHLY",
+            "wkst": "MO",
+            "opens_at": "09:00",
+            "closes_at": "12:00",
+            "byday": None,
+            "bymonthday": "1",
+        }
+        s.update(over)
+        return s
+
+    def test_identical_recurrence_matches(self):
+        assert JobProcessor._same_recurrence(self._base(), self._base()) is True
+
+    def test_differs_only_in_bymonthday_does_not_match(self):
+        # The bug this fixes: same hours/freq, byday NULL, only the
+        # day-of-month differs (1st vs 15th) — must be treated as distinct.
+        a = self._base(bymonthday="1")
+        b = self._base(bymonthday="15")
+        assert JobProcessor._same_recurrence(a, b) is False
+
+    def test_differs_only_in_byday_does_not_match(self):
+        a = self._base(freq="WEEKLY", bymonthday=None, byday="MO")
+        b = self._base(freq="WEEKLY", bymonthday=None, byday="TH")
+        assert JobProcessor._same_recurrence(a, b) is False
+
+    def test_differs_in_hours_does_not_match(self):
+        assert (
+            JobProcessor._same_recurrence(
+                self._base(opens_at="09:00"), self._base(opens_at="08:00")
+            )
+            is False
+        )
+
+    def test_missing_keys_treated_as_none(self):
+        # A dict without bymonthday matches one with bymonthday=None (both
+        # absent/None), but not one with a real bymonthday.
+        no_bmd = {"freq": "WEEKLY", "wkst": "MO", "opens_at": "9", "closes_at": "5"}
+        assert JobProcessor._same_recurrence(no_bmd, dict(no_bmd, byday=None)) is True
+        assert (
+            JobProcessor._same_recurrence(no_bmd, dict(no_bmd, bymonthday="15"))
+            is False
+        )
+
+
 class TestSubmarineDirectIdPath:
     """Test submarine's direct ID-based location matching path."""
 


### PR DESCRIPTION
Pre-deploy integration review fast-follow #2 (cross-PR interaction).

REC-2 (#509) keyed the schedule UPSERT on recurrence identity (freq + byday + bymonthday), but the **in-memory dedup** in `job_processor` that collects `schedules_to_create` *before* the upsert still compared only freq/wkst/opens/closes/**byday** — not bymonthday. So two MONTHLY windows differing only in day-of-month (e.g. the 1st vs the 15th, byday NULL on both) collapsed in memory and only one reached the upsert — silently dropping the second window and partially defeating REC-2. SUB-6 (#500) introduced bymonthday into the flow; REC-2 fixed the DB layer; this in-memory pre-dedup was the missed seam.

**Fix:** extract the duplicated 6-field comparison (it appeared verbatim in both the location-nested and service_at_location-nested collection loops) into one testable `JobProcessor._same_recurrence` helper comparing the **full** recurrence identity incl. bymonthday, matching the DB upsert key. Both call sites use it. Also fixes two misleading "for both new and existing locations" comments (those blocks are in the create-new branch only) and declares `bymonthday` on the `ScheduleDict` TypedDict.

**TDD:** unit tests on `_same_recurrence` — identical→match; differ-only-in-bymonthday→distinct; differ-only-in-byday→distinct; hours differ→distinct; missing-keys-as-None. 280 reconciler tests pass; black ✓ ruff ✓ bandit ✓ (reconciler excluded from CI mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)