### PR TITLE
docs(env): document Lighthouse↔Beacon cross-app URL vars in the sample

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -259,6 +259,16 @@ TIGHTBEAM_API_KEYS=  # Comma-separated API keys for tightbeam endpoints
 # ppr-beacon Plugin (CDK deployment only, production custom domain)
 # BEACON_HOSTED_ZONE_ID=your-route53-hosted-zone-id
 # BEACON_DOMAIN=your-beacon-domain.example.com
+# Cross-app links between Lighthouse and Beacon (the claim funnel):
+#   NEXT_PUBLIC_BEACON_BASE_URL — Lighthouse "View on directory" links
+#     point here. Baked into the Lighthouse client bundle at Amplify
+#     build time. When unset, the app uses its own built-in directory
+#     default.
+# NEXT_PUBLIC_BEACON_BASE_URL=https://directory.your-domain.example.com
+#   LIGHTHOUSE_BASE_URL — Beacon's "Claim this listing" CTA links here
+#     (Lighthouse /claim/new). Required together with
+#     BEACON_CLAIM_UI_ENABLED=true for the claim button to render.
+# LIGHTHOUSE_BASE_URL=https://lighthouse.your-domain.example.com
 # Google Analytics 4 — Beacon static site (beacon.example.com)
 BEACON_GA4_MEASUREMENT_ID=
 BEACON_GOOGLE_SITE_VERIFICATION=


### PR DESCRIPTION
## Summary

Two env vars that wire the **claim funnel** between Lighthouse and Beacon were missing from `.env.example`:

- **`NEXT_PUBLIC_BEACON_BASE_URL`** — Lighthouse "View on directory" links target (the Beacon directory). Baked into the Lighthouse client bundle at Amplify build time; the app uses its own built-in default when unset. *(Now wired into the Amplify app env — see ppr-lighthouse PR #216.)*
- **`LIGHTHOUSE_BASE_URL`** — Beacon's "Claim this listing" CTA target (Lighthouse `/claim/new`). Required together with `BEACON_CLAIM_UI_ENABLED=true` for the claim button to render.

Added as commented placeholders in the `ppr-beacon` section using the existing `your-domain.example.com` convention. Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)