### PR TITLE
fix(bouy): don't commit org-specific 1Password pointer; account optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ ENV/
 # Environment variables
 .env
 .env.prod
+config/op.conf
 .env.local
 .env.*.local
 .env.test.tmp.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,12 @@ bouy can source per-environment config from 1Password instead of a `.env` file:
   into containers through a runtime, names-only passthrough overlay. **Secrets are
   never written to disk.** Auth is the `op` desktop-app biometric integration;
   `help`/`version`/`setup`/`op` never trigger a prompt.
-- Pointer defaults (baked into bouy): account `plentiful.1password.com`, vault
-  `Pantry Pirate Radio`, item `bouy-env`. Override via `OP_ACCOUNT`/`OP_VAULT`/
-  `OP_ITEM` env vars or `config/op.conf` (precedence: env > op.conf > built-in).
+- Pointer config: the **account has no built-in default** (it is org-specific) —
+  set it via `config/op.conf` (a gitignored local pointer like `.env`, copied from
+  the committed `config/op.conf.example`) or the `OP_ACCOUNT` env var; blank means
+  bouy omits the `op --account` flag and the op CLI uses its default account. Vault
+  and item still default to `Pantry Pirate Radio` / `bouy-env`. Precedence:
+  env > op.conf > built-in.
 - `--no-1password` / `USE_1PASSWORD=false` force the file path; `--1password` /
   `USE_1PASSWORD=true` force the vault. Auto-detect is the default.
 

--- a/bouy
+++ b/bouy
@@ -159,10 +159,19 @@ resolve_op_pointer() {
         file_vault=$(grep -E '^OP_VAULT=' config/op.conf | cut -d= -f2-)
         file_item=$(grep -E '^OP_ITEM=' config/op.conf | cut -d= -f2-)
     fi
-    OP_ACCOUNT="${OP_ACCOUNT:-${file_account:-plentiful.1password.com}}"
+    # No hardcoded account default (it is org-specific). When unset, bouy omits
+    # the `op --account` flag and the op CLI uses its default account. Vault and
+    # item have neutral, project-generic defaults.
+    OP_ACCOUNT="${OP_ACCOUNT:-$file_account}"
     OP_VAULT="${OP_VAULT:-${file_vault:-Pantry Pirate Radio}}"
     OP_ITEM="${OP_ITEM:-${file_item:-bouy-env}}"
     export OP_ACCOUNT OP_VAULT OP_ITEM
+    # Optional --account flag (empty array when no account configured).
+    if [ -n "$OP_ACCOUNT" ]; then
+        OP_ACCOUNT_ARGS=(--account "$OP_ACCOUNT")
+    else
+        OP_ACCOUNT_ARGS=()
+    fi
 }
 
 # Single mockable seam for the 1Password CLI. Tests set BOUY_OP_CMD to a stub.
@@ -174,24 +183,24 @@ op_cli() {
 onepassword_available() {
     local bin="${BOUY_OP_CMD:-op}"
     command -v "$bin" >/dev/null 2>&1 || return 1
-    op_cli account get --account "$OP_ACCOUNT" >/dev/null 2>&1
+    op_cli account get "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1
 }
 
 # Print resolved pointer + sign-in + which fields exist. No secret values shown.
 op_status() {
     resolve_op_pointer
-    output info "1Password account: $OP_ACCOUNT"
+    output info "1Password account: ${OP_ACCOUNT:-(op CLI default)}"
     output info "Vault: $OP_VAULT"
     output info "Item:  $OP_ITEM"
     if onepassword_available; then
-        output success "Signed in to $OP_ACCOUNT"
+        output success "Signed in to ${OP_ACCOUNT:-your default 1Password account}"
     else
-        output warning "Not signed in (run: op signin --account $OP_ACCOUNT)"
+        output warning "Not signed in (run: op signin --account ${OP_ACCOUNT:-your default 1Password account})"
         return 0
     fi
     local field
     for field in dev test prod; do
-        if op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT" >/dev/null 2>&1; then
+        if op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1; then
             output info "  field '$field': present"
         else
             output info "  field '$field': missing"
@@ -211,7 +220,7 @@ op_pull() {
         esac
     done
     local blob
-    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT") || {
+    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}") || {
         output error "Could not read op://$OP_VAULT/$OP_ITEM/$field"; return 1; }
     if [ -n "$out" ]; then
         printf '%s' "$blob" > "$out"
@@ -237,9 +246,9 @@ op_push() {
         *) fields=("$field") ;;
     esac
     # Ensure the item exists (create empty Secure Note if missing).
-    if ! op_cli item get "$OP_ITEM" --vault "$OP_VAULT" --account "$OP_ACCOUNT" >/dev/null 2>&1; then
+    if ! op_cli item get "$OP_ITEM" --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1; then
         op_cli item create --category "Secure Note" --title "$OP_ITEM" \
-            --vault "$OP_VAULT" --account "$OP_ACCOUNT" >/dev/null 2>&1 || true
+            --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1 || true
     fi
     local f src content
     for f in "${fields[@]}"; do
@@ -252,7 +261,7 @@ op_push() {
             continue
         fi
         content=$(cat "$src")
-        if op_cli item edit "$OP_ITEM" --vault "$OP_VAULT" --account "$OP_ACCOUNT" \
+        if op_cli item edit "$OP_ITEM" --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" \
             "$f[text]=$content" >/dev/null 2>&1; then
             output success "Pushed $src -> field '$f'"
         else
@@ -265,7 +274,7 @@ op_push() {
 # Reads the whole field with a single op call; the value lives only in memory.
 load_env_from_1password() {
     local field="$1" blob
-    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT") || return 1
+    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}") || return 1
     [ -n "$blob" ] || return 1
     load_env_lines <<< "$blob"
 }
@@ -328,7 +337,7 @@ load_environment() {
     fi
 
     output error "No $file on disk and 1Password is unavailable."
-    output error "Sign in (op signin --account $OP_ACCOUNT) or run './bouy setup' to create $file."
+    output error "Sign in (op signin --account ${OP_ACCOUNT:-your default 1Password account}) or run './bouy setup' to create $file."
     return 1
 }
 
@@ -1007,7 +1016,7 @@ case "$1" in
         # prompt, so a bare 'read' would hit EOF and abort under 'set -e'.
         read -p "Configure 1Password pointer now? (y/N): " want_op || want_op="n"
         if [[ "$want_op" =~ ^[Yy]$ ]]; then
-            prompt_with_default "1Password account" "plentiful.1password.com" "SETUP_OP_ACCOUNT"
+            prompt_with_default "1Password account (blank = your default; e.g. my.1password.com)" "" "SETUP_OP_ACCOUNT"
             prompt_with_default "Vault" "Pantry Pirate Radio" "SETUP_OP_VAULT"
             prompt_with_default "Item" "bouy-env" "SETUP_OP_ITEM"
             mkdir -p config

--- a/bouy-functions.sh
+++ b/bouy-functions.sh
@@ -163,10 +163,19 @@ resolve_op_pointer() {
         file_vault=$(grep -E '^OP_VAULT=' config/op.conf | cut -d= -f2-)
         file_item=$(grep -E '^OP_ITEM=' config/op.conf | cut -d= -f2-)
     fi
-    OP_ACCOUNT="${OP_ACCOUNT:-${file_account:-plentiful.1password.com}}"
+    # No hardcoded account default (it is org-specific). When unset, bouy omits
+    # the `op --account` flag and the op CLI uses its default account. Vault and
+    # item have neutral, project-generic defaults.
+    OP_ACCOUNT="${OP_ACCOUNT:-$file_account}"
     OP_VAULT="${OP_VAULT:-${file_vault:-Pantry Pirate Radio}}"
     OP_ITEM="${OP_ITEM:-${file_item:-bouy-env}}"
     export OP_ACCOUNT OP_VAULT OP_ITEM
+    # Optional --account flag (empty array when no account configured).
+    if [ -n "$OP_ACCOUNT" ]; then
+        OP_ACCOUNT_ARGS=(--account "$OP_ACCOUNT")
+    else
+        OP_ACCOUNT_ARGS=()
+    fi
 }
 
 # Single mockable seam for the 1Password CLI. Tests set BOUY_OP_CMD to a stub.
@@ -178,24 +187,24 @@ op_cli() {
 onepassword_available() {
     local bin="${BOUY_OP_CMD:-op}"
     command -v "$bin" >/dev/null 2>&1 || return 1
-    op_cli account get --account "$OP_ACCOUNT" >/dev/null 2>&1
+    op_cli account get "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1
 }
 
 # Print resolved pointer + sign-in + which fields exist. No secret values shown.
 op_status() {
     resolve_op_pointer
-    output info "1Password account: $OP_ACCOUNT"
+    output info "1Password account: ${OP_ACCOUNT:-(op CLI default)}"
     output info "Vault: $OP_VAULT"
     output info "Item:  $OP_ITEM"
     if onepassword_available; then
-        output success "Signed in to $OP_ACCOUNT"
+        output success "Signed in to ${OP_ACCOUNT:-your default 1Password account}"
     else
-        output warning "Not signed in (run: op signin --account $OP_ACCOUNT)"
+        output warning "Not signed in (run: op signin --account ${OP_ACCOUNT:-your default 1Password account})"
         return 0
     fi
     local field
     for field in dev test prod; do
-        if op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT" >/dev/null 2>&1; then
+        if op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1; then
             output info "  field '$field': present"
         else
             output info "  field '$field': missing"
@@ -215,7 +224,7 @@ op_pull() {
         esac
     done
     local blob
-    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT") || {
+    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}") || {
         output error "Could not read op://$OP_VAULT/$OP_ITEM/$field"; return 1; }
     if [ -n "$out" ]; then
         printf '%s' "$blob" > "$out"
@@ -241,9 +250,9 @@ op_push() {
         *) fields=("$field") ;;
     esac
     # Ensure the item exists (create empty Secure Note if missing).
-    if ! op_cli item get "$OP_ITEM" --vault "$OP_VAULT" --account "$OP_ACCOUNT" >/dev/null 2>&1; then
+    if ! op_cli item get "$OP_ITEM" --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1; then
         op_cli item create --category "Secure Note" --title "$OP_ITEM" \
-            --vault "$OP_VAULT" --account "$OP_ACCOUNT" >/dev/null 2>&1 || true
+            --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" >/dev/null 2>&1 || true
     fi
     local f src content
     for f in "${fields[@]}"; do
@@ -256,7 +265,7 @@ op_push() {
             continue
         fi
         content=$(cat "$src")
-        if op_cli item edit "$OP_ITEM" --vault "$OP_VAULT" --account "$OP_ACCOUNT" \
+        if op_cli item edit "$OP_ITEM" --vault "$OP_VAULT" "${OP_ACCOUNT_ARGS[@]}" \
             "$f[text]=$content" >/dev/null 2>&1; then
             output success "Pushed $src -> field '$f'"
         else
@@ -269,7 +278,7 @@ op_push() {
 # Reads the whole field with a single op call; the value lives only in memory.
 load_env_from_1password() {
     local field="$1" blob
-    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" --account "$OP_ACCOUNT") || return 1
+    blob=$(op_cli read "op://$OP_VAULT/$OP_ITEM/$field" "${OP_ACCOUNT_ARGS[@]}") || return 1
     [ -n "$blob" ] || return 1
     load_env_lines <<< "$blob"
 }
@@ -332,7 +341,7 @@ load_environment() {
     fi
 
     output error "No $file on disk and 1Password is unavailable."
-    output error "Sign in (op signin --account $OP_ACCOUNT) or run './bouy setup' to create $file."
+    output error "Sign in (op signin --account ${OP_ACCOUNT:-your default 1Password account}) or run './bouy setup' to create $file."
     return 1
 }
 

--- a/config/op.conf
+++ b/config/op.conf
@@ -1,6 +1,0 @@
-# 1Password pointer for bouy (names only — NOT secrets). Override any value via
-# the matching OP_* environment variable. Delete this file to fall back to the
-# built-in defaults in bouy.
-OP_ACCOUNT=plentiful.1password.com
-OP_VAULT=Pantry Pirate Radio
-OP_ITEM=bouy-env

--- a/config/op.conf.example
+++ b/config/op.conf.example
@@ -1,0 +1,9 @@
+# bouy 1Password pointer (OPTIONAL — only if you load secrets from 1Password
+# instead of a .env file). Copy this to config/op.conf and set your values.
+# config/op.conf is gitignored — it's your local pointer, like .env.
+#
+# OP_ACCOUNT may be left blank: bouy then omits `op --account ...` and the op
+# CLI uses your default signed-in account. Set it if you have multiple accounts.
+OP_ACCOUNT=
+OP_VAULT=Pantry Pirate Radio
+OP_ITEM=bouy-env

--- a/tests/bouy_tests/test_bouy_onepassword.py
+++ b/tests/bouy_tests/test_bouy_onepassword.py
@@ -108,9 +108,28 @@ def test_resolve_op_pointer_builtin_defaults(tmp_path):
         f"cd {tmp_path}; source {FUNCTIONS}; resolve_op_pointer; "
         f'echo "$OP_ACCOUNT|$OP_VAULT|$OP_ITEM"'
     )
-    assert result.stdout.strip() == (
-        "plentiful.1password.com|Pantry Pirate Radio|bouy-env"
+    assert result.stdout.strip() == ("|Pantry Pirate Radio|bouy-env")
+
+
+def test_resolve_op_pointer_no_account_omits_flag(tmp_path):
+    result = run_bash(
+        f"cd {tmp_path}; source {FUNCTIONS}; resolve_op_pointer; "
+        f'echo "N=${{#OP_ACCOUNT_ARGS[@]}}"; echo "A=[$OP_ACCOUNT]"',
     )
+    assert "N=0" in result.stdout, result.stderr  # empty array -> no --account
+    assert "A=[]" in result.stdout
+
+
+def test_resolve_op_pointer_with_account_sets_flag(tmp_path):
+    result = run_bash(
+        f"cd {tmp_path}; source {FUNCTIONS}; resolve_op_pointer; "
+        f'printf "%s\\n" "${{OP_ACCOUNT_ARGS[@]}}"',
+        env={"OP_ACCOUNT": "x.1password.com"},
+    )
+    assert result.stdout.split("\n")[:2] == [
+        "--account",
+        "x.1password.com",
+    ], result.stdout
 
 
 def test_onepassword_available_true_when_signed_in():
@@ -400,9 +419,10 @@ def test_op_status_reports_pointer_and_signin(tmp_path):
             "BOUY_OP_CMD": str(OP_MOCK),
             "OP_MOCK_SIGNED_IN": "1",
             "OP_MOCK_READ_OUT": "X=1\n",
+            "OP_ACCOUNT": "example.1password.com",
         },
     )
-    assert "plentiful.1password.com" in (result.stdout + result.stderr)
+    assert "example.1password.com" in (result.stdout + result.stderr)
     assert "bouy-env" in (result.stdout + result.stderr)
 
 


### PR DESCRIPTION
Follow-up to #543. The committed `config/op.conf` (and bouy's built-in default) hardcoded `plentiful.1password.com` — wrong to ship in a public, contributor-facing repo.

- `config/op.conf` is now **gitignored** (a local pointer, like `.env`); a neutral **`config/op.conf.example`** documents the format.
- bouy no longer hardcodes an account default. When `OP_ACCOUNT` is unset, the `op --account` flag is **omitted** and the `op` CLI uses its default signed-in account; set it via `config/op.conf` or `OP_ACCOUNT` only if you have multiple accounts. `OP_VAULT`/`OP_ITEM` keep project-generic defaults (`Pantry Pirate Radio` / `bouy-env`).
- Status/error messages render an empty account as `(op CLI default)` / `your default 1Password account`.

## Test plan
- [x] `run_bouy_tests.py onepassword + setup + deploy` → 59 passed (incl. 2 new tests pinning the optional-`--account` array)
- [x] All 6 op helpers byte-identical across `bouy`/`bouy-functions.sh`; `bash -n` clean; black/ruff clean
- [x] `config/op.conf` untracked + gitignored + still on disk; no `plentiful` refs in committed bouy/config
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)