### PR TITLE
feat(federation): P0 foundations — identity, discovery, signing, SSRF guard, HSDS Profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -953,6 +953,41 @@ The authenticated write API for location data management is now a separate plugi
 
 See `plugins/ppr-write-api/CLAUDE.md` for full documentation.
 
+## Federation (HSDS federation core)
+
+### Federation (core) — P0 foundations
+
+Every PPR deployment is (becoming) a federating node in an open HSDS food-resource network — peers discover each other, publish signed snapshots of their data, and pull/corroborate each other's records. Federation is a **core capability, on by default** (gated by nothing in P0; the `FEDERATION_ENABLED` kill switch the publish surface will sit behind is fully enforced in P1). Design of record: `docs/superpowers/specs/2026-06-03-hsds-federation-core-design.md`; living plan: `docs/superpowers/plans/2026-06-03-hsds-federation-core.md`; epic #519.
+
+**P0 surface shipped (discoverable in BOTH Uvicorn and the slim Lambda):** registered via `app/federation/routes_public.py:register_federation_public_routes`, wired into both apps.
+- `GET /.well-known/hsds-federation` — federation discovery doc.
+- `GET /.well-known/did.json` — `did:web` document with the ordered recovery-key schema (design §6.1a). Returns 404 until both `FEDERATION_DID` and `FEDERATION_SIGNING_KEY` are configured.
+- `GET /.well-known/webfinger?resource=` — RFC 7033 JRD.
+- `GET /api/v1/federation/actor` — ActivityStreams actor document.
+
+**Primitives in `app/federation/`:**
+- `fetch.py` — SSRF-hardened outbound egress helper: HTTPS-only, blocks internal IPs / CGNAT / IPv6-ULA. **Note:** the DNS-rebinding connect-pin and the streaming byte-cap are deferred to P2/P3 and are hard gates on the first real outbound fetch (no live peer fetch happens in P0).
+- `canonical.py` — RFC 8785 JCS canonicalization (minimal serializer, ES6 number formatting); the normative byte form used for hashing/signing. Entry point `jcs_bytes()`.
+- `signing.py` — minimal RFC 9421 Ed25519 HTTP Message Signatures + RFC 9530 `Content-Digest`.
+- `identity.py` — `did:web` doc, actor, WebFinger, Ed25519 key loading, base58btc multibase encoding.
+- `discovery.py` — the discovery-doc builder.
+
+**Config (on by default):**
+- `FEDERATION_ENABLED` (default `True`) — the publish-surface kill switch (fully enforced in P1).
+- `FEDERATION_DID`, `FEDERATION_SIGNING_KEY` (secret), `FEDERATION_HSDS_VERSIONS`, `FEDERATION_DOMAIN`, `FEDERATION_PROFILE_URI`, `FEDERATION_ALLOW_LIST_POLICY`, `FEDERATION_CONTACT`, `FEDERATION_RETENTION_DAYS`, `FEDERATION_DATE_SKEW_SECONDS`, `FEDERATION_INGEST_MAX_RECORDS_PER_PEER_PER_DAY`, `FEDERATION_INGEST_MAX_LLM_JOBS_PER_PEER_PER_DAY`, `FEDERATION_EXPORT_PAGE_SIZE`.
+
+**HSDS version note (Principle II):** the API advertises HSDS **3.1.1** because the Pydantic models in `app/models/hsds/` genuinely implement the 3.1.1 shape. The vendored `docs/HSDS/` submodule is v3.2.3 — a spec-only bump; the models do **not** yet carry 3.2's `additional_websites` / `additional_urls` / `attributes` / `metadata`, so advertising 3.2.3 would overstate conformance. The multi-file HSDS Profile lives at `profiles/hsds-ppr/` (RFC 7386 merge patches adding optional `confidence_score` / `verified_by` / `sources`) and is advertised via the API root `profile` field (`= settings.FEDERATION_PROFILE_URI`).
+
+**`source_type='federated_node'`:** the reserved `location_source.source_type` value that federated peers' records will carry once ingest lands (P2). Reserved only — **not yet wired in P0**.
+
+**Forthcoming (NOT in P0):**
+- **P1** — the verifiable Merkle log + signed checkpoints + `/api/v1/federation/export | state.txt | checkpoint | history`.
+- **P2** — pull ingest + corroboration (and the `federated_node` source_type wiring).
+- **P3** — `/inbox` push delivery.
+- **P4** — the `./bouy federation` peer-add/remove/list/status command family.
+
+**`federation_*` structlog grep targets:** none emitted in P0; these will be enumerated per phase starting P1 (per design §14) — e.g. (P1+: `federation_checkpoint_published`, `federation_proof_failed`, `federation_consistency_failed`, `federation_killswitch_active`, …).
+
 ## Plugin System
 
 Plugins extend Pantry Pirate Radio with additional commands, compose overlays, and CDK stacks.

--- a/app/api/lambda_app.py
+++ b/app/api/lambda_app.py
@@ -13,6 +13,7 @@ from starlette import status
 
 from app.api.v1.router import router as v1_router
 from app.core.config import Settings
+from app.federation.routes_public import register_federation_public_routes
 from app.middleware.correlation import CorrelationMiddleware
 from app.middleware.errors import ErrorHandlingMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
@@ -64,3 +65,6 @@ async def root_redirect():
 
 
 app.include_router(v1_router, prefix=settings.api_prefix)
+
+# Root-level public federation discovery routes (Principle XV: identical to main)
+register_federation_public_routes(app)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -359,7 +359,7 @@ async def get_api_metadata() -> dict[str, str]:
     """
     return {
         "version": "3.1.1",
-        "profile": "https://docs.openhumanservices.org/hsds/",
+        "profile": settings.FEDERATION_PROFILE_URI,
         "openapi_url": "/openapi.json",
         "documentation_url": "/docs",
         "api_status": "healthy",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,7 +2,7 @@
 
 import urllib.parse
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -267,8 +267,10 @@ class Settings(BaseSettings):
     FEDERATION_PROFILE_URI: str = (
         "https://hsds-federation.pantrypirateradio.org/profile"
     )
-    # Allow-list policy: one of open | mutual | private.
-    FEDERATION_ALLOW_LIST_POLICY: str = "mutual"
+    # Allow-list policy: one of open | mutual | private. A Literal so a typo
+    # raises ValidationError at Settings construction (startup) rather than
+    # silently downgrading the advertised trust posture at serve time.
+    FEDERATION_ALLOW_LIST_POLICY: Literal["open", "mutual", "private"] = "mutual"
     # Operator contact (URL or email) advertised to peers; optional.
     FEDERATION_CONTACT: str | None = None
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -253,6 +253,24 @@ class Settings(BaseSettings):
     FEDERATION_INGEST_MAX_RECORDS_PER_PEER_PER_DAY: int = Field(default=50_000, ge=1)
     FEDERATION_INGEST_MAX_LLM_JOBS_PER_PEER_PER_DAY: int = Field(default=50_000, ge=1)
     FEDERATION_EXPORT_PAGE_SIZE: int = Field(default=1000, ge=1, le=10_000)
+    # Discovery document (.well-known/hsds-federation) — §8.4 / §6.7.
+    # HSDS versions advertised. Set-membership, NOT exact-match (§8.4): a peer
+    # accepts us if any advertised version is mutually supported. Default
+    # tracks the version the Pydantic models and API root genuinely implement
+    # (the docs/HSDS submodule is pinned at 3.2.3, but the models still omit
+    # decisive 3.2 fields — additional_websites / additional_urls / the
+    # attributes & metadata collections — so we do NOT advertise 3.2 here).
+    FEDERATION_HSDS_VERSIONS: list[str] = Field(default_factory=lambda: ["3.1.1"])
+    # Node public host for absolute endpoint URLs; falls back to the DID host.
+    FEDERATION_DOMAIN: str | None = None
+    # Canonical PPR HSDS profile URI (Task 0.8 aligns router.py to this value).
+    FEDERATION_PROFILE_URI: str = (
+        "https://hsds-federation.pantrypirateradio.org/profile"
+    )
+    # Allow-list policy: one of open | mutual | private.
+    FEDERATION_ALLOW_LIST_POLICY: str = "mutual"
+    # Operator contact (URL or email) advertised to peers; optional.
+    FEDERATION_CONTACT: str | None = None
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -240,6 +240,20 @@ class Settings(BaseSettings):
         default=_SHARED["SUBMARINE_COOLDOWN_ERROR_DAYS"], ge=0
     )
 
+    # Federation Settings (HSDS federation core)
+    FEDERATION_ENABLED: bool = True
+    FEDERATION_DID: str | None = (
+        None  # did:web:<domain> for this node; None disables publish identity
+    )
+    FEDERATION_SIGNING_KEY: str | None = (
+        None  # Ed25519 private key (PEM/base64); secret — never committed
+    )
+    FEDERATION_RETENTION_DAYS: int = Field(default=365, ge=1)
+    FEDERATION_DATE_SKEW_SECONDS: int = Field(default=300, ge=1)
+    FEDERATION_INGEST_MAX_RECORDS_PER_PEER_PER_DAY: int = Field(default=50_000, ge=1)
+    FEDERATION_INGEST_MAX_LLM_JOBS_PER_PEER_PER_DAY: int = Field(default=50_000, ge=1)
+    FEDERATION_EXPORT_PAGE_SIZE: int = Field(default=1000, ge=1, le=10_000)
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/app/federation/__init__.py
+++ b/app/federation/__init__.py
@@ -1,0 +1,1 @@
+"""HSDS federation core. See docs/superpowers/specs/2026-06-03-hsds-federation-core-design.md."""

--- a/app/federation/canonical.py
+++ b/app/federation/canonical.py
@@ -1,0 +1,150 @@
+"""RFC 8785 JSON Canonicalization Scheme (JCS).
+
+A minimal, correct JCS serializer used as the cryptographic substrate for HSDS
+federation: in P1 the same ``jcs_bytes`` canonicalizes the full activity envelope
+(including HSDS Location float coordinates) for the content-address
+``id = sha256(jcs_bytes(envelope))`` and the Ed25519 ``proof``. It therefore takes
+any JSON-serializable ``dict`` / ``list`` / scalar and returns canonical UTF-8 bytes
+with no envelope-specific assumptions.
+
+Number formatting follows the ECMAScript ``Number.prototype.toString()`` algorithm
+(RFC 8785 §3.2.2.3); string escaping follows §3.2.2.2.
+"""
+
+from typing import Any
+
+# Control characters with JSON short-form escapes (RFC 8785 §3.2.2.2).
+_SHORT_ESCAPES = {
+    0x08: "\\b",
+    0x09: "\\t",
+    0x0A: "\\n",
+    0x0C: "\\f",
+    0x0D: "\\r",
+    0x22: '\\"',
+    0x5C: "\\\\",
+}
+
+
+def jcs_bytes(obj: Any) -> bytes:
+    """Serialize ``obj`` to canonical RFC 8785 JSON bytes (UTF-8)."""
+    return _serialize(obj).encode("utf-8")
+
+
+def _serialize(obj: Any) -> str:
+    if obj is None:
+        return "null"
+    # bool is a subclass of int — check it FIRST.
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if isinstance(obj, str):
+        return _escape_string(obj)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        return _format_float(obj)
+    if isinstance(obj, dict):
+        return _serialize_object(obj)
+    if isinstance(obj, list | tuple):
+        return "[" + ",".join(_serialize(item) for item in obj) + "]"
+    raise ValueError(f"unsupported type for JCS: {type(obj).__name__}")
+
+
+def _serialize_object(obj: dict[Any, Any]) -> str:
+    # NOTE: RFC 8785 sorts keys by UTF-16 code units. For our ASCII/BMP envelope
+    # field names this equals Python's default sorted() over str keys. Non-BMP
+    # keys would require UTF-16 ordering (out of scope; our keys are ASCII).
+    items = []
+    for key in sorted(obj.keys()):
+        if not isinstance(key, str):
+            raise ValueError("JCS object keys must be strings")
+        items.append(_escape_string(key) + ":" + _serialize(obj[key]))
+    return "{" + ",".join(items) + "}"
+
+
+def _escape_string(s: str) -> str:
+    out = ['"']
+    for ch in s:
+        code = ord(ch)
+        escape = _SHORT_ESCAPES.get(code)
+        if escape is not None:
+            out.append(escape)
+        elif code < 0x20:
+            # Remaining control chars -> \u00XX (lowercase hex per RFC 8785).
+            out.append(f"\\u{code:04x}")
+        else:
+            # Printable / non-ASCII emitted raw (UTF-8); solidus NOT escaped.
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+def _format_float(x: float) -> str:
+    """Format a Python float per ECMAScript Number.prototype.toString (RFC 8785)."""
+    if x != x or x in (float("inf"), float("-inf")):
+        raise ValueError("NaN and Infinity are not valid JCS numbers")
+    if x == 0.0:
+        return "0"  # covers both 0.0 and -0.0
+
+    sign = "-" if x < 0 else ""
+    digits, n = _shortest_digits_and_point(abs(x))
+    k = len(digits)
+
+    if k <= n <= 21:
+        body = digits + "0" * (n - k)
+    elif 0 < n <= 21:
+        body = digits[:n] + "." + digits[n:]
+    elif -6 < n <= 0:
+        body = "0." + "0" * (-n) + digits
+    else:
+        # Exponential: first digit, optional fraction, then e±exp.
+        if k > 1:
+            mantissa = digits[0] + "." + digits[1:]
+        else:
+            mantissa = digits[0]
+        exp = n - 1
+        exp_sign = "+" if exp >= 0 else "-"
+        body = f"{mantissa}e{exp_sign}{abs(exp)}"
+    return sign + body
+
+
+def _shortest_digits_and_point(x: float) -> tuple[str, int]:
+    """Return ``(digits, n)`` where ``x = digits * 10^(n - len(digits))``.
+
+    ``digits`` is the shortest round-trip significant-digit string with no
+    leading/trailing zeros; ``n`` is the position of the decimal point relative
+    to the start of ``digits`` (the power of ten of the first digit, plus one).
+    Built on Python's ``repr`` which already yields the shortest round-trip form.
+    """
+    rep = repr(x)  # x is positive, finite, nonzero here
+    if "e" in rep or "E" in rep:
+        mantissa, exp_part = rep.lower().split("e")
+        exp = int(exp_part)
+    else:
+        mantissa, exp = rep, 0
+
+    if "." in mantissa:
+        int_part, frac_part = mantissa.split(".")
+    else:
+        int_part, frac_part = mantissa, ""
+
+    # All significant digits, in order, with the decimal exponent of the last digit.
+    raw_digits = int_part + frac_part
+    # Decimal exponent applying to the least-significant digit of raw_digits.
+    low_exp = exp - len(frac_part)
+
+    # Strip leading zeros (track how many integer-side positions they were).
+    stripped_leading = raw_digits.lstrip("0")
+    if stripped_leading == "":
+        # Should not happen (x != 0), but guard defensively.
+        return "0", 1
+    # Strip trailing zeros, folding them into the exponent.
+    trailing_zeros = len(stripped_leading) - len(stripped_leading.rstrip("0"))
+    digits = stripped_leading.rstrip("0")
+    if digits == "":
+        digits = "0"
+    low_exp += trailing_zeros
+
+    # n = exponent of the most-significant digit, + 1.
+    # value = digits * 10^low_exp ; first digit weight = low_exp + (len(digits)-1).
+    n = low_exp + len(digits)
+    return digits, n

--- a/app/federation/discovery.py
+++ b/app/federation/discovery.py
@@ -16,8 +16,6 @@ slim-Lambda-safe (no Redis/LLM deps); Task 0.7 serves it from the slim Lambda.
 
 from app.core.config import Settings
 
-_ALLOWED_POLICIES = {"open", "mutual", "private"}
-
 
 def _host_from_did(did: str | None) -> str | None:
     """Derive the host from a ``did:web:<host>`` or ``https://<host>`` DID.
@@ -48,9 +46,9 @@ def build_discovery_doc(settings: Settings) -> dict:
 
     base = f"https://{domain}/api/v1/federation"
 
+    # FEDERATION_ALLOW_LIST_POLICY is a validated Literal on Settings, so a typo
+    # already failed at construction — use the value directly, no substitution.
     policy = settings.FEDERATION_ALLOW_LIST_POLICY
-    if policy not in _ALLOWED_POLICIES:
-        policy = "mutual"
 
     return {
         "did": settings.FEDERATION_DID,

--- a/app/federation/discovery.py
+++ b/app/federation/discovery.py
@@ -1,0 +1,68 @@
+"""Federation discovery document (``.well-known/hsds-federation``) — §8.4 / §6.7.
+
+A peer fetches this document to learn this node's DID, the location of its key
+(did.json), the HSDS versions it supports, its profile URI, the absolute URLs of
+its data endpoints, its allow-list policy, and its retention window.
+
+Version handling is **set-membership** (a list), not exact-match (§8.4): a v1
+node and a future v5 node can still federate if any advertised version is
+mutually supported. Endpoints are advertised as **absolute** URLs (OPR-style,
+§6.3) so partners never hard-code the ``/api/v1/federation`` prefix — the data
+router itself lands in P1/P3, but advertising the forward URLs now is correct.
+
+Imports are restricted to stdlib + ``app.core.config`` so this module stays
+slim-Lambda-safe (no Redis/LLM deps); Task 0.7 serves it from the slim Lambda.
+"""
+
+from app.core.config import Settings
+
+_ALLOWED_POLICIES = {"open", "mutual", "private"}
+
+
+def _host_from_did(did: str | None) -> str | None:
+    """Derive the host from a ``did:web:<host>`` or ``https://<host>`` DID.
+
+    Returns ``None`` for ``None`` input. Port encoding
+    (``did:web:host%3A8443``) is out of scope — a bare host is assumed per the
+    design (matches ``app.federation.identity._host_from_did`` for non-None).
+    """
+    if did is None:
+        return None
+    if did.startswith("did:web:"):
+        return did[len("did:web:") :]
+    if did.startswith("https://"):
+        return did[len("https://") :].split("/", 1)[0]
+    return did
+
+
+def build_discovery_doc(settings: Settings) -> dict:
+    """Build the ``.well-known/hsds-federation`` discovery document.
+
+    Renders a valid (status-200-able) doc even with all defaults: when neither
+    ``FEDERATION_DOMAIN`` nor ``FEDERATION_DID`` is configured, the host falls
+    back to ``"localhost"`` so endpoint/key URLs remain well-formed.
+    """
+    domain = settings.FEDERATION_DOMAIN or _host_from_did(settings.FEDERATION_DID)
+    if not domain:
+        domain = "localhost"
+
+    base = f"https://{domain}/api/v1/federation"
+
+    policy = settings.FEDERATION_ALLOW_LIST_POLICY
+    if policy not in _ALLOWED_POLICIES:
+        policy = "mutual"
+
+    return {
+        "did": settings.FEDERATION_DID,
+        "key_location": f"https://{domain}/.well-known/did.json",
+        "hsds_versions": settings.FEDERATION_HSDS_VERSIONS,
+        "profile_uri": settings.FEDERATION_PROFILE_URI,
+        "endpoints": {
+            "export": f"{base}/export",
+            "inbox": f"{base}/inbox",
+            "history": f"{base}/history",
+        },
+        "allow_list_policy": policy,
+        "retention_days": settings.FEDERATION_RETENTION_DAYS,
+        "contact": settings.FEDERATION_CONTACT,
+    }

--- a/app/federation/fetch.py
+++ b/app/federation/fetch.py
@@ -1,0 +1,80 @@
+"""Single hardened egress helper for ALL federation outbound HTTP (SSRF guard, §11.1).
+
+NOTE (deferred to P2/P3, do NOT implement until real peer fetches are wired):
+  1. DNS-rebinding connect-pin: connect to the *validated* IP while preserving SNI/Host
+     via a custom httpx transport, so the address resolved+checked in
+     ``_resolve_and_validate`` is the address actually dialed (closes the
+     resolve-then-connect TOCTOU window).
+  2. Streaming byte-counted hard cap: replace the header-only ``content-length`` check
+     with ``client.stream()`` + an incremental counter that aborts once the running
+     total exceeds ``_MAX_BYTES`` (defends against missing/lying content-length).
+Both are deferred together; the tested core here is IP-range validation and
+HTTPS-only enforcement.
+"""
+
+import ipaddress
+import socket
+
+import httpx
+
+_MAX_BYTES = 5 * 1024 * 1024
+_MAX_REDIRECTS = 3
+_TIMEOUT = httpx.Timeout(5.0, connect=3.0)
+
+
+class FederationFetchError(Exception):
+    """Raised when a federation fetch is rejected or fails safety checks."""
+
+
+def is_blocked_ip(ip: str) -> bool:
+    addr = ipaddress.ip_address(ip)
+    if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+        return True
+    if addr.is_multicast or addr.is_unspecified:
+        return True
+    # CGNAT 100.64.0.0/10 (not flagged is_private)
+    if addr.version == 4 and addr in ipaddress.ip_network("100.64.0.0/10"):
+        return True
+    return False
+
+
+def _resolve_and_validate(host: str) -> None:
+    try:
+        infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise FederationFetchError(f"DNS resolution failed for {host}") from exc
+    for info in infos:
+        ip = str(info[4][0])  # sockaddr[0] is the address; str() narrows for mypy
+        if is_blocked_ip(ip):
+            raise FederationFetchError(f"blocked internal IP {ip} for host {host}")
+
+
+async def hardened_get(url: str) -> httpx.Response:
+    """HTTPS-only GET with internal-IP blocking, redirect cap + per-hop revalidation, size cap."""
+    current = url
+    for _ in range(_MAX_REDIRECTS + 1):
+        parsed = httpx.URL(current)
+        if parsed.scheme != "https":
+            raise FederationFetchError(f"non-https URL rejected: {current}")
+        if parsed.host is None or _is_ip_literal(parsed.host):
+            raise FederationFetchError("IP-literal or hostless URL rejected")
+        _resolve_and_validate(parsed.host)
+        async with httpx.AsyncClient(
+            follow_redirects=False, timeout=_TIMEOUT
+        ) as client:
+            resp = await client.get(current)
+        if resp.is_redirect and resp.next_request is not None:
+            current = str(resp.next_request.url)  # revalidate next hop on loop
+            continue
+        if int(resp.headers.get("content-length", 0)) > _MAX_BYTES:
+            raise FederationFetchError("response exceeds size cap")
+        return resp
+    raise FederationFetchError("too many redirects")
+
+
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False

--- a/app/federation/fetch.py
+++ b/app/federation/fetch.py
@@ -28,6 +28,13 @@ class FederationFetchError(Exception):
 
 def is_blocked_ip(ip: str) -> bool:
     addr = ipaddress.ip_address(ip)
+    # Un-map IPv4-mapped IPv6 (::ffff:a.b.c.d) before any range check: such an
+    # address has version==6, so the v4-only CGNAT branch and (on some Python
+    # versions) the private/loopback/link-local checks are skipped, letting an
+    # attacker reach internal IPs (incl. IMDS 169.254.169.254) via a mapped
+    # literal. Unwrap to the v4 address so every check below applies (SSRF).
+    if addr.version == 6 and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
     if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
         return True
     if addr.is_multicast or addr.is_unspecified:

--- a/app/federation/identity.py
+++ b/app/federation/identity.py
@@ -183,3 +183,23 @@ def build_actor(did: str, domain: str, public_key_multibase: str) -> dict:
             "publicKeyMultibase": public_key_multibase,
         },
     }
+
+
+def build_webfinger(resource: str, actor_url: str) -> dict:
+    """Build a WebFinger JRD (RFC 7033) resolving an ``acct:`` handle.
+
+    A peer queries ``/.well-known/webfinger?resource=acct:<handle>`` to
+    discover the actor document URL — the discovery entry point alongside
+    ``did.json``. This is a pure shape builder; query parsing and the
+    ``resource``-absent 422 are HTTP concerns handled by the route (Task 0.7).
+    """
+    return {
+        "subject": resource,
+        "links": [
+            {
+                "rel": "self",
+                "type": "application/activity+json",
+                "href": actor_url,
+            },
+        ],
+    }

--- a/app/federation/identity.py
+++ b/app/federation/identity.py
@@ -117,6 +117,7 @@ def build_did_document(
     did: str,
     public_key_multibase: str,
     recovery_keys_multibase: list[str] | None = None,
+    actor_url: str | None = None,
 ) -> dict:
     """Build a W3C DID document with an ordered, priority-tagged key list.
 
@@ -124,6 +125,11 @@ def build_did_document(
     keys (offline, ``priority >= 10``) precede the online signing key
     (``#main-key``, ``priority == 1``). P3 enforces that a key change must be
     signed by a key of ``>=`` priority; P0 ships the schema only.
+
+    ``alsoKnownAs`` advertises where the actor doc is served. When ``actor_url``
+    is given it is used verbatim (the caller passes the URL built from the
+    resolved node domain, which may differ from the DID host); when ``None`` it
+    falls back to the did-host-derived URL.
     """
     main_key = {
         "id": f"{did}#main-key",
@@ -146,7 +152,9 @@ def build_did_document(
     # Highest priority first: recovery keys before the main key.
     verification_method = [*reversed(recovery_methods), main_key]
 
-    host = _host_from_did(did)
+    if actor_url is None:
+        host = _host_from_did(did)
+        actor_url = f"https://{host}/api/v1/federation/actor"
     return {
         "@context": [
             "https://www.w3.org/ns/did/v1",
@@ -156,7 +164,7 @@ def build_did_document(
         "verificationMethod": verification_method,
         "authentication": [f"{did}#main-key"],
         "assertionMethod": [f"{did}#main-key"],
-        "alsoKnownAs": [f"https://{host}/api/v1/federation/actor"],
+        "alsoKnownAs": [actor_url],
     }
 
 

--- a/app/federation/identity.py
+++ b/app/federation/identity.py
@@ -1,0 +1,185 @@
+"""Federation identity: did:web document, ActivityStreams actor, key loading.
+
+Implements the recovery-key hierarchy schema (design §6.1a, did:plc-inspired).
+``did:web`` derives trust from DNS+TLS, which is trust-on-first-use and as
+strong as the operator's domain control. To harden key rotation we ship an
+**ordered** ``verificationMethod`` list carrying an explicit integer
+``priority`` per entry: offline recovery keys outrank the online signing key,
+so a compromised online key cannot authorize an unbounded key change.
+
+P0 ships the forward-compatible SCHEMA only (issue #532). The verify-side
+priority-enforcement rule — a key-change must be signed by a key of
+``>=`` the priority being changed — ships in **P3** per the implementation
+plan; this module deliberately does NOT implement that enforcement.
+
+multibase encoding: ``publicKeyMultibase`` follows the W3C
+Ed25519VerificationKey2020 suite — base58btc ("z" prefix) over the
+``0xed 0x01`` ed25519-pub multicodec prefix followed by the 32 raw public key
+bytes. The encoding is hand-rolled (no ``base58`` dependency) so non-PPR
+partners can implement against the standard without our exact toolchain.
+"""
+
+import base64
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+# Bitcoin / base58btc alphabet.
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+# multicodec varint prefix for ed25519-pub.
+_ED25519_PUB_MULTICODEC = b"\xed\x01"
+
+# Priority convention: HIGHER priority == HIGHER authority. Recovery keys
+# (offline) outrank the online signing key so they can authorize key changes
+# the online key cannot. The list is ordered highest-priority-first.
+_MAIN_KEY_PRIORITY = 1
+_RECOVERY_KEY_PRIORITY_BASE = 10
+
+
+def _b58encode(data: bytes) -> str:
+    """Encode bytes as base58btc. Used only when ``base58`` is unavailable."""
+    num = int.from_bytes(data, "big")
+    encoded = ""
+    while num > 0:
+        num, rem = divmod(num, 58)
+        encoded = _B58_ALPHABET[rem] + encoded
+    # Each leading zero byte maps to a leading '1'.
+    pad = 0
+    for byte in data:
+        if byte == 0:
+            pad += 1
+        else:
+            break
+    return "1" * pad + encoded
+
+
+def public_key_multibase(public_key: Ed25519PublicKey) -> str:
+    """Encode an Ed25519 public key as a W3C ``publicKeyMultibase`` string."""
+    raw = public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    payload = _ED25519_PUB_MULTICODEC + raw
+    try:
+        import base58
+
+        return "z" + base58.b58encode(payload).decode("ascii")
+    except ImportError:
+        return "z" + _b58encode(payload)
+
+
+def load_signing_key(material: str | None) -> Ed25519PrivateKey | None:
+    """Load an Ed25519 private key from PEM or a base64 raw 32-byte seed.
+
+    ``None`` material yields ``None`` (no key configured). PEM material (starts
+    with ``-----BEGIN``) is parsed via PKCS8; otherwise the material is treated
+    as a base64-encoded 32-byte raw seed. Any parse failure raises
+    ``ValueError`` — never a silent ``None`` (Principle XI).
+    """
+    if material is None:
+        return None
+
+    if material.lstrip().startswith("-----BEGIN"):
+        try:
+            key = serialization.load_pem_private_key(
+                material.encode("utf-8"), password=None
+            )
+        except (ValueError, TypeError) as exc:
+            raise ValueError("invalid PEM Ed25519 private key") from exc
+        if not isinstance(key, Ed25519PrivateKey):
+            raise ValueError("PEM key is not an Ed25519 private key")
+        return key
+
+    try:
+        raw = base64.b64decode(material, validate=True)
+        return Ed25519PrivateKey.from_private_bytes(raw)
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        raise ValueError("invalid base64 Ed25519 seed") from exc
+
+
+def _host_from_did(did: str) -> str:
+    """Derive the host from a ``did:web:<host>`` or ``https://<host>`` DID.
+
+    Port encoding (``did:web:host%3A8443``) is out of scope — a bare host is
+    assumed per the design.
+    """
+    if did.startswith("did:web:"):
+        return did[len("did:web:") :]
+    if did.startswith("https://"):
+        return did[len("https://") :].split("/", 1)[0]
+    return did
+
+
+def build_did_document(
+    did: str,
+    public_key_multibase: str,
+    recovery_keys_multibase: list[str] | None = None,
+) -> dict:
+    """Build a W3C DID document with an ordered, priority-tagged key list.
+
+    The ``verificationMethod`` list is ordered highest-priority-first: recovery
+    keys (offline, ``priority >= 10``) precede the online signing key
+    (``#main-key``, ``priority == 1``). P3 enforces that a key change must be
+    signed by a key of ``>=`` priority; P0 ships the schema only.
+    """
+    main_key = {
+        "id": f"{did}#main-key",
+        "type": "Ed25519VerificationKey2020",
+        "controller": did,
+        "publicKeyMultibase": public_key_multibase,
+        "priority": _MAIN_KEY_PRIORITY,
+    }
+
+    recovery_methods = [
+        {
+            "id": f"{did}#recovery-key-{i}",
+            "type": "Ed25519VerificationKey2020",
+            "controller": did,
+            "publicKeyMultibase": mb,
+            "priority": _RECOVERY_KEY_PRIORITY_BASE + i,
+        }
+        for i, mb in enumerate(recovery_keys_multibase or [])
+    ]
+    # Highest priority first: recovery keys before the main key.
+    verification_method = [*reversed(recovery_methods), main_key]
+
+    host = _host_from_did(did)
+    return {
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+        ],
+        "id": did,
+        "verificationMethod": verification_method,
+        "authentication": [f"{did}#main-key"],
+        "assertionMethod": [f"{did}#main-key"],
+        "alsoKnownAs": [f"https://{host}/api/v1/federation/actor"],
+    }
+
+
+def build_actor(did: str, domain: str, public_key_multibase: str) -> dict:
+    """Build an ActivityStreams-style federation actor document.
+
+    Federation data endpoints mount under ``/api/v1/federation/*`` and are
+    advertised as absolute URLs. The ``inbox`` lands in P3 and the ``outbox``
+    (export) in P1; advertising the forward URLs now is intentional.
+    """
+    base = f"https://{domain}/api/v1/federation"
+    return {
+        "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            "https://w3id.org/security/v1",
+        ],
+        "id": f"{base}/actor",
+        "type": "Service",
+        "inbox": f"{base}/inbox",
+        "outbox": f"{base}/export",
+        "publicKey": {
+            "id": f"{did}#main-key",
+            "owner": did,
+            "publicKeyMultibase": public_key_multibase,
+        },
+    }

--- a/app/federation/routes_public.py
+++ b/app/federation/routes_public.py
@@ -1,0 +1,101 @@
+"""Root-level public federation routes (Task 0.7, Principle XV).
+
+These make PPR *discoverable*. A peer fetches:
+
+* ``GET /.well-known/hsds-federation`` — the discovery doc (§8.4 / §6.7):
+  DID, key location, supported HSDS versions, profile, endpoint URLs,
+  allow-list policy, retention.
+* ``GET /.well-known/did.json`` — the W3C DID document with the node's keys.
+* ``GET /.well-known/webfinger?resource=...`` — RFC 7033 JRD resolving an
+  ``acct:`` handle to the actor URL.
+* ``GET /api/v1/federation/actor`` — the ActivityStreams actor doc advertised
+  by did.json (``alsoKnownAs``) and the discovery doc.
+
+did:web and WebFinger REQUIRE the ``.well-known`` paths at the domain root, so
+they cannot live under the ``/api/v1`` prefix. ``register_federation_public_routes``
+is the single seam both the Uvicorn app (``app/main.py``) and the slim Lambda
+(``app/api/lambda_app.py``) call, so the routes behave identically in both.
+
+Imports are restricted to ``fastapi`` + ``app.federation.{identity,discovery}``
++ ``app.core.config`` — NO Redis/RQ/LLM — so the slim Lambda image stays slim.
+Handlers read the module-level ``settings`` singleton at call time so tests can
+monkeypatch it.
+"""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from app.core.config import settings
+from app.federation.discovery import _host_from_did, build_discovery_doc
+from app.federation.identity import (
+    build_actor,
+    build_did_document,
+    build_webfinger,
+    load_signing_key,
+    public_key_multibase,
+)
+
+
+def _node_domain() -> str:
+    """Resolve the node's public host, matching the discovery doc derivation."""
+    domain = settings.FEDERATION_DOMAIN or _host_from_did(settings.FEDERATION_DID)
+    return domain or "localhost"
+
+
+def _signing_key_multibase() -> str | None:
+    """Return the node's online public key as multibase, or ``None``.
+
+    ``None`` when ``FEDERATION_DID`` is unset or no signing key is configured.
+    """
+    if not settings.FEDERATION_DID:
+        return None
+    private_key = load_signing_key(settings.FEDERATION_SIGNING_KEY)
+    if private_key is None:
+        return None
+    return public_key_multibase(private_key.public_key())
+
+
+def register_federation_public_routes(app: FastAPI) -> None:
+    """Register the root-level public federation routes onto ``app``.
+
+    Called by both ``app/main.py`` and ``app/api/lambda_app.py`` so the
+    discovery surface is identical across Uvicorn and the slim Lambda
+    (Principle XV).
+    """
+
+    @app.get("/.well-known/hsds-federation", include_in_schema=False)
+    async def hsds_federation_discovery() -> JSONResponse:
+        """Serve the federation discovery doc — always 200 (renders defaults)."""
+        return JSONResponse(build_discovery_doc(settings))
+
+    @app.get("/.well-known/did.json", include_in_schema=False)
+    async def did_document() -> JSONResponse:
+        """Serve the DID document — 404 until DID + signing key are configured."""
+        mb = _signing_key_multibase()
+        if settings.FEDERATION_DID is None or mb is None:
+            raise HTTPException(status_code=404, detail="DID not configured")
+        return JSONResponse(
+            build_did_document(settings.FEDERATION_DID, mb),
+            media_type="application/json",
+        )
+
+    @app.get("/.well-known/webfinger", include_in_schema=False)
+    async def webfinger(resource: str) -> JSONResponse:
+        """Resolve an ``acct:`` handle to the actor URL (RFC 7033).
+
+        ``resource`` is a required query parameter — FastAPI returns 422 when
+        it is absent.
+        """
+        actor_url = f"https://{_node_domain()}/api/v1/federation/actor"
+        return JSONResponse(
+            build_webfinger(resource, actor_url),
+            media_type="application/jrd+json",
+        )
+
+    @app.get("/api/v1/federation/actor", include_in_schema=False)
+    async def federation_actor() -> JSONResponse:
+        """Serve the actor doc — 404 until DID + signing key are configured."""
+        mb = _signing_key_multibase()
+        if settings.FEDERATION_DID is None or mb is None:
+            raise HTTPException(status_code=404, detail="actor not configured")
+        return JSONResponse(build_actor(settings.FEDERATION_DID, _node_domain(), mb))

--- a/app/federation/routes_public.py
+++ b/app/federation/routes_public.py
@@ -22,6 +22,7 @@ Handlers read the module-level ``settings`` singleton at call time so tests can
 monkeypatch it.
 """
 
+import structlog
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
@@ -35,6 +36,8 @@ from app.federation.identity import (
     public_key_multibase,
 )
 
+_logger = structlog.get_logger(__name__)
+
 
 def _node_domain() -> str:
     """Resolve the node's public host, matching the discovery doc derivation."""
@@ -42,14 +45,26 @@ def _node_domain() -> str:
     return domain or "localhost"
 
 
+def _actor_url() -> str:
+    """The absolute actor URL this node serves (from the resolved node domain)."""
+    return f"https://{_node_domain()}/api/v1/federation/actor"
+
+
 def _signing_key_multibase() -> str | None:
     """Return the node's online public key as multibase, or ``None``.
 
     ``None`` when ``FEDERATION_DID`` is unset or no signing key is configured.
+    A *malformed* ``FEDERATION_SIGNING_KEY`` (``load_signing_key`` raises
+    ``ValueError``) is logged and treated as "no key" → callers 404 instead of
+    surfacing an opaque, un-logged 500 (Principle XI graceful / XII observable).
     """
     if not settings.FEDERATION_DID:
         return None
-    private_key = load_signing_key(settings.FEDERATION_SIGNING_KEY)
+    try:
+        private_key = load_signing_key(settings.FEDERATION_SIGNING_KEY)
+    except ValueError as exc:
+        _logger.error("federation_signing_key_invalid", error=str(exc))
+        return None
     if private_key is None:
         return None
     return public_key_multibase(private_key.public_key())
@@ -75,7 +90,7 @@ def register_federation_public_routes(app: FastAPI) -> None:
         if settings.FEDERATION_DID is None or mb is None:
             raise HTTPException(status_code=404, detail="DID not configured")
         return JSONResponse(
-            build_did_document(settings.FEDERATION_DID, mb),
+            build_did_document(settings.FEDERATION_DID, mb, actor_url=_actor_url()),
             media_type="application/json",
         )
 
@@ -86,9 +101,8 @@ def register_federation_public_routes(app: FastAPI) -> None:
         ``resource`` is a required query parameter — FastAPI returns 422 when
         it is absent.
         """
-        actor_url = f"https://{_node_domain()}/api/v1/federation/actor"
         return JSONResponse(
-            build_webfinger(resource, actor_url),
+            build_webfinger(resource, _actor_url()),
             media_type="application/jrd+json",
         )
 

--- a/app/federation/signing.py
+++ b/app/federation/signing.py
@@ -1,0 +1,137 @@
+"""RFC 9421 HTTP Message Signatures — minimal Ed25519 profile.
+
+Covered components are fixed at ``("@method" "@target-uri" "content-digest")``;
+``created`` / ``keyid`` / ``alg="ed25519"`` are signature parameters. The
+content-digest header follows RFC 9530 (``sha-256=:<b64>:``).
+
+Design-forward: the P1 envelope ``proof`` (Ed25519 over ``jcs_bytes(envelope)``)
+reuses the same key type. The raw ``private_key.sign(bytes)`` /
+``public_key.verify(sig, bytes)`` primitives stay directly available here.
+"""
+
+import base64
+import hashlib
+import re
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+_COVERED = '("@method" "@target-uri" "content-digest")'
+_SIG_LABEL = "sig1"
+
+
+class SignatureError(Exception):
+    """Raised on any HTTP Message Signature construction or verification failure."""
+
+
+def _signature_params(created: int, keyid: str) -> str:
+    return f'{_COVERED};created={created};keyid="{keyid}";alg="ed25519"'
+
+
+def build_signature_base(
+    method: str,
+    target_uri: str,
+    content_digest: str,
+    created: int,
+    keyid: str,
+) -> str:
+    """Build the RFC 9421 signature base string (no trailing newline)."""
+    return (
+        f'"@method": {method}\n'
+        f'"@target-uri": {target_uri}\n'
+        f'"content-digest": {content_digest}\n'
+        f'"@signature-params": {_signature_params(created, keyid)}'
+    )
+
+
+def _content_digest(body: bytes) -> str:
+    """RFC 9530 Content-Digest for SHA-256."""
+    digest = base64.b64encode(hashlib.sha256(body).digest()).decode("ascii")
+    return f"sha-256=:{digest}:"
+
+
+def sign_request(
+    private_key: Ed25519PrivateKey,
+    keyid: str,
+    method: str,
+    target_uri: str,
+    body: bytes,
+    created: int,
+) -> dict[str, str]:
+    """Sign a request; return the Content-Digest, Signature-Input, Signature headers."""
+    content_digest = _content_digest(body)
+    base = build_signature_base(method, target_uri, content_digest, created, keyid)
+    signature = private_key.sign(base.encode("utf-8"))
+    sig_b64 = base64.b64encode(signature).decode("ascii")
+    return {
+        "Content-Digest": content_digest,
+        "Signature-Input": f"{_SIG_LABEL}={_signature_params(created, keyid)}",
+        "Signature": f"{_SIG_LABEL}=:{sig_b64}:",
+    }
+
+
+def _parse_param(signature_input: str, name: str) -> str:
+    """Extract a single parameter value from the Signature-Input header."""
+    match = re.search(rf";{name}=\"?([^\";]+)\"?", signature_input)
+    if match is None:
+        raise SignatureError(f"missing {name} in Signature-Input")
+    return match.group(1)
+
+
+def _extract_signature(signature_header: str) -> bytes:
+    """Strip the ``sig1=:<b64>:`` wrapper and decode the base64 signature."""
+    match = re.search(r"=:(.+):\s*$", signature_header.strip())
+    if match is None:
+        raise SignatureError("malformed Signature header")
+    try:
+        return base64.b64decode(match.group(1), validate=True)
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        raise SignatureError("invalid base64 in Signature header") from exc
+
+
+def verify_request(
+    public_key: Ed25519PublicKey,
+    method: str,
+    target_uri: str,
+    headers: dict[str, str],
+    body: bytes,
+    max_skew_seconds: int,
+    now: int,
+) -> None:
+    """Verify a signed request. Raise ``SignatureError`` on any failure."""
+    received_digest = headers.get("Content-Digest")
+    if received_digest is None:
+        raise SignatureError("missing Content-Digest header")
+    # 1. Body integrity: recomputed digest must match the header.
+    if _content_digest(body) != received_digest:
+        raise SignatureError("content-digest mismatch (body tampered)")
+
+    signature_input = headers.get("Signature-Input")
+    if signature_input is None:
+        raise SignatureError("missing Signature-Input header")
+    signature_header = headers.get("Signature")
+    if signature_header is None:
+        raise SignatureError("missing Signature header")
+
+    # 2. Replay window.
+    try:
+        created = int(_parse_param(signature_input, "created"))
+    except ValueError as exc:
+        raise SignatureError("invalid created parameter") from exc
+    if abs(now - created) > max_skew_seconds:
+        raise SignatureError("created timestamp outside allowed skew")
+
+    keyid = _parse_param(signature_input, "keyid")
+
+    # 3. Rebuild the base from the verified digest + parsed params.
+    base = build_signature_base(method, target_uri, received_digest, created, keyid)
+
+    # 4. Verify the Ed25519 signature over the base.
+    signature = _extract_signature(signature_header)
+    try:
+        public_key.verify(signature, base.encode("utf-8"))
+    except InvalidSignature as exc:
+        raise SignatureError("Ed25519 signature verification failed") from exc

--- a/app/federation/signing.py
+++ b/app/federation/signing.py
@@ -102,17 +102,21 @@ def verify_request(
     now: int,
 ) -> None:
     """Verify a signed request. Raise ``SignatureError`` on any failure."""
-    received_digest = headers.get("Content-Digest")
+    # ASGI/Starlette lowercases header keys, so normalize before lookup — a
+    # case-sensitive get would silently reject every valid signature from a
+    # real request.headers mapping.
+    h = {k.lower(): v for k, v in headers.items()}
+    received_digest = h.get("content-digest")
     if received_digest is None:
         raise SignatureError("missing Content-Digest header")
     # 1. Body integrity: recomputed digest must match the header.
     if _content_digest(body) != received_digest:
         raise SignatureError("content-digest mismatch (body tampered)")
 
-    signature_input = headers.get("Signature-Input")
+    signature_input = h.get("signature-input")
     if signature_input is None:
         raise SignatureError("missing Signature-Input header")
-    signature_header = headers.get("Signature")
+    signature_header = h.get("signature")
     if signature_header is None:
         raise SignatureError("missing Signature header")
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from starlette import status
 from app.api.v1.router import router as v1_router
 from app.core.config import Settings
 from app.core.events import create_start_app_handler, create_stop_app_handler
+from app.federation.routes_public import register_federation_public_routes
 from app.middleware.correlation import CorrelationMiddleware
 from app.middleware.errors import ErrorHandlingMiddleware
 from app.middleware.metrics import MetricsMiddleware
@@ -76,3 +77,6 @@ app.add_event_handler("shutdown", create_stop_app_handler(app))
 
 # Include routers - mount v1 routes under prefix
 app.include_router(v1_router, prefix=settings.api_prefix)
+
+# Root-level public federation discovery routes (Principle XV: identical to Lambda)
+register_federation_public_routes(app)

--- a/profiles/hsds-ppr/README.md
+++ b/profiles/hsds-ppr/README.md
@@ -1,0 +1,74 @@
+# Pantry Pirate Radio HSDS Profile
+
+This directory is the Pantry Pirate Radio (PPR) **HSDS Profile**: a set of
+modifications to the Human Services Data Specification (HSDS) that PPR declares
+itself conformant to.
+
+## What this is
+
+Per the HSDS Profiles Specification, a Profile is expressed as a set of files
+that describe changes to the canonical HSDS schema files via **JSON Merge Patch
+([RFC 7386](https://datatracker.ietf.org/doc/html/rfc7386))**. Each file shares
+the filename of the HSDS schema it modifies; merging the patch over the canonical
+HSDS schema must produce valid JSON Schema (object schemas) or a valid OpenAPI 3.1
+document (`openapi.json`).
+
+Files in this Profile:
+
+- `location.json` — merge patch over the HSDS `location` schema.
+- `service.json` — merge patch over the HSDS `service` schema.
+- `openapi.json` — merge patch over the HSDS API specification.
+
+## Permitted modifications only
+
+Per the HSDS Profiles "Permitted Modifications" rules, this Profile only
+**adds new OPTIONAL properties** to the core schemas. It does **not** add any
+property to a schema's `required` array, does not override or remove any core
+property, and the added terms do not overlap semantically with existing HSDS
+terms.
+
+The added optional properties on both `location` and `service` are:
+
+| Property           | Type             | Notes                                                                                  |
+| ------------------ | ---------------- | -------------------------------------------------------------------------------------- |
+| `confidence_score` | integer (0–100)  | PPR data-quality confidence. Scraped data capped at 90; 91–100 are human corrections.  |
+| `verified_by`      | string enum      | `auto` / `admin` / `source` / `claimed` / `network` — provenance of the verification.  |
+| `sources`          | array of strings | Scraper / network identifiers that corroborated the record (multi-source corroboration). |
+
+These mirror fields PPR already emits. The `openapi.json` patch documents the
+forthcoming `/api/v1/federation/*` endpoints (`/export`, `/actor`, `/inbox`,
+`/history`); those operations land fully in later federation phases (P1/P3) — the
+Profile documents them now as new optional API endpoints.
+
+## HSDS baseline: 3.1.1 (honest)
+
+This Profile is pinned to the **HSDS 3.1.1** baseline. PPR's Pydantic models
+(`app/models/hsds/`) are genuinely 3.1.1-shaped: they intentionally omit the
+decisive HSDS 3.2 additions (`additional_websites`, `additional_urls`, the
+`attributes` collection, and `metadata`). The vendored HSDS specification
+submodule under `docs/HSDS/` is pinned at v3.2.3, but the running implementation
+is 3.1.1 — so this Profile and the API root metadata both honestly advertise
+**3.1.1** rather than the submodule's tag. Revisit the baseline when the models
+are upgraded to 3.2.
+
+Adding only optional properties is itself version-agnostic, but the patches are
+authored against the 3.1.1 schema shape that the models actually implement; they
+do not assume any 3.2 field exists.
+
+## Canonical Profile URI
+
+```
+https://hsds-federation.pantrypirateradio.org/profile
+```
+
+The API root (`GET /api/v1/`) advertises this URI as the value of its `profile`
+field, sourced from `settings.FEDERATION_PROFILE_URI` so the router and the
+federation discovery document stay in lockstep.
+
+## Hosting (future work)
+
+The HSDS Profiles spec recommends serving the modification files (and
+pre-generated `/schema` compilations) under the Profile's canonical URI, on a
+publicly accessible host. Hosting this Profile on the neutral HSDS-FX domain
+(design §8.5) is future work; for now the files live in-repo and the router
+points at the canonical URI.

--- a/profiles/hsds-ppr/location.json
+++ b/profiles/hsds-ppr/location.json
@@ -1,0 +1,31 @@
+{
+  "properties": {
+    "confidence_score": {
+      "name": "confidence_score",
+      "type": "integer",
+      "title": "Confidence Score",
+      "description": "Pantry Pirate Radio data-quality confidence for this location, 0-100. Scraped data is capped at 90; values 91-100 are reserved for human corrections. Optional profile extension.",
+      "minimum": 0,
+      "maximum": 100,
+      "core": "N"
+    },
+    "verified_by": {
+      "name": "verified_by",
+      "type": "string",
+      "title": "Verified By",
+      "description": "Provenance of the most authoritative verification for this location. Optional profile extension.",
+      "enum": ["auto", "admin", "source", "claimed", "network"],
+      "core": "N"
+    },
+    "sources": {
+      "name": "sources",
+      "type": "array",
+      "title": "Sources",
+      "description": "Identifiers of the scrapers or networks that corroborated this location. Optional profile extension supporting multi-source corroboration.",
+      "items": {
+        "type": "string"
+      },
+      "core": "N"
+    }
+  }
+}

--- a/profiles/hsds-ppr/openapi.json
+++ b/profiles/hsds-ppr/openapi.json
@@ -1,0 +1,56 @@
+{
+  "paths": {
+    "/api/v1/federation/export": {
+      "get": {
+        "summary": "Export HSDS records for federation peers",
+        "description": "Returns a signed, paginated export of canonical HSDS records for consumption by federation peers. Optional profile endpoint; lands fully in P1.",
+        "operationId": "federationExport",
+        "tags": ["federation"],
+        "responses": {
+          "200": {
+            "description": "A page of HSDS records with federation provenance."
+          }
+        }
+      }
+    },
+    "/api/v1/federation/inbox": {
+      "post": {
+        "summary": "Receive HSDS records from a federation peer",
+        "description": "Accepts signed HSDS record submissions from an authenticated federation peer. Optional profile endpoint; lands fully in P3.",
+        "operationId": "federationInbox",
+        "tags": ["federation"],
+        "responses": {
+          "202": {
+            "description": "Submission accepted for processing."
+          }
+        }
+      }
+    },
+    "/api/v1/federation/history": {
+      "get": {
+        "summary": "Change history for a federated record",
+        "description": "Returns the provenance and change history of a federated HSDS record. Optional profile endpoint; lands fully in P3.",
+        "operationId": "federationHistory",
+        "tags": ["federation"],
+        "responses": {
+          "200": {
+            "description": "Change history entries for the requested record."
+          }
+        }
+      }
+    },
+    "/api/v1/federation/actor": {
+      "get": {
+        "summary": "Federation actor / node identity",
+        "description": "Returns this node's federation actor document, including its DID and public signing keys. Optional profile endpoint; lands fully in P1.",
+        "operationId": "federationActor",
+        "tags": ["federation"],
+        "responses": {
+          "200": {
+            "description": "The federation actor document for this node."
+          }
+        }
+      }
+    }
+  }
+}

--- a/profiles/hsds-ppr/openapi.json
+++ b/profiles/hsds-ppr/openapi.json
@@ -42,7 +42,7 @@
     "/api/v1/federation/actor": {
       "get": {
         "summary": "Federation actor / node identity",
-        "description": "Returns this node's federation actor document, including its DID and public signing keys. Optional profile endpoint; lands fully in P1.",
+        "description": "Returns this node's federation actor document, including its DID and public signing keys. Served in P0; the data endpoints (/export, /inbox, /history) are forthcoming (P1/P3).",
         "operationId": "federationActor",
         "tags": ["federation"],
         "responses": {

--- a/profiles/hsds-ppr/service.json
+++ b/profiles/hsds-ppr/service.json
@@ -1,0 +1,31 @@
+{
+  "properties": {
+    "confidence_score": {
+      "name": "confidence_score",
+      "type": "integer",
+      "title": "Confidence Score",
+      "description": "Pantry Pirate Radio data-quality confidence for this service, 0-100. Scraped data is capped at 90; values 91-100 are reserved for human corrections. Optional profile extension.",
+      "minimum": 0,
+      "maximum": 100,
+      "core": "N"
+    },
+    "verified_by": {
+      "name": "verified_by",
+      "type": "string",
+      "title": "Verified By",
+      "description": "Provenance of the most authoritative verification for this service. Optional profile extension.",
+      "enum": ["auto", "admin", "source", "claimed", "network"],
+      "core": "N"
+    },
+    "sources": {
+      "name": "sources",
+      "type": "array",
+      "title": "Sources",
+      "description": "Identifiers of the scrapers or networks that corroborated this service. Optional profile extension supporting multi-source corroboration.",
+      "items": {
+        "type": "string"
+      },
+      "core": "N"
+    }
+  }
+}

--- a/tests/test_federation/test_canonical.py
+++ b/tests/test_federation/test_canonical.py
@@ -1,0 +1,38 @@
+import pytest
+
+from app.federation.canonical import jcs_bytes
+
+
+def test_jcs_orders_keys_and_strips_whitespace():
+    # RFC 8785: lexicographic key order, no insignificant whitespace, UTF-8
+    assert jcs_bytes({"b": 1, "a": "ü"}) == '{"a":"ü","b":1}'.encode()
+
+
+def test_jcs_is_stable_across_dict_insertion_order():
+    assert jcs_bytes({"x": [2, 1], "a": True}) == jcs_bytes(
+        dict([("a", True), ("x", [2, 1])])
+    )
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ({"a": 1, "b": 2}, '{"a":1,"b":2}'),  # int passthrough
+        ({"n": 0}, '{"n":0}'),
+        ({"n": -0.0}, '{"n":0}'),  # negative zero -> "0"
+        ({"n": 1.0}, '{"n":1}'),  # integral float -> "1"
+        ({"n": 4.50}, '{"n":4.5}'),  # trailing zero stripped
+        ({"n": 0.002}, '{"n":0.002}'),  # 2e-3 -> 0.002 (n=-2, fixed)
+        ({"n": 1e30}, '{"n":1e+30}'),  # large -> exponential, e+30
+        ({"n": 1e-7}, '{"n":1e-7}'),  # n=-6 boundary -> exponential
+        ({"n": 1e21}, '{"n":1e+21}'),  # n=21 boundary: 1e+21 (n>21 region)
+        ({"n": 1e20}, '{"n":100000000000000000000}'),  # n=21 -> fixed (k<=n<=21)
+        ({"n": 333333333.33333329}, '{"n":333333333.3333333}'),
+        ({"n": 1e-27}, '{"n":1e-27}'),
+        ({"t": True, "f": False, "z": None}, '{"f":false,"t":true,"z":null}'),
+        ({"s": 'a/b"c'}, '{"s":"a/b\\"c"}'),  # quote escaped; solidus NOT escaped
+        ({"arr": [3, 2.5, "x"]}, '{"arr":[3,2.5,"x"]}'),
+    ],
+)
+def test_jcs_rfc8785_official_vectors(value, expected):
+    assert jcs_bytes(value) == expected.encode("utf-8")

--- a/tests/test_federation/test_config.py
+++ b/tests/test_federation/test_config.py
@@ -1,0 +1,12 @@
+from app.core.config import Settings
+
+
+def test_federation_settings_have_safe_defaults():
+    s = Settings()
+    assert s.FEDERATION_ENABLED is True  # on by default (driver 3)
+    assert s.FEDERATION_DATE_SKEW_SECONDS == 300  # §8.3 replay window
+    assert s.FEDERATION_RETENTION_DAYS == 365  # OPR SLA
+    assert s.FEDERATION_INGEST_MAX_RECORDS_PER_PEER_PER_DAY > 0  # §11.3 budget
+    assert s.FEDERATION_DID is None or s.FEDERATION_DID.startswith(
+        ("did:web:", "https://")
+    )

--- a/tests/test_federation/test_config.py
+++ b/tests/test_federation/test_config.py
@@ -1,3 +1,6 @@
+import pydantic
+import pytest
+
 from app.core.config import Settings
 
 
@@ -10,3 +13,15 @@ def test_federation_settings_have_safe_defaults():
     assert s.FEDERATION_DID is None or s.FEDERATION_DID.startswith(
         ("did:web:", "https://")
     )
+
+
+def test_allow_list_policy_rejects_typo():
+    # A typo on this access-control field must error at construction (startup),
+    # not silently downgrade the advertised trust posture at serve time.
+    with pytest.raises(pydantic.ValidationError):
+        Settings(FEDERATION_ALLOW_LIST_POLICY="bogus")
+
+
+def test_allow_list_policy_accepts_valid_value():
+    s = Settings(FEDERATION_ALLOW_LIST_POLICY="private")
+    assert s.FEDERATION_ALLOW_LIST_POLICY == "private"

--- a/tests/test_federation/test_discovery.py
+++ b/tests/test_federation/test_discovery.py
@@ -1,0 +1,90 @@
+"""Tests for the .well-known/hsds-federation discovery document (§8.4 / §6.7).
+
+The discovery doc is how a peer learns this node's DID, key location, supported
+HSDS versions (set-membership, not exact-match), profile, endpoint URLs,
+allow-list policy, and retention. It must render a valid (status-200-able) doc
+with all defaults (domain -> "localhost") AND with a did:web DID (host derived).
+"""
+
+from app.core.config import Settings
+from app.federation.discovery import build_discovery_doc
+
+_EXPECTED_KEYS = {
+    "did",
+    "key_location",
+    "hsds_versions",
+    "profile_uri",
+    "endpoints",
+    "allow_list_policy",
+    "retention_days",
+    "contact",
+}
+
+
+def test_discovery_doc_with_defaults_is_valid() -> None:
+    settings = Settings()
+    doc = build_discovery_doc(settings)
+
+    # Exactly the contracted keys, no extras (§8.4 / §6.7 contract).
+    assert set(doc.keys()) == _EXPECTED_KEYS
+
+    # hsds_versions is a non-empty LIST (set-membership, §8.4).
+    assert isinstance(doc["hsds_versions"], list)
+    assert doc["hsds_versions"]
+    assert all(isinstance(v, str) for v in doc["hsds_versions"])
+    assert doc["hsds_versions"] == settings.FEDERATION_HSDS_VERSIONS
+
+    # allow_list_policy is one of the known values.
+    assert doc["allow_list_policy"] in {"open", "mutual", "private"}
+    assert doc["allow_list_policy"] == settings.FEDERATION_ALLOW_LIST_POLICY
+
+    # retention mirrors settings.
+    assert doc["retention_days"] == settings.FEDERATION_RETENTION_DAYS
+
+    # profile_uri and contact mirror settings.
+    assert doc["profile_uri"] == settings.FEDERATION_PROFILE_URI
+    assert doc["contact"] == settings.FEDERATION_CONTACT
+
+    # did may be None when unconfigured (allowed).
+    assert doc["did"] == settings.FEDERATION_DID
+
+    # With all defaults, domain falls back to "localhost".
+    assert doc["key_location"] == "https://localhost/.well-known/did.json"
+
+    # endpoints: absolute https:// URLs ending in the right paths.
+    endpoints = doc["endpoints"]
+    assert set(endpoints.keys()) == {"export", "inbox", "history"}
+    for value in endpoints.values():
+        assert value.startswith("https://")
+    assert endpoints["export"].endswith("/api/v1/federation/export")
+    assert endpoints["inbox"].endswith("/api/v1/federation/inbox")
+    assert endpoints["history"].endswith("/api/v1/federation/history")
+    # Default host is localhost.
+    assert endpoints["export"] == "https://localhost/api/v1/federation/export"
+
+
+def test_discovery_doc_derives_host_from_did_web() -> None:
+    settings = Settings(FEDERATION_DID="did:web:h.example")
+    doc = build_discovery_doc(settings)
+
+    assert doc["did"] == "did:web:h.example"
+    # Host derived from the did:web DID (FEDERATION_DOMAIN unset).
+    assert doc["key_location"] == "https://h.example/.well-known/did.json"
+    assert doc["endpoints"]["export"] == "https://h.example/api/v1/federation/export"
+    assert doc["endpoints"]["inbox"] == "https://h.example/api/v1/federation/inbox"
+    assert doc["endpoints"]["history"] == "https://h.example/api/v1/federation/history"
+
+
+def test_discovery_doc_domain_overrides_did_host() -> None:
+    settings = Settings(
+        FEDERATION_DID="did:web:h.example",
+        FEDERATION_DOMAIN="node.public.example",
+    )
+    doc = build_discovery_doc(settings)
+
+    # FEDERATION_DOMAIN takes precedence over the DID-derived host.
+    assert doc["key_location"] == "https://node.public.example/.well-known/did.json"
+    assert (
+        doc["endpoints"]["export"]
+        == "https://node.public.example/api/v1/federation/export"
+    )

--- a/tests/test_federation/test_fetch.py
+++ b/tests/test_federation/test_fetch.py
@@ -13,6 +13,12 @@ from app.federation.fetch import is_blocked_ip, FederationFetchError
         "::1",
         "fc00::1",
         "fe80::1",
+        # IPv4-mapped-IPv6 must be un-mapped before range checks (SSRF bypass).
+        "::ffff:127.0.0.1",
+        "::ffff:10.0.0.5",
+        "::ffff:192.168.1.1",
+        "::ffff:169.254.169.254",  # IMDS via mapped literal
+        "::ffff:100.64.0.1",  # CGNAT via mapped literal
     ],
 )
 def test_internal_ips_are_blocked(ip):

--- a/tests/test_federation/test_fetch.py
+++ b/tests/test_federation/test_fetch.py
@@ -1,0 +1,31 @@
+import pytest
+from app.federation.fetch import is_blocked_ip, FederationFetchError
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "10.0.0.5",
+        "192.168.1.1",
+        "169.254.169.254",  # IMDS
+        "100.64.0.1",  # CGNAT
+        "::1",
+        "fc00::1",
+        "fe80::1",
+    ],
+)
+def test_internal_ips_are_blocked(ip):
+    assert is_blocked_ip(ip) is True
+
+
+@pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2606:4700::1111"])
+def test_public_ips_are_allowed(ip):
+    assert is_blocked_ip(ip) is False
+
+
+async def test_fetch_rejects_non_https():  # asyncio auto-mode; no explicit marker (ruff PT)
+    with pytest.raises(FederationFetchError):
+        from app.federation.fetch import hardened_get
+
+        await hardened_get("http://example.com/x")  # http -> reject

--- a/tests/test_federation/test_identity.py
+++ b/tests/test_federation/test_identity.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 from app.federation.identity import (
     build_actor,
     build_did_document,
+    build_webfinger,
     load_signing_key,
     public_key_multibase,
 )
@@ -134,3 +135,15 @@ def test_build_actor_shape() -> None:
     assert actor["publicKey"]["owner"] == "did:web:h.example"
     assert actor["publicKey"]["id"] == "did:web:h.example#main-key"
     assert actor["publicKey"]["publicKeyMultibase"] == "zTEST"
+
+
+def test_build_webfinger_returns_jrd_with_self_link() -> None:
+    jrd = build_webfinger(
+        "acct:north-jersey-fb@h.example",
+        "https://h.example/api/v1/federation/actor",
+    )
+    assert jrd["subject"] == "acct:north-jersey-fb@h.example"
+    self_links = [link for link in jrd["links"] if link["rel"] == "self"]
+    assert len(self_links) == 1
+    assert self_links[0]["type"] == "application/activity+json"
+    assert self_links[0]["href"] == "https://h.example/api/v1/federation/actor"

--- a/tests/test_federation/test_identity.py
+++ b/tests/test_federation/test_identity.py
@@ -1,0 +1,136 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from app.federation.identity import (
+    build_actor,
+    build_did_document,
+    load_signing_key,
+    public_key_multibase,
+)
+
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58decode(data: str) -> bytes:
+    """Minimal base58btc decoder used only to pin the multibase round-trip."""
+    num = 0
+    for char in data:
+        num = num * 58 + _B58_ALPHABET.index(char)
+    body = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
+    pad = 0
+    for char in data:
+        if char == "1":
+            pad += 1
+        else:
+            break
+    return b"\x00" * pad + body
+
+
+def test_build_did_document_priority_ordering_and_also_known_as() -> None:
+    doc = build_did_document(
+        "did:web:h.example", "zTEST", recovery_keys_multibase=["zRECOVERY"]
+    )
+    assert doc["id"] == "did:web:h.example"
+
+    methods = doc["verificationMethod"]
+    main = next(m for m in methods if m["id"] == "did:web:h.example#main-key")
+    assert main["type"] == "Ed25519VerificationKey2020"
+    assert main["controller"] == "did:web:h.example"
+    assert main["publicKeyMultibase"] == "zTEST"
+    assert isinstance(main["priority"], int)
+
+    recovery = [m for m in methods if m["id"] != "did:web:h.example#main-key"]
+    assert len(recovery) >= 1
+    assert all(r["priority"] > main["priority"] for r in recovery)
+    assert recovery[0]["publicKeyMultibase"] == "zRECOVERY"
+
+    # Ordered highest-priority-first: recovery keys come before the main key.
+    priorities = [m["priority"] for m in methods]
+    assert priorities == sorted(priorities, reverse=True)
+    assert methods[-1]["id"] == "did:web:h.example#main-key"
+
+    assert doc["authentication"] == ["did:web:h.example#main-key"]
+    assert doc["assertionMethod"] == ["did:web:h.example#main-key"]
+    assert "https://h.example/api/v1/federation/actor" in doc["alsoKnownAs"]
+
+
+def test_build_did_document_no_recovery_keys() -> None:
+    doc = build_did_document("did:web:h.example", "zMAIN")
+    methods = doc["verificationMethod"]
+    assert len(methods) == 1
+    assert methods[0]["id"] == "did:web:h.example#main-key"
+
+
+def test_load_signing_key_none_returns_none() -> None:
+    assert load_signing_key(None) is None
+
+
+def test_load_signing_key_pem_roundtrips_and_signs() -> None:
+    original = Ed25519PrivateKey.generate()
+    pem = original.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+    loaded = load_signing_key(pem)
+    assert isinstance(loaded, Ed25519PrivateKey)
+
+    message = b"federation-proof"
+    signature = loaded.sign(message)
+    # Verifying with the original public key proves it is the same key.
+    original.public_key().verify(signature, message)
+
+
+def test_load_signing_key_base64_seed_roundtrips() -> None:
+    import base64
+
+    original = Ed25519PrivateKey.generate()
+    raw = original.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    seed_b64 = base64.b64encode(raw).decode("ascii")
+
+    loaded = load_signing_key(seed_b64)
+    assert isinstance(loaded, Ed25519PrivateKey)
+    message = b"seed-roundtrip"
+    original.public_key().verify(loaded.sign(message), message)
+
+
+def test_load_signing_key_raises_on_garbage() -> None:
+    with pytest.raises(ValueError):
+        load_signing_key("not-a-valid-key-!!!")
+
+
+def test_public_key_multibase_roundtrips_with_multicodec_prefix() -> None:
+    pub: Ed25519PublicKey = Ed25519PrivateKey.generate().public_key()
+    raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+    mb = public_key_multibase(pub)
+    assert mb.startswith("z")
+
+    decoded = _b58decode(mb[1:])
+    assert decoded[0] == 0xED
+    assert decoded[1] == 0x01
+    assert decoded[2:] == raw
+    assert len(raw) == 32
+
+
+def test_build_actor_shape() -> None:
+    actor = build_actor("did:web:h.example", "h.example", "zTEST")
+    assert actor["id"] == "https://h.example/api/v1/federation/actor"
+    assert actor["type"] == "Service"
+    assert actor["inbox"].endswith("/api/v1/federation/inbox")
+    assert actor["outbox"].endswith("/api/v1/federation/export")
+    assert actor["publicKey"]["owner"] == "did:web:h.example"
+    assert actor["publicKey"]["id"] == "did:web:h.example#main-key"
+    assert actor["publicKey"]["publicKeyMultibase"] == "zTEST"

--- a/tests/test_federation/test_identity.py
+++ b/tests/test_federation/test_identity.py
@@ -66,6 +66,25 @@ def test_build_did_document_no_recovery_keys() -> None:
     assert methods[0]["id"] == "did:web:h.example#main-key"
 
 
+def test_build_did_document_uses_explicit_actor_url() -> None:
+    # When the node is served from a domain that differs from the DID host,
+    # alsoKnownAs must point at where the actor is actually served, not the
+    # did-host-derived fallback.
+    doc = build_did_document(
+        did="did:web:h.example",
+        public_key_multibase="zX",
+        actor_url="https://node.example/api/v1/federation/actor",
+    )
+    assert doc["alsoKnownAs"] == ["https://node.example/api/v1/federation/actor"]
+    assert "https://h.example/api/v1/federation/actor" not in doc["alsoKnownAs"]
+
+
+def test_build_did_document_actor_url_fallback_to_did_host() -> None:
+    # No actor_url provided: keep the did-host-derived fallback (P0.4 behavior).
+    doc = build_did_document(did="did:web:h.example", public_key_multibase="zX")
+    assert doc["alsoKnownAs"] == ["https://h.example/api/v1/federation/actor"]
+
+
 def test_load_signing_key_none_returns_none() -> None:
     assert load_signing_key(None) is None
 

--- a/tests/test_federation/test_profile.py
+++ b/tests/test_federation/test_profile.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_api_root_profile_is_ppr_not_generic():
+    from app.core.config import settings
+    from app.main import app
+
+    client = TestClient(app)
+    r = client.get("/api/v1/")
+    assert r.status_code == 200
+    profile = r.json()["profile"]
+    assert profile != "https://docs.openhumanservices.org/hsds/"
+    assert profile == settings.FEDERATION_PROFILE_URI
+
+
+def test_api_root_version_unchanged():
+    """The advertised HSDS version must remain 3.1.1 (models are 3.1.1-shaped)."""
+    from app.main import app
+
+    client = TestClient(app)
+    r = client.get("/api/v1/")
+    assert r.status_code == 200
+    assert r.json()["version"] == "3.1.1"
+
+
+@pytest.mark.parametrize("name", ["location.json", "service.json", "openapi.json"])
+def test_profile_patch_is_valid_json(name):
+    path = Path("profiles/hsds-ppr") / name
+    data = json.loads(path.read_text())
+    assert isinstance(data, dict)
+
+
+def test_location_profile_adds_only_optional_props():
+    data = json.loads(Path("profiles/hsds-ppr/location.json").read_text())
+    # the merge patch must NOT introduce required entries
+    assert "required" not in data or data.get("required") in (None, [], {})
+    props = data.get("properties", {})
+    assert "confidence_score" in props and "verified_by" in props and "sources" in props
+
+
+def test_service_profile_adds_only_optional_props():
+    data = json.loads(Path("profiles/hsds-ppr/service.json").read_text())
+    assert "required" not in data or data.get("required") in (None, [], {})
+    props = data.get("properties", {})
+    assert "confidence_score" in props and "verified_by" in props and "sources" in props
+
+
+def test_openapi_patch_documents_federation_paths():
+    data = json.loads(Path("profiles/hsds-ppr/openapi.json").read_text())
+    paths = data.get("paths", {})
+    assert "/api/v1/federation/export" in paths
+    assert "/api/v1/federation/inbox" in paths

--- a/tests/test_federation/test_profile.py
+++ b/tests/test_federation/test_profile.py
@@ -4,6 +4,11 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+# Anchor to the repo root via this file's location, NOT the process CWD: the full
+# test suite contains tests that chdir, so a CWD-relative path is flaky (passes in
+# isolation, fails in the full run). parents[2] = repo root (tests/test_federation/..).
+_PROFILES = Path(__file__).resolve().parents[2] / "profiles" / "hsds-ppr"
+
 
 def test_api_root_profile_is_ppr_not_generic():
     from app.core.config import settings
@@ -29,13 +34,12 @@ def test_api_root_version_unchanged():
 
 @pytest.mark.parametrize("name", ["location.json", "service.json", "openapi.json"])
 def test_profile_patch_is_valid_json(name):
-    path = Path("profiles/hsds-ppr") / name
-    data = json.loads(path.read_text())
+    data = json.loads((_PROFILES / name).read_text())
     assert isinstance(data, dict)
 
 
 def test_location_profile_adds_only_optional_props():
-    data = json.loads(Path("profiles/hsds-ppr/location.json").read_text())
+    data = json.loads((_PROFILES / "location.json").read_text())
     # the merge patch must NOT introduce required entries
     assert "required" not in data or data.get("required") in (None, [], {})
     props = data.get("properties", {})
@@ -43,14 +47,14 @@ def test_location_profile_adds_only_optional_props():
 
 
 def test_service_profile_adds_only_optional_props():
-    data = json.loads(Path("profiles/hsds-ppr/service.json").read_text())
+    data = json.loads((_PROFILES / "service.json").read_text())
     assert "required" not in data or data.get("required") in (None, [], {})
     props = data.get("properties", {})
     assert "confidence_score" in props and "verified_by" in props and "sources" in props
 
 
 def test_openapi_patch_documents_federation_paths():
-    data = json.loads(Path("profiles/hsds-ppr/openapi.json").read_text())
+    data = json.loads((_PROFILES / "openapi.json").read_text())
     paths = data.get("paths", {})
     assert "/api/v1/federation/export" in paths
     assert "/api/v1/federation/inbox" in paths

--- a/tests/test_federation/test_property_canonical.py
+++ b/tests/test_federation/test_property_canonical.py
@@ -1,0 +1,114 @@
+"""Hypothesis property tests for the RFC 8785 (JCS) canonicalizer.
+
+These pin the invariants the content-address and ``proof`` substrate depends on
+(design of record §P0.4): the canonical bytes are independent of dict insertion
+order, deterministic across calls, valid UTF-8, and parse back to a value equal
+to the input. Float-format spot pins reaffirm the official ECMAScript vectors.
+
+NOTE: the JSON-safe strategy below excludes Unicode surrogates (category ``Cs``).
+A lone surrogate is not a valid UTF-8-encodable string and is therefore outside
+the set of JSON-serializable inputs JCS is defined over (``jcs_bytes`` correctly
+raises ``UnicodeEncodeError`` on such input). Restricting the strategy keeps the
+properties scoped to genuinely JSON-safe values.
+"""
+
+import json
+import math
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import pytest
+
+from app.federation.canonical import jcs_bytes
+
+# Surrogate-free text: the JSON-safe string domain JCS is defined over.
+_json_text = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",)),
+    max_size=24,
+)
+
+# Recursive JSON-like values: str keys -> str / int / bool / None / list / dict.
+_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-(10**12), max_value=10**12),
+    _json_text,
+)
+_json_values = st.recursive(
+    _scalars,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.dictionaries(_json_text, children, max_size=4),
+    ),
+    max_leaves=12,
+)
+_json_dicts = st.dictionaries(_json_text, _json_values, max_size=6)
+
+
+def _shuffle_dict_order(d, ordering):
+    """Return a dict with the same items but a permuted insertion order."""
+    keys = list(d.keys())
+    if not keys:
+        return dict(d)
+    perm = ordering % math.factorial(len(keys)) if len(keys) <= 7 else ordering
+    # Simple rotation-based reordering is enough to exercise insertion order:
+    rotated = keys[perm % len(keys):] + keys[: perm % len(keys)]
+    return {k: d[k] for k in rotated}
+
+
+@settings(max_examples=300)
+@given(obj=_json_dicts, ordering=st.integers(min_value=0, max_value=5039))
+def test_canonical_bytes_are_independent_of_key_insertion_order(obj, ordering):
+    """Permuting a dict's insertion order does not change its canonical bytes."""
+    reordered = _shuffle_dict_order(obj, ordering)
+    assert jcs_bytes(reordered) == jcs_bytes(obj)
+
+
+@settings(max_examples=300)
+@given(obj=_json_values)
+def test_canonical_bytes_are_deterministic(obj):
+    """``jcs_bytes`` is a pure function: same input, byte-identical output."""
+    first = jcs_bytes(obj)
+    assert first == jcs_bytes(obj)
+    assert first == jcs_bytes(obj)
+
+
+@settings(max_examples=300)
+@given(obj=_json_values)
+def test_canonical_output_is_valid_utf8_and_round_trips(obj):
+    """Output decodes as UTF-8 and ``json.loads`` recovers the input value."""
+    raw = jcs_bytes(obj)
+    text = raw.decode("utf-8")  # must be valid UTF-8
+    parsed = json.loads(text)  # must be parseable JSON
+    assert parsed == obj  # value equality (ints/strs/bools/None compare exactly)
+
+
+@settings(max_examples=200)
+@given(x=st.floats(allow_nan=False, allow_infinity=False, min_value=-1e15, max_value=1e15))
+def test_finite_floats_round_trip_by_value(x):
+    """A finite float canonicalizes to a token that parses back to the same value."""
+    raw = jcs_bytes({"n": x})
+    parsed = json.loads(raw.decode("utf-8"))
+    assert parsed["n"] == x
+
+
+@pytest.mark.parametrize(
+    "value, token",
+    [
+        (0.0, "0"),
+        (-0.0, "0"),
+        (1.0, "1"),
+        (4.50, "4.5"),
+        (0.002, "0.002"),
+        (1e30, "1e+30"),
+        (1e-7, "1e-7"),
+        (1e21, "1e+21"),
+        (1e20, "100000000000000000000"),
+        (333333333.33333329, "333333333.3333333"),
+        (1e-27, "1e-27"),
+    ],
+)
+def test_float_format_reaffirms_official_vectors(value, token):
+    """Spot pins on the ECMAScript Number.prototype.toString vectors (RFC 8785)."""
+    assert jcs_bytes({"n": value}) == ('{"n":' + token + "}").encode("utf-8")

--- a/tests/test_federation/test_property_canonical.py
+++ b/tests/test_federation/test_property_canonical.py
@@ -53,7 +53,7 @@ def _shuffle_dict_order(d, ordering):
         return dict(d)
     perm = ordering % math.factorial(len(keys)) if len(keys) <= 7 else ordering
     # Simple rotation-based reordering is enough to exercise insertion order:
-    rotated = keys[perm % len(keys):] + keys[: perm % len(keys)]
+    rotated = keys[perm % len(keys) :] + keys[: perm % len(keys)]
     return {k: d[k] for k in rotated}
 
 
@@ -85,7 +85,9 @@ def test_canonical_output_is_valid_utf8_and_round_trips(obj):
 
 
 @settings(max_examples=200)
-@given(x=st.floats(allow_nan=False, allow_infinity=False, min_value=-1e15, max_value=1e15))
+@given(
+    x=st.floats(allow_nan=False, allow_infinity=False, min_value=-1e15, max_value=1e15)
+)
 def test_finite_floats_round_trip_by_value(x):
     """A finite float canonicalizes to a token that parses back to the same value."""
     raw = jcs_bytes({"n": x})

--- a/tests/test_federation/test_property_signing.py
+++ b/tests/test_federation/test_property_signing.py
@@ -1,0 +1,152 @@
+"""Hypothesis property tests for the RFC 9421 Ed25519 signing substrate.
+
+These pin the invariants the federation crypto layer must uphold (design of
+record §P0.3): a freshly-signed request always verifies; any tamper to the body,
+the key, the replay window, or the signature headers is rejected with a
+``SignatureError`` rather than an uncaught exception.
+"""
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+import pytest
+
+from app.federation.signing import (
+    SignatureError,
+    sign_request,
+    verify_request,
+)
+
+_METHOD = "POST"
+_URI = "https://harbor.example/federation/inbox"
+_KEYID = "did:web:harbor.example#main-key"
+_MAX_SKEW = 300
+
+# Small bodies keep example generation cheap while still exercising the
+# digest/signature path over arbitrary byte content (including empty).
+_bodies = st.binary(min_size=0, max_size=64)
+# Ed25519 timestamps live well inside the signed 64-bit space; keep them in a
+# plausible epoch-seconds window so created/now arithmetic stays realistic.
+_epochs = st.integers(min_value=1_600_000_000, max_value=2_000_000_000)
+
+
+def _fresh_keys() -> tuple[Ed25519PrivateKey, object]:
+    private_key = Ed25519PrivateKey.generate()
+    return private_key, private_key.public_key()
+
+
+@settings(max_examples=200)
+@given(body=_bodies, created=_epochs, drift=st.integers(min_value=-_MAX_SKEW, max_value=_MAX_SKEW))
+def test_sign_then_verify_always_roundtrips_within_skew(body, created, drift):
+    """A freshly signed request verifies whenever ``now`` is within the skew."""
+    private_key, public_key = _fresh_keys()
+    headers = sign_request(private_key, _KEYID, _METHOD, _URI, body, created)
+    verify_request(
+        public_key,
+        _METHOD,
+        _URI,
+        headers,
+        body=body,
+        max_skew_seconds=_MAX_SKEW,
+        now=created + drift,
+    )
+
+
+@settings(max_examples=200)
+@given(body=_bodies, created=_epochs, index=st.integers(min_value=0), flip=st.integers(min_value=1, max_value=255))
+def test_flipping_any_body_byte_is_rejected(body, created, index, flip):
+    """Mutating any byte of a non-empty body fails the content-digest check."""
+    assume(len(body) > 0)
+    private_key, public_key = _fresh_keys()
+    headers = sign_request(private_key, _KEYID, _METHOD, _URI, body, created)
+
+    pos = index % len(body)
+    mutated = bytearray(body)
+    mutated[pos] = mutated[pos] ^ flip  # guaranteed-different byte (flip != 0)
+    tampered = bytes(mutated)
+    assume(tampered != body)
+
+    with pytest.raises(SignatureError):
+        verify_request(
+            public_key,
+            _METHOD,
+            _URI,
+            headers,
+            body=tampered,
+            max_skew_seconds=_MAX_SKEW,
+            now=created,
+        )
+
+
+@settings(max_examples=150)
+@given(body=_bodies, created=_epochs)
+def test_verifying_with_a_different_key_is_rejected(body, created):
+    """A signature does not verify against an unrelated public key."""
+    signer, _ = _fresh_keys()
+    _, stranger_public = _fresh_keys()
+    headers = sign_request(signer, _KEYID, _METHOD, _URI, body, created)
+
+    with pytest.raises(SignatureError):
+        verify_request(
+            stranger_public,
+            _METHOD,
+            _URI,
+            headers,
+            body=body,
+            max_skew_seconds=_MAX_SKEW,
+            now=created,
+        )
+
+
+@settings(max_examples=200)
+@given(body=_bodies, created=_epochs, overshoot=st.integers(min_value=1, max_value=10_000))
+def test_created_outside_skew_is_rejected_at_the_boundary(body, created, overshoot):
+    """Exactly ``== max_skew`` passes; one second beyond (either side) fails."""
+    private_key, public_key = _fresh_keys()
+    headers = sign_request(private_key, _KEYID, _METHOD, _URI, body, created)
+
+    # Boundary: |now - created| == max_skew must still verify.
+    verify_request(
+        public_key, _METHOD, _URI, headers,
+        body=body, max_skew_seconds=_MAX_SKEW, now=created + _MAX_SKEW,
+    )
+    verify_request(
+        public_key, _METHOD, _URI, headers,
+        body=body, max_skew_seconds=_MAX_SKEW, now=created - _MAX_SKEW,
+    )
+
+    # One past the window in either direction must be rejected.
+    for now in (created + _MAX_SKEW + overshoot, created - _MAX_SKEW - overshoot):
+        with pytest.raises(SignatureError):
+            verify_request(
+                public_key, _METHOD, _URI, headers,
+                body=body, max_skew_seconds=_MAX_SKEW, now=now,
+            )
+
+
+@settings(max_examples=200)
+@given(
+    body=_bodies,
+    created=_epochs,
+    header_name=st.sampled_from(["Signature", "Content-Digest", "Signature-Input"]),
+    corruption=st.sampled_from(["", "garbage", "sig1=:!!!notb64!!!:", "sig1=:YWJjZA==:", "x" * 80]),
+)
+def test_corrupting_a_signed_header_raises_signature_error_not_a_crash(
+    body, created, header_name, corruption
+):
+    """Any corrupted signed header yields SignatureError, never an uncaught error."""
+    private_key, public_key = _fresh_keys()
+    headers = sign_request(private_key, _KEYID, _METHOD, _URI, body, created)
+    headers[header_name] = corruption  # clobber one header with junk
+
+    with pytest.raises(SignatureError):
+        verify_request(
+            public_key,
+            _METHOD,
+            _URI,
+            headers,
+            body=body,
+            max_skew_seconds=_MAX_SKEW,
+            now=created,
+        )

--- a/tests/test_federation/test_property_signing.py
+++ b/tests/test_federation/test_property_signing.py
@@ -37,7 +37,11 @@ def _fresh_keys() -> tuple[Ed25519PrivateKey, object]:
 
 
 @settings(max_examples=200)
-@given(body=_bodies, created=_epochs, drift=st.integers(min_value=-_MAX_SKEW, max_value=_MAX_SKEW))
+@given(
+    body=_bodies,
+    created=_epochs,
+    drift=st.integers(min_value=-_MAX_SKEW, max_value=_MAX_SKEW),
+)
 def test_sign_then_verify_always_roundtrips_within_skew(body, created, drift):
     """A freshly signed request verifies whenever ``now`` is within the skew."""
     private_key, public_key = _fresh_keys()
@@ -54,7 +58,12 @@ def test_sign_then_verify_always_roundtrips_within_skew(body, created, drift):
 
 
 @settings(max_examples=200)
-@given(body=_bodies, created=_epochs, index=st.integers(min_value=0), flip=st.integers(min_value=1, max_value=255))
+@given(
+    body=_bodies,
+    created=_epochs,
+    index=st.integers(min_value=0),
+    flip=st.integers(min_value=1, max_value=255),
+)
 def test_flipping_any_body_byte_is_rejected(body, created, index, flip):
     """Mutating any byte of a non-empty body fails the content-digest check."""
     assume(len(body) > 0)
@@ -100,7 +109,9 @@ def test_verifying_with_a_different_key_is_rejected(body, created):
 
 
 @settings(max_examples=200)
-@given(body=_bodies, created=_epochs, overshoot=st.integers(min_value=1, max_value=10_000))
+@given(
+    body=_bodies, created=_epochs, overshoot=st.integers(min_value=1, max_value=10_000)
+)
 def test_created_outside_skew_is_rejected_at_the_boundary(body, created, overshoot):
     """Exactly ``== max_skew`` passes; one second beyond (either side) fails."""
     private_key, public_key = _fresh_keys()
@@ -108,20 +119,35 @@ def test_created_outside_skew_is_rejected_at_the_boundary(body, created, oversho
 
     # Boundary: |now - created| == max_skew must still verify.
     verify_request(
-        public_key, _METHOD, _URI, headers,
-        body=body, max_skew_seconds=_MAX_SKEW, now=created + _MAX_SKEW,
+        public_key,
+        _METHOD,
+        _URI,
+        headers,
+        body=body,
+        max_skew_seconds=_MAX_SKEW,
+        now=created + _MAX_SKEW,
     )
     verify_request(
-        public_key, _METHOD, _URI, headers,
-        body=body, max_skew_seconds=_MAX_SKEW, now=created - _MAX_SKEW,
+        public_key,
+        _METHOD,
+        _URI,
+        headers,
+        body=body,
+        max_skew_seconds=_MAX_SKEW,
+        now=created - _MAX_SKEW,
     )
 
     # One past the window in either direction must be rejected.
     for now in (created + _MAX_SKEW + overshoot, created - _MAX_SKEW - overshoot):
         with pytest.raises(SignatureError):
             verify_request(
-                public_key, _METHOD, _URI, headers,
-                body=body, max_skew_seconds=_MAX_SKEW, now=now,
+                public_key,
+                _METHOD,
+                _URI,
+                headers,
+                body=body,
+                max_skew_seconds=_MAX_SKEW,
+                now=now,
             )
 
 
@@ -130,7 +156,9 @@ def test_created_outside_skew_is_rejected_at_the_boundary(body, created, oversho
     body=_bodies,
     created=_epochs,
     header_name=st.sampled_from(["Signature", "Content-Digest", "Signature-Input"]),
-    corruption=st.sampled_from(["", "garbage", "sig1=:!!!notb64!!!:", "sig1=:YWJjZA==:", "x" * 80]),
+    corruption=st.sampled_from(
+        ["", "garbage", "sig1=:!!!notb64!!!:", "sig1=:YWJjZA==:", "x" * 80]
+    ),
 )
 def test_corrupting_a_signed_header_raises_signature_error_not_a_crash(
     body, created, header_name, corruption

--- a/tests/test_federation/test_public_routes.py
+++ b/tests/test_federation/test_public_routes.py
@@ -112,6 +112,17 @@ def test_did_json_404_when_did_set_but_no_signing_key(monkeypatch) -> None:
     assert client.get("/api/v1/federation/actor").status_code == 404
 
 
+def test_did_json_404_when_signing_key_malformed(monkeypatch) -> None:
+    # A misconfigured (malformed) signing key must be logged and treated as
+    # "no key" → 404, never an opaque 500 (Principle XI/XII).
+    settings = Settings(
+        FEDERATION_DID="did:web:node.example",
+        FEDERATION_SIGNING_KEY="not-a-valid-key",
+    )
+    client = _client_with_settings(monkeypatch, settings)
+    assert client.get("/.well-known/did.json").status_code == 404
+
+
 def test_webfinger_resolves_actor_url(monkeypatch) -> None:
     settings = Settings(FEDERATION_DOMAIN="node.public.example")
     client = _client_with_settings(monkeypatch, settings)

--- a/tests/test_federation/test_public_routes.py
+++ b/tests/test_federation/test_public_routes.py
@@ -1,0 +1,125 @@
+"""Tests for the root-level public federation routes (Task 0.7, Principle XV).
+
+These routes make PPR discoverable: a peer hits ``/.well-known/hsds-federation``
+and ``/.well-known/did.json`` to learn the node's identity, keys, versions, and
+endpoints. did:web + WebFinger REQUIRE the ``.well-known`` paths at the domain
+root, so they cannot live under the ``/api/v1`` prefix. The same routes must
+register identically in the Uvicorn app (``app/main.py``) and the slim Lambda
+(``app/api/lambda_app.py``).
+
+``register_federation_public_routes`` is the seam both apps call; this module
+exercises it in isolation on a bare ``FastAPI`` instance.
+"""
+
+import base64
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.config import Settings
+from app.federation.routes_public import register_federation_public_routes
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    register_federation_public_routes(app)
+    return TestClient(app)
+
+
+def _client_with_settings(monkeypatch, settings: Settings) -> TestClient:
+    """Build a client whose route handlers read an overridden settings object."""
+    monkeypatch.setattr("app.federation.routes_public.settings", settings)
+    return _client()
+
+
+def _b64_seed() -> str:
+    """A fictional, deterministic base64 Ed25519 seed for the 200-path tests."""
+    key = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+    raw = key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return base64.b64encode(raw).decode("ascii")
+
+
+def test_well_known_discovery_served() -> None:
+    r = _client().get("/.well-known/hsds-federation")
+    assert r.status_code == 200
+    assert isinstance(r.json()["hsds_versions"], list)  # §8.4 set-membership
+
+
+def test_did_json_served() -> None:
+    r = _client().get("/.well-known/did.json")
+    # 404 only if FEDERATION_DID unset; 200 when configured.
+    assert r.status_code in (200, 404)
+
+
+def test_webfinger_requires_resource() -> None:
+    assert _client().get("/.well-known/webfinger").status_code == 422
+
+
+def test_actor_route_served() -> None:
+    r = _client().get("/api/v1/federation/actor")
+    # 200 when FEDERATION_DID + signing key configured, 404 when not.
+    assert r.status_code in (200, 404)
+
+
+def test_did_json_200_when_configured(monkeypatch) -> None:
+    settings = Settings(
+        FEDERATION_DID="did:web:node.example",
+        FEDERATION_SIGNING_KEY=_b64_seed(),
+    )
+    client = _client_with_settings(monkeypatch, settings)
+    r = client.get("/.well-known/did.json")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "did:web:node.example"
+    assert isinstance(body["verificationMethod"], list)
+    assert body["verificationMethod"]
+    assert body["verificationMethod"][-1]["id"] == "did:web:node.example#main-key"
+
+
+def test_actor_200_when_configured(monkeypatch) -> None:
+    settings = Settings(
+        FEDERATION_DID="did:web:node.example",
+        FEDERATION_SIGNING_KEY=_b64_seed(),
+    )
+    client = _client_with_settings(monkeypatch, settings)
+    r = client.get("/api/v1/federation/actor")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["type"] == "Service"
+    assert body["id"] == "https://node.example/api/v1/federation/actor"
+
+
+def test_did_json_404_when_unconfigured(monkeypatch) -> None:
+    settings = Settings(FEDERATION_DID=None, FEDERATION_SIGNING_KEY=None)
+    client = _client_with_settings(monkeypatch, settings)
+    assert client.get("/.well-known/did.json").status_code == 404
+
+
+def test_did_json_404_when_did_set_but_no_signing_key(monkeypatch) -> None:
+    # DID configured before the signing key is provisioned: still 404 (no key
+    # to publish), exercising the missing-key guard distinct from missing-DID.
+    settings = Settings(
+        FEDERATION_DID="did:web:node.example", FEDERATION_SIGNING_KEY=None
+    )
+    client = _client_with_settings(monkeypatch, settings)
+    assert client.get("/.well-known/did.json").status_code == 404
+    assert client.get("/api/v1/federation/actor").status_code == 404
+
+
+def test_webfinger_resolves_actor_url(monkeypatch) -> None:
+    settings = Settings(FEDERATION_DOMAIN="node.public.example")
+    client = _client_with_settings(monkeypatch, settings)
+    r = client.get("/.well-known/webfinger", params={"resource": "acct:node@example"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["subject"] == "acct:node@example"
+    assert (
+        body["links"][0]["href"]
+        == "https://node.public.example/api/v1/federation/actor"
+    )

--- a/tests/test_federation/test_signing.py
+++ b/tests/test_federation/test_signing.py
@@ -60,3 +60,27 @@ def test_sign_then_verify_roundtrips_and_rejects_tamper():
             max_skew_seconds=300,
             now=1780600060,
         )
+
+
+def test_verify_request_lowercased_headers():
+    # Real ASGI/Starlette headers are lowercased; verify must look them up
+    # case-insensitively so a P3 /inbox handler passing request.headers works.
+    priv, pub = _keys()
+    headers = sign_request(
+        priv,
+        "did:web:h.example#main-key",
+        "POST",
+        "https://h.example/federation/inbox",
+        body=b'{"x":1}',
+        created=1780600000,
+    )
+    lowered = {k.lower(): v for k, v in headers.items()}
+    verify_request(
+        pub,
+        "POST",
+        "https://h.example/federation/inbox",
+        lowered,
+        body=b'{"x":1}',
+        max_skew_seconds=300,
+        now=1780600060,
+    )

--- a/tests/test_federation/test_signing.py
+++ b/tests/test_federation/test_signing.py
@@ -1,0 +1,62 @@
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from app.federation.signing import (
+    SignatureError,
+    build_signature_base,
+    sign_request,
+    verify_request,
+)
+
+
+def _keys():
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+def test_signature_base_is_rfc9421_shaped():
+    base = build_signature_base(
+        method="POST",
+        target_uri="https://h.example/federation/inbox",
+        content_digest="sha-256=:abc=:",
+        created=1780600000,
+        keyid="did:web:h.example#main-key",
+    )
+    assert '"@method": POST' in base
+    assert '"@target-uri": https://h.example/federation/inbox' in base
+    assert base.rstrip().endswith(
+        '"@signature-params": ("@method" "@target-uri" "content-digest")'
+        ';created=1780600000;keyid="did:web:h.example#main-key";alg="ed25519"'
+    )
+
+
+def test_sign_then_verify_roundtrips_and_rejects_tamper():
+    priv, pub = _keys()
+    headers = sign_request(
+        priv,
+        "did:web:h.example#main-key",
+        "POST",
+        "https://h.example/federation/inbox",
+        body=b'{"x":1}',
+        created=1780600000,
+    )
+    assert {"Content-Digest", "Signature-Input", "Signature"} <= set(headers)
+    verify_request(
+        pub,
+        "POST",
+        "https://h.example/federation/inbox",
+        headers,
+        body=b'{"x":1}',
+        max_skew_seconds=300,
+        now=1780600060,
+    )
+    with pytest.raises(SignatureError):
+        verify_request(
+            pub,
+            "POST",
+            "https://h.example/federation/inbox",
+            headers,
+            body=b'{"x":2}',
+            max_skew_seconds=300,
+            now=1780600060,
+        )


### PR DESCRIPTION
Implements **P0 — Foundations** of the HSDS Federation epic (#519, phase issue #520) per the living plan `docs/superpowers/plans/2026-06-03-hsds-federation-core.md` and design of record `docs/superpowers/specs/2026-06-03-hsds-federation-core-design.md`.

> **⚠️ DO NOT MERGE without owner product sign-off.** Built autonomously via `superpowers:subagent-driven-development` (fresh Opus subagent per task, machine review between tasks) + the **PR Gauntlet** (multi-lens + adversarial + property tests). The owner cannot deep-review crypto/concurrency by design — the machine is the reviewer; this PR is the owner's product-level go/no-go.

## What P0 ships — PPR is now *discoverable* as a federation node

Built TDD red-first, one fresh subagent per task. Sub-issues #529–#537 closed task-by-task.

| Task | What | Issue |
|---|---|---|
| 0.1 | `FEDERATION_*` config (on by default: `FEDERATION_ENABLED=True`) + `app/federation/` package | #529 |
| 0.2 | SSRF-hardened egress helper (`fetch.py`) — HTTPS-only, internal/CGNAT/ULA/IMDS blocking | #530 |
| 0.3 | JCS canonicalization (RFC 8785, `canonical.py`) + RFC 9421/Ed25519 + RFC 9530 signing (`signing.py`) | #531 |
| 0.4 | did:web doc + actor + Ed25519 key loading + ordered recovery-key schema §6.1a (`identity.py`) | #532 |
| 0.5 | `.well-known/hsds-federation` discovery doc (`discovery.py`) + discovery settings | #533 |
| 0.6 | WebFinger JRD responder | #534 |
| 0.7 | Root-level public routes wired into **both** Uvicorn (`app/main.py`) and the slim Lambda (`app/api/lambda_app.py`) — Principle XV | #535 |
| 0.8 | Multi-file HSDS Profile (`profiles/hsds-ppr/`) + router profile URI | #536 |
| 0.9 | CLAUDE.md "Federation (core)" subsection + full gate | #537 |

**Discoverable surface (both envs):** `GET /.well-known/hsds-federation`, `/.well-known/did.json` (404 until DID+key configured), `/.well-known/webfinger?resource=`, `/api/v1/federation/actor`.

## Key decisions & findings (owner: please note)

1. **JCS: minimal serializer, not the `rfc8785` lib** (design §8.3 sanctioned alternative). The `./bouy exec app poetry` path is unusable in this multi-clone env and adding a dep forces a shared-image rebuild — disproportionate. The hand-rolled ES6 number formatter was **fuzzed against node's V8 `Number.prototype.toString()` over 6,731 doubles with 0 mismatches**, and is pinned with 15 official RFC 8785 vectors + Hypothesis property tests. `jcs_bytes()` is a clean seam — P1 can swap to `rfc8785` with zero call-site changes.
2. **Signing: minimal RFC 9421 Ed25519 profile on the already-present `cryptography` lib** — no new deps.
3. **HSDS version stays at 3.1.1 (honest).** Verified the Pydantic models in `app/models/hsds/` are genuinely 3.1.1-shaped (they lack 3.2's `additional_websites`/`additional_urls`/`attributes`/`metadata`); the vendored `docs/HSDS/` submodule at v3.2.3 is a spec-only bump. Advertising 3.2 would violate Principle II. **This contradicts the design's v3.1 baseline assumption that P1 pins "the 3.2 line" — flagged for the P1 expansion.**
4. **Deferred SSRF hardening = hard gates on the first real outbound fetch (P2/P3), not optional:** the DNS-rebinding connect-pin and the streaming byte-counted cap. Documented in `fetch.py`. The header-only size check and resolve-then-connect TOCTOU are not production-safe alone.
5. **Recovery-key verify-side enforcement → P3** (schema-only in P0), following the plan (design §6.1a said v1); not blocking (#532).

## Gauntlet verdict — ran, fixed, re-verified

The full PR Gauntlet (15 agents: static gates → 8 parallel review lenses → 4 adversarial refute-skeptics → Hypothesis property tests → synthesis) returned **MERGE_AFTER_FIXES** with 4 *important* blocking findings. **All 4 (plus 2 cheap minors) are now fixed, TDD red→green, and re-verified** — commits `f4de5f6`, `e055419`, `fe6ce32`:

1. **SSRF: IPv4-mapped-IPv6 bypass** (`fetch.py`) — `is_blocked_ip` skipped the CGNAT check for `::ffff:100.64.x.x` (and raw `is_private` didn't catch mapped CGNAT). **Fix:** un-map `ipv4_mapped` before all checks. Independently re-probed: all of `::ffff:{127.0.0.1,10.x,169.254.169.254,192.168.x,100.64.x}` + 6to4 + NAT64 embeddings now blocked; public IPs still allowed.
2. **did.json `alsoKnownAs` host mismatch** (`identity.py`/`routes_public.py`) — now threads the served node domain via an `actor_url` param.
3. **Silent allow-list-policy downgrade** (`config.py`/`discovery.py`) — `FEDERATION_ALLOW_LIST_POLICY` is now `Literal["open","mutual","private"]` (typo → startup `ValidationError`, not a silent serve-time substitution).
4. **Misconfigured signing key → opaque 500** (`routes_public.py`) — now caught, logged `federation_signing_key_invalid` (Principle XII), returns 404.
5. (minor) `verify_request` now does case-insensitive header lookup (prevents a P3 `/inbox` silent-reject footgun).
6. (minor) corrected `openapi.json` `/actor` wording (served in P0).

**Adversarial outcome:** 3/4 claims held intact; the JCS float formatter matched Node's `Number.toString` across a **1.52M-value differential fuzz, 0 mismatches**; signing fails closed on every tamper/wrong-key/skew/missing-header probe. **Property tests:** 20/20 passed, committed (`d55fc7db`), no properties weakened.

**Deferred (non-blocking, documented):** `FEDERATION_ENABLED` is config-only in P0 (the kill switch gates the P1 publish/ingest surface per design §6.2d — nothing to gate yet); the theoretical unbounded-int JCS edge (our data is bounded); covered-components assertion in `verify_request` (fails closed today, tighten in P3).

## Constitution gates

- `./bouy test --pytest`: **4547 passed**, 117 skipped, 3 xfailed (full suite, post-fixes; +31 vs the pre-Gauntlet baseline = the new regression + Hypothesis property tests). A CWD-relative-path flake in the profile tests was caught by the full-suite run and fixed (`9b4b1e9`).
- black / ruff / bandit: clean on `app/federation/`.
- mypy: `app/federation/` clean in isolation ("Success: no issues found in 7 source files"). Full `./bouy test --mypy` has a **pre-existing, local-only** crash in `openai/_client.py` (crawl4ai drags openai to 2.36.0 over the lock's 1.93.2); **CI on `main` is green** — this is local image drift, not this PR.
- No new pip dependencies; `pyproject.toml`/`poetry.lock` unchanged.

## Out of scope (later phases)

Verifiable Merkle log + signed checkpoints + `/export`/`state.txt`/`/checkpoint`/`history` (P1); pull ingest + corroboration + FA-feed acceptance (P2); `/inbox` push (P3); `./bouy federation` CLI + PII + review-at-scale (P4). **P1+ are `blocked:hard-gate` pending the P0.5 spike go/no-go memo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
