### PR TITLE
fix(datasette): drop stale custom-nav plugin COPY so the image builds

### DIFF
--- a/.docker/images/datasette/Dockerfile
+++ b/.docker/images/datasette/Dockerfile
@@ -9,11 +9,10 @@ RUN pip install \
     datasette-leaflet \
     datasette-vega
 
-# Copy and install custom plugin
-WORKDIR /tmp/plugin
-COPY plugins/setup.py plugins/datasette_custom_nav.py ./
-RUN pip install -e .
-WORKDIR /
+# Note: the former datasette-custom-nav plugin (plugins/setup.py,
+# plugins/datasette_custom_nav.py) was removed in #398. Navigation is now
+# driven by datasette-metadata.json ("custom_nav_links") + datasette-custom.css,
+# so no custom plugin is baked into the image.
 
 # Default command (will be overridden by docker-compose)
 CMD ["datasette", "--help"]


### PR DESCRIPTION
## Problem

The datasette image fails to build from a clean checkout:

```
#8 [4/6] COPY plugins/setup.py plugins/datasette_custom_nav.py ./
#8 ERROR: "/plugins/setup.py": not found
```

#398 ("generalized plugin CDK deploy system") removed `plugins/setup.py` and `plugins/datasette_custom_nav.py` as *"stale Datasette files"* and repurposed `plugins/` into the plugin-system directory (now just `.gitkeep`) — but left `.docker/images/datasette/Dockerfile` (and CD's `build-datasette` job) still `COPY`-ing those deleted files.

Impact:
- **Dev:** `./bouy up` fails, because the dev compose overlay includes the `datasette` service and builds its image from scratch on a fresh machine.
- **CD:** the `build-datasette` job in `.github/workflows/cd.yml` builds the same Dockerfile and is almost certainly failing on `main` for the same reason.

## Fix

Remove the now-dead `COPY` + `pip install -e .` steps. The custom navigation the deleted plugin provided is already handled at runtime by `datasette-metadata.json` (`custom_nav_links`) + `datasette-custom.css` — the datasette service command never loaded the JS plugin — so it's genuinely superseded. The PyPI plugin installs are untouched.

## Verification

```
docker build -f .docker/images/datasette/Dockerfile -t ppr-datasette-buildcheck .
# => exporting to image ... DONE  (previously failed at the COPY step)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)