### PR TITLE
chore(deps): clear pip-audit/safety findings via real upgrades; drop stale ignores

### DIFF
--- a/.docker/images/app/Dockerfile
+++ b/.docker/images/app/Dockerfile
@@ -38,8 +38,9 @@ RUN apt-get update && apt-get install -y \
 # Set working directory
 WORKDIR /app
 
-# Install Poetry (upgrade pip and wheel first to fix CVE-2025-8869 and CVE-2026-24049)
-RUN pip install --upgrade pip>=26.0 wheel>=0.46.2 && pip install 'distlib<0.4.0' poetry
+# Install Poetry (upgrade pip and wheel first to fix CVE-2025-8869, CVE-2026-24049,
+# and the pip 26.1.x CVEs: CVE-2026-8643 / CVE-2026-3219 / CVE-2026-6357)
+RUN pip install --upgrade pip>=26.1.2 wheel>=0.46.2 && pip install 'distlib<0.4.0' poetry
 
 # Configure Poetry
 ENV POETRY_VIRTUALENVS_CREATE=false

--- a/.docker/images/submarine/Dockerfile
+++ b/.docker/images/submarine/Dockerfile
@@ -68,8 +68,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Install pip, wheel, poetry
-RUN pip install --upgrade pip>=26.0 wheel>=0.46.2 && pip install 'distlib<0.4.0' poetry
+# Install pip, wheel, poetry (pip>=26.1.2 fixes the pip 26.1.x CVEs)
+RUN pip install --upgrade pip>=26.1.2 wheel>=0.46.2 && pip install 'distlib<0.4.0' poetry
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,16 +451,24 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-ansi
 
+      - name: Upgrade build tools to patched versions before audit
+        # pip/wheel CVEs were previously only ignored because the runner's system
+        # build tools are uncontrolled; patch them in the audited env instead.
+        run: python -m pip install --upgrade "pip>=26.1.2" "wheel>=0.46.2"
+
       - name: Run Safety security check
-        # Ignore 79883 (pip CVE-2025-8869) - pip upgraded to >=26.0 in Dockerfile
-        # Ignore 84961 (wheel CVE-2026-24049) - wheel pinned >=0.46.2 in Dockerfile; CI runner system wheel uncontrolled
-        # Ignore 89047 (black CVE-2026-32274) - path-traversal in cache file name; dev-only tool, not exposed to untrusted input
-        # Ignore SFTY-20260122-20373 (pytest /tmp race) - dev-only, CI runner is single-tenant, no untrusted local users
-        # Ignore SFTY-20260322-35073 (pygments CVE-2026-4539) - dev-only tool (syntax highlighter in docs build); matches the parallel GHSA-5239-wwwm-4pmq pip-audit ignore, no fix available in 2.19.2
-        # Ignore SFTY-20260427-69629 (pip CVE-2026-6357) - pip is a build tool; fix 26.1 installed in Dockerfile, CI runner system pip uncontrolled (parallels GHSA-jp4c-xjxw-mgf9 pip-audit ignore)
-        # Ignore SFTY-20260420-60812 (pip CVE-2026-3219) - pip is a build tool; pip upgraded in Dockerfile, CI runner system pip uncontrolled (parallels GHSA-58qw-9mgm-455v pip-audit ignore)
-        # (python-dotenv 94066 / pillow 93093 cleared by poetry update -> python-dotenv 1.2.2 / pillow 12.2.0)
-        run: poetry run safety check --ignore 79883 --ignore 84961 --ignore 89047 --ignore SFTY-20260122-20373 --ignore SFTY-20260322-35073 --ignore SFTY-20260427-69629 --ignore SFTY-20260420-60812
+        # Only two ignores remain, both dev-only with deferred major-bump fixes.
+        # Ignore 89047 (black CVE-2026-32274, path-traversal in the cache file name) -
+        #   dev-only formatter (group.dev), run only via ./bouy test --black + pre-commit
+        #   over our own trusted source; fix 26.3.1 is a two-major bump (24->26) with a
+        #   codebase-wide reformat, deferred to its own PR.
+        # Ignore SFTY-20260122-20373 (pytest /tmp predictable-path) - dev-only test runner,
+        #   CI runner is single-tenant (no untrusted local users); fix 9.0.3 is a 7->8->9
+        #   migration that also needs lifting the pytest-asyncio/-benchmark caps, deferred.
+        # (pip 79883/SFTY-20260427-69629/SFTY-20260420-60812 + wheel 84961 cleared by the
+        #  build-tool upgrade above; pygments SFTY-20260322-35073 cleared by ->2.20.0;
+        #  python-dotenv 94066 / pillow 93093 cleared previously.)
+        run: poetry run safety check --ignore 89047 --ignore SFTY-20260122-20373
 
   pip-audit:
     needs: setup
@@ -506,17 +514,24 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-ansi
 
+      - name: Upgrade pip to patched version before audit
+        # The pip CVEs were previously only ignored because the runner's system pip
+        # is uncontrolled; patch it in the audited env instead.
+        run: python -m pip install --upgrade "pip>=26.1.2"
+
       - name: Run pip-audit security check
-        # Ignore GHSA-4xh5-x5gv-qwph (pip CVE-2025-8869) - pip upgraded in Dockerfile
-        # Ignore GHSA-3936-cmfr-pm3m (black ReDoS) - dev-only tool, not in production
-        # Ignore GHSA-5239-wwwm-4pmq (pygments ReDoS in ADL lexer) - dev-only, no fix available (2.19.2 is latest)
-        # Ignore GHSA-p423-j2cm-9vmq (cryptography) - fix is 46.0.7, pending poetry update
-        # Ignore GHSA-6w46-j5rx-g56g (pytest) - fix is 9.0.3 (major bump); dev-only, breaking change
-        # Ignore PYSEC-2026-161 (starlette) - fix is 1.0.1, unreachable: fastapi 0.121.0 pins starlette <0.50.0 (latest fastapi still <0.51.0); revisit when fastapi supports starlette 1.x
-        # Ignore GHSA-58qw-9mgm-455v (pip) - no fixed version available upstream yet; pip upgraded in Dockerfile so runtime is unaffected
-        # Ignore GHSA-jp4c-xjxw-mgf9 (pip) - fix is 26.1; pip is a build tool, upgraded in Dockerfile so runtime is unaffected
-        # (pillow GHSA-whj4/wjx4/5xmw/r73j/pwv6 and python-dotenv GHSA-mf9w cleared by poetry update -> pillow 12.2.0 / python-dotenv 1.2.2; idna + pyjwt likewise upgraded to fixed versions)
-        run: poetry run pip-audit --ignore-vuln GHSA-4xh5-x5gv-qwph --ignore-vuln GHSA-3936-cmfr-pm3m --ignore-vuln GHSA-5239-wwwm-4pmq --ignore-vuln GHSA-p423-j2cm-9vmq --ignore-vuln GHSA-6w46-j5rx-g56g --ignore-vuln PYSEC-2026-161 --ignore-vuln GHSA-58qw-9mgm-455v --ignore-vuln GHSA-jp4c-xjxw-mgf9
+        # Only two ignores remain, both dev-only with deferred major-bump fixes.
+        # Ignore GHSA-3936-cmfr-pm3m (black CVE-2026-32274, path-traversal in the cache
+        #   file name) - dev-only formatter, run only over our own trusted source; fix
+        #   26.3.1 is a two-major bump (24->26) with a codebase-wide reformat, deferred.
+        # Ignore GHSA-6w46-j5rx-g56g (pytest /tmp predictable-path) - dev-only test runner,
+        #   CI runner single-tenant; fix 9.0.3 is a 7->8->9 migration that also needs lifting
+        #   the pytest-asyncio/-benchmark caps, deferred to its own PR.
+        # (cryptography GHSA-p423-j2cm-9vmq cleared by ->48.0.0; pygments GHSA-5239-wwwm-4pmq
+        #  by ->2.20.0; starlette PYSEC-2026-161 by ->1.2.1; pip GHSA-4xh5/GHSA-58qw/GHSA-jp4c
+        #  by the pip upgrade above. lxml PYSEC-2026-87 is crawl4ai-only — absent from this
+        #  poetry-only audit env — and is tracked in a separate PR.)
+        run: poetry run pip-audit --ignore-vuln GHSA-3936-cmfr-pm3m --ignore-vuln GHSA-6w46-j5rx-g56g
 
   xenon:
     needs: setup

--- a/app/core/events.py
+++ b/app/core/events.py
@@ -6,7 +6,8 @@ It must NOT be imported in Lambda environments (use app/api/lambda_app.py instea
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
 from typing import Any, Protocol, TypeVar, cast
 
 from prometheus_client import Gauge
@@ -327,11 +328,20 @@ def create_stop_app_handler(app: Any) -> Callable[[], Awaitable[None]]:
     return stop_app
 
 
-def init_app_events(app: Any) -> None:
-    """Initialize application events.
+@asynccontextmanager
+async def lifespan(app: Any) -> AsyncIterator[None]:
+    """ASGI lifespan: run startup handlers, serve, then run shutdown handlers.
+
+    Replaces the deprecated ``add_event_handler("startup"/"shutdown", ...)`` API
+    (removed in Starlette 1.0). Pass to ``FastAPI(lifespan=lifespan)``. Startup/
+    shutdown ordering and semantics are preserved: the start handler completes
+    before the app serves; the stop handler always runs on shutdown.
 
     Args:
         app: FastAPI application instance
     """
-    app.add_event_handler("startup", create_start_app_handler(app))
-    app.add_event_handler("shutdown", create_stop_app_handler(app))
+    await create_start_app_handler(app)()
+    try:
+        yield
+    finally:
+        await create_stop_app_handler(app)()

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from starlette import status
 
 from app.api.v1.router import router as v1_router
 from app.core.config import Settings
-from app.core.events import create_start_app_handler, create_stop_app_handler
+from app.core.events import lifespan
 from app.federation.routes_public import register_federation_public_routes
 from app.middleware.correlation import CorrelationMiddleware
 from app.middleware.errors import ErrorHandlingMiddleware
@@ -28,6 +28,7 @@ app = FastAPI(
     openapi_url="/openapi.json",
     default_response_class=JSONResponse,
     redirect_slashes=True,  # Enable automatic trailing slash redirection
+    lifespan=lifespan,  # startup/shutdown (Starlette 1.0 removed add_event_handler)
 )
 
 # Middleware stack (last added = outermost wrapper):
@@ -70,9 +71,7 @@ async def root_redirect() -> Response:
     )
 
 
-# Event handlers
-app.add_event_handler("startup", create_start_app_handler(app))
-app.add_event_handler("shutdown", create_stop_app_handler(app))
+# Startup/shutdown are wired via the lifespan handler passed to FastAPI() above.
 
 
 # Include routers - mount v1 routes under prefix

--- a/poetry.lock
+++ b/poetry.lock
@@ -926,26 +926,27 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "fastapi"
-version = "0.121.0"
+version = "0.136.3"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106"},
-    {file = "fastapi-0.121.0.tar.gz", hash = "sha256:06663356a0b1ee93e875bbf05a31fb22314f5bed455afaaad2b2dad7f26e98fa"},
+    {file = "fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620"},
+    {file = "fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.40.0,<0.50.0"
+pydantic = ">=2.9.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
+typing-inspection = ">=0.4.2"
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
-standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "filelock"
@@ -2920,14 +2921,14 @@ dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
+python-versions = ">=3.9"
+groups = ["main", "dev"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -4070,14 +4071,14 @@ tui = ["trogon"]
 
 [[package]]
 name = "starlette"
-version = "0.49.3"
+version = "1.2.1"
 description = "The little ASGI library that shines."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f"},
-    {file = "starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284"},
+    {file = "starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89"},
+    {file = "starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6"},
 ]
 
 [package.dependencies]
@@ -4296,14 +4297,14 @@ files = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51"},
-    {file = "typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"},
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
 
 [package.dependencies]
@@ -4691,4 +4692,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c27c22e5628f7fec5809427b4f9c8887cd0bf8612bd80b2bc22db4cbec859e81"
+content-hash = "12792b61c7c6af57f2a0764350cab346b69f65f3652ad8bc19ff0b0753049497"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ pytest-asyncio = "<0.25.0"
 redis = "^5.0.0"
 rq = "^1.15.1"
 rq-dashboard = "^0.6.1"
-fastapi = ">=0.116.0"
+# Floor raised to >=0.133.0 so the resolver can take starlette >=1.0.1
+# (fastapi <0.133 caps starlette <0.50). Pairs with the starlette pin below.
+fastapi = ">=0.133.0"
 uvicorn = "^0.27.0"
 prometheus-client = "^0.19.0"
 pydantic = "^2.6.0"
@@ -70,11 +72,16 @@ cryptography = ">=46.0.7"
 # lockfile at the earlier vulnerable patch.)
 urllib3 = ">=2.7.0"
 xlrd = "^2.0.1"
-starlette = ">=0.49.1"
+# Pinned directly to force >=1.0.1, fixing PYSEC-2026-161. Reachable now that
+# the fastapi floor is >=0.133.0 (which permits starlette 1.x).
+starlette = ">=1.0.1"
 mangum = ">=0.17.0"
 defusedxml = "^0.7.1"
 db-to-sqlite = "^1.5"
 requests = "^2.33.0"
+# Pinned directly (transitive via rich/etc.) to force >=2.20.0, fixing the
+# ADL-lexer ReDoS GHSA-5239-wwwm-4pmq (no fix existed at 2.19.2; 2.20.0 ships it).
+pygments = ">=2.20.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/tests/test_app_main_unit.py
+++ b/tests/test_app_main_unit.py
@@ -95,12 +95,43 @@ def test_settings_import() -> None:
 
 
 def test_event_handlers_registered() -> None:
-    """Test that startup and shutdown handlers are registered."""
+    """Startup/shutdown are wired via the FastAPI lifespan (Starlette 1.0 removed
+    the add_event_handler API). Entering the app's lifespan must run the startup
+    handler before serving and the shutdown handler on exit, in order.
+    """
+    from unittest import mock
+
+    from fastapi.testclient import TestClient
+
+    import app.core.events as events
     from app.main import app
 
-    # Check event handlers are registered
-    startup_handlers = app.router.on_startup
-    shutdown_handlers = app.router.on_shutdown
+    # Migrated OFF the deprecated event-handler lists...
+    assert app.router.on_startup == []
+    assert app.router.on_shutdown == []
 
-    assert len(startup_handlers) > 0
-    assert len(shutdown_handlers) > 0
+    calls: list[str] = []
+
+    def fake_start(_app: object):
+        async def _start() -> None:
+            calls.append("start")
+
+        return _start
+
+    def fake_stop(_app: object):
+        async def _stop() -> None:
+            calls.append("stop")
+
+        return _stop
+
+    # ...and ONTO the lifespan, which the running app actually invokes end-to-end
+    # (entering/exiting the TestClient context drives the ASGI lifespan). Handlers
+    # are mocked so this needs no Redis.
+    with (
+        mock.patch.object(events, "create_start_app_handler", fake_start),
+        mock.patch.object(events, "create_stop_app_handler", fake_stop),
+    ):
+        with TestClient(app):
+            calls.append("serving")
+
+    assert calls == ["start", "serving", "stop"]


### PR DESCRIPTION
Unblocks the `pip-audit` (and `safety`) CI jobs that started failing on the new pip advisory **PYSEC-2026-196**, by applying the now-available fixes and removing the stopgap ignores rather than adding more. A 7-agent research workflow verified each item's fix availability, reachability, and breaking risk before any change.

## Real upgrades (poetry.lock — only 4 packages moved)
| Package | From → To | Vuln cleared |
|---|---|---|
| pygments | 2.19.2 → **2.20.0** | GHSA-5239-wwwm-4pmq / SFTY-20260322-35073 (ADL-lexer ReDoS; first fixed release) |
| starlette | 0.49.3 → **1.2.1** | PYSEC-2026-161 |
| fastapi | 0.121.0 → **0.136.3** | (required to reach starlette 1.x) |
| typing-inspection | 0.4.1 → 0.4.2 | (transitive) |

**Starlette 1.0 removed `add_event_handler`** → `app/main.py` + `app/core/events.py` migrate startup/shutdown to a FastAPI **lifespan** handler. Lambda is unaffected (Mangum runs `lifespan="off"`). Full suite: **4553 passed, 0 failed**.

## Build-tool CVEs (pip, wheel) — patch the audited env, don't ignore
Both the `safety` and `pip-audit` CI jobs get a post-`poetry install` step `pip install --upgrade "pip>=26.1.2" [wheel>=0.46.2]`. (poetry install pins pip back to 26.0.1, so the upgrade must run *after* it.) Clears the pip 26.1.x CVEs (PYSEC-2026-196 / GHSA-58qw / GHSA-jp4c) + wheel CVE-2026-24049. Dockerfiles (app + submarine) bump the build pip pin `>=26.0 → >=26.1.2`.

## Stale ignores removed (no longer in the resolved set)
- cryptography `GHSA-p423-j2cm-9vmq` (lock already 48.0.0 ≥ 46.0.7 fix)
- pip CVE-2025-8869 (`GHSA-4xh5` / safety `79883`; 26.0.1 already past the 25.3 fix)

Each ignore list is now **two dev-only entries** (black, pytest) whose fixes are deferred major bumps, with corrected comments (black is CVE-2026-32274 path-traversal, not "ReDoS").

## Out of scope (tracked separately)
- **lxml** PYSEC-2026-87 (fix 6.1.0): crawl4ai-only (not poetry-managed; blocked by crawl4ai's `lxml~=5.3` pin) — it never appears in the poetry-only CI audit env, so it does **not** block these jobs. Separate follow-up.
- **black 26.x** (codebase-wide reformat) and **pytest 9.x** (7→8→9 migration + lifting plugin caps): each its own PR.

## Verification
- `./bouy test --pytest`: 4553 passed, 0 failed (under the new deps + lifespan).
- black, ruff: clean. mypy: CI-gated (local `openai` env crash is unrelated).
- In-container `pip-audit` (no ignores) now shows only the expected residual (lxml + pip-pre-step + black + pytest), confirming pygments/starlette/cryptography cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)