### PR TITLE
docs(process): portable machine-reviewed development methodology (design + build)

### DIFF
--- a/docs/process/adversarial-design-and-planning.md
+++ b/docs/process/adversarial-design-and-planning.md
@@ -1,0 +1,200 @@
+# Adversarial Design & Planning
+
+A portable process for **designing** a hard system before you build it — the
+companion to [Machine-Reviewed RED-Tier Development](./machine-reviewed-red-tier-development.md)
+(which governs the build). Distilled from designing a federation/crypto epic, but
+the method is domain-agnostic.
+
+The premise: **spend heavily on design and review now to save far more effort —
+and avoid production failures — later.** A few days of adversarial design review
+and a throwaway spike are cheap next to shipping the wrong architecture, or a
+correct-looking one that fails the first time it meets reality. Reviews run
+*constantly*, not once at the end.
+
+The other premise, equally load-bearing: **the human is in the loop throughout, but
+is never asked to understand the implementation.** They own judgment — scope, risk
+appetite, product behavior, go/no-go — and the machine owns mechanism. So every
+question put to them is framed in approachable, outcome-level terms (§4).
+
+---
+
+## 1. Artifacts
+
+Keep design state in a small, stable set of documents:
+
+- **Design-of-record** — the normative spec: the wire formats, the data model, the
+  trust/threat model, the activity semantics. The single source of truth a
+  partner could implement against. Carries a **versioned amendment log** at the top
+  so the design's *history and rationale* are legible (why v3 chose X over Y).
+- **Living plan** — the phased task breakdown that turns the design into PRs. Tasks
+  are sized to one Gauntlet-able PR each, ordered by dependency, with risk tier
+  tagged.
+- **Epic / tracker** — the issue that links them and tracks phase status.
+- **Spec-cache / fixtures** — pinned byte-format vectors and worked examples (see
+  §5), so the design is *executable*, not just prose.
+
+Versioning the design (v1 → v2 → v3 …) with an amendment log is what lets review be
+continuous: each pass produces a new version with its corrections folded in and
+attributed.
+
+---
+
+## 2. The design Gauntlet — review the DESIGN, not just the code
+
+Before a line is built, the design itself goes through the same adversarial,
+multi-perspective treatment the code will (the build Gauntlet). Run **panels of
+independent lenses** over the design and fold the blockers back in, iterating to a
+new version. The lenses that paid off here:
+
+- **Constitution / first-principles** — does it violate a standing project
+  invariant? (Caught: "no new logic needed" was false — there *was* an integration
+  contract that had to be specified.)
+- **Completeness** — what's unspecified, hand-waved, or "just works"? (Caught: a
+  "plain ingestion just works" claim that did not.)
+- **Partner / implementability** — could an outsider build against this from the
+  spec alone? Forces the wire format to be normative.
+- **Threat model / security** — enumerate the attacks; each becomes a v1 requirement
+  (SSRF, cost-amplification, injection, equivocation, rogue-peer recovery).
+- **Ecosystem / standards research** — *don't design in a vacuum.* A live scan of
+  the surrounding ecosystem ("is anyone already doing this? what vocabulary do they
+  use?") prevents duplicating a standard or freezing field names you'll have to
+  rename. Align, don't reinvent.
+
+Then a distinct pass that is **steelman, not bug-hunt**: a panel that tries to make
+the design *stronger and more ambitious in the one way that compounds* (here:
+verifiability), rather than only finding flaws. Bug-hunting hardens; steelmanning
+raises the ceiling. Do both, in that order.
+
+Every pass ends at an **owner decision point** (§4), not an agent fait accompli.
+
+---
+
+## 3. De-risk the riskiest assumption first (a throwaway spike)
+
+Identify the single assumption that, if wrong, breaks the whole plan — and prove it
+*before* committing the design. Build a **throwaway spike** that exercises exactly
+that risk against reality (real DB, real concurrency, real volume), get a clear
+**GO / NO-GO**, and write the result into the plan. Then throw the spike away and
+build it properly with tests.
+
+> Worked example: the riskiest assumption was that a dense, gapless sequence could
+> be assigned under a short advisory lock without serializing the main write path.
+> A spike proved the exact lock shape **GO** under real concurrency before the plan
+> depended on it. (It also surfaced the caveats — re-confirm throughput at real
+> volume — which became tracked plan items.)
+
+A spike is cheap insurance on the most expensive possible mistake.
+
+---
+
+## 4. Owner decision points — judgment to the human, mechanism to the machine
+
+This is the heart of keeping a non-implementer human meaningfully in control.
+
+**Bring to the human** (they own these):
+- scope and phasing ("ship A now, defer B?"), go/no-go, priorities
+- risk appetite and irreversible/expensive trade-offs (cost, blast radius, security posture)
+- product behavior and policy ("serve low-confidence data with a caveat, or hide it?")
+- naming, positioning, external/partner-facing choices
+- anything genuinely ambiguous in their request
+
+**Decide yourself** (mechanism — do *not* make them adjudicate):
+- algorithms, data structures, lock shapes, byte formats, library choices
+- whether the crypto/concurrency is *correct* (that's the Gauntlet's job, not theirs)
+- test design, refactors, conventional defaults
+
+**How to ask — approachably (non-negotiable):**
+- Frame the question in **outcomes and trade-offs**, never implementation. "Do we
+  optimize for the cheapest path or the most-thorough audit?" not "should we use a
+  CvRDT origin-dedup?"
+- Offer **2–4 concrete options**, each with a plain-language description of what it
+  means and its consequence; **lead with a recommendation** and say why.
+- Make **"defer to your default" easy** — if they don't have an opinion, your
+  recommended option proceeds.
+- Reserve questions for where the answer **changes what you do**. Don't ask to
+  offload work or to seem diligent; don't ask them to grade a proof.
+- When you made a reversible mechanism choice on your own, **state it in one line**
+  and move on — visibility without a quiz.
+- After a hard call, record it (with the rationale) in the amendment log / decision
+  record so it isn't re-litigated and survives the context window.
+
+The test: a smart non-engineer should be able to answer every question you ask them
+without opening the code.
+
+---
+
+## 5. Conformance-first / pin the bytes before you build
+
+If the system implements a standard or a wire format, **pin the exact bytes with
+vendored official vectors during design**, not after. Canonicalization ambiguity is
+the classic interop graveyard; pinning a worked example + the standard's own
+conformance vectors in the spec-cache turns "we think this is right" into "any
+conformant peer reproduces this byte-for-byte." This is the design-time half of the
+build process's "machinery, not memory" (conformance vectors over self-derived
+oracles).
+
+Where two valid readings of a spec exist and the vectors don't settle it, **pin
+your reading in a fixture and flag it as interop-pending** — only a second
+implementation (or the real external feed) resolves it later; track it explicitly
+so it isn't silently assumed.
+
+---
+
+## 6. Cost is a first-class design constraint
+
+Design for the bill, not just for correctness. If the project can be killed by
+cost (a runaway build, an unbounded scan, a per-request fan-out), that constraint
+shapes the architecture as hard as any functional requirement — and it's an
+explicit owner trade-off (§4), surfaced in plain terms ("this option adds ~$X per
+run; the cheaper one is slower — which do you want?").
+
+---
+
+## 7. Phasing — each phase stands alone and is killable
+
+Decompose the epic so that **every phase is independently shippable, independently
+valuable, and reversible** — gated behind a kill switch / feature flag, with a clean
+no-op when off. This lets you ship incrementally, get real feedback, and back out a
+phase without unwinding the rest. The first phase that delivers a *real external
+edge* (a live partner, a usable artifact) is worth pulling earlier than its
+"logical" order — a running reference beats a finished spec.
+
+---
+
+## 8. Hand-off to the build
+
+When a phase's design is settled and de-risked, it enters the build process: each
+task is TDD red-first, each PR runs the **Gauntlet at least once before merge**, and
+multi-agent orchestration is the default. Design review and build review are the
+same discipline applied at two altitudes — **continuously, never once.** See the
+companion doc.
+
+---
+
+## 9. Anti-patterns this prevents
+
+- **Designing in a vacuum** — reinventing a standard, or freezing vocabulary you
+  must later rename. → ecosystem-signals research (§2).
+- **Committing the plan on an unproven assumption** — discovering the core mechanism
+  doesn't work after building three phases on it. → de-risk spike (§3).
+- **Asking the human to adjudicate mechanism** — "should the Merkle leaf be
+  0x00-prefixed?" They can't, shouldn't, and will rubber-stamp. → §4 framing.
+- **Silent designer decisions on product/policy** — quietly choosing user-facing
+  behavior the operator owns. → bring it to them, approachably (§4).
+- **Bug-hunt-only review** — a technically-correct design that's unambitious where
+  ambition compounds. → the steelman pass (§2).
+- **Prose-only rigor** — a great design rule that never becomes an executable gate.
+  → pin bytes + fixtures at design time (§5), enforce them in the build.
+
+---
+
+## 10. Adapting to your domain
+
+- Swap the **design lenses** for your risk dimensions (payments: settlement,
+  idempotency, reconciliation, regulatory).
+- Swap the **riskiest-assumption spike** for whatever would sink *your* plan.
+- Keep the **shape**: versioned design-of-record → multi-lens adversarial passes +
+  a steelman → de-risk spike → owner decision points (asked approachably) →
+  conformance-pinned, cost-aware, phased plan → hand off to the per-PR Gauntlet.
+- Keep the two non-negotiables: **review constantly** (design and build), and **the
+  human is asked throughout but never asked to understand the implementation.**

--- a/docs/process/machine-reviewed-red-tier-development.md
+++ b/docs/process/machine-reviewed-red-tier-development.md
@@ -12,6 +12,33 @@ trade safe.
 
 ---
 
+## 0. The mandate (non-negotiable)
+
+When this process is invoked, two rules are not optional:
+
+1. **The Gauntlet runs at least once per PR, before merge.** Once per PR is the
+   *floor*, not the target — re-run it after any critical or structural
+   remediation (§4.6). **No PR merges without a clean (or fully-triaged-and-
+   deferred) Gauntlet pass on its final state.** A green test suite and green CI
+   are necessary but **not sufficient**: the Gauntlet is a required, independent
+   merge gate that sits alongside CI, never in place of it. If the code changed
+   after the last Gauntlet, the Gauntlet is stale — run it again on what will
+   actually merge.
+
+2. **Multi-agent orchestration is authorized by default and preferred.** Running
+   the review (and much of the build) as parallel agent workflows — "ultracode" in
+   this project's tooling — is the standing default for substantive work under this
+   process, not a special-case escalation. Optimize for the most exhaustive,
+   correct result; thoroughness and independent adversarial verification outweigh
+   speed and token cost. Reserve solo, single-context work for trivial or purely
+   mechanical changes.
+
+These two rules are what make "the machine is the reviewer" real rather than
+aspirational. Write them into your project's governing doc so they bind future
+contributors (human and agent), not just the person who set the process up.
+
+---
+
 ## 1. Roles
 
 - **Operator (human):** product sign-off, scope/go-no-go decisions, and the final
@@ -66,7 +93,8 @@ accumulates them.
 ## 4. The Gauntlet
 
 The centerpiece: a **multi-agent adversarial review** run as a deterministic
-workflow against a finished, green PR. Three phases.
+workflow against a finished, green PR. **Mandatory at least once per PR before
+merge (§0).** Three phases.
 
 ### 4.1 Phase 1 — Review lenses (parallel)
 
@@ -182,9 +210,10 @@ assume it will be violated.
 ```
 decompose → per task: [RED test → GREEN → refactor] → review between tasks
    → PR is green locally (full suite + all standard gates)
-   → GAUNTLET (review lenses ‖ attackers ‖ critic)
+   → GAUNTLET (review lenses ‖ attackers ‖ critic)      [MANDATORY, ≥1× per PR — §0]
    → triage; remediate red-first; RE-GAUNTLET on critical/structural fixes
-   → push; CI green (the authoritative gate)
+   → (Gauntlet clean or fully triaged on the FINAL state)
+   → push; CI green (the authoritative gate — alongside, never instead of, the Gauntlet)
    → operator reviews + merges
 ```
 
@@ -197,10 +226,11 @@ that's the operator's call — surface it, don't quietly force it.
 
 ## 7. Cost discipline
 
-A workflow can spawn dozens of agents; that is real money. So:
+A workflow can spawn dozens of agents; that is real money. Under this process,
+multi-agent orchestration is authorized-by-default (§0) — the opt-in gate is at the
+level of *invoking the process at all*, not each individual workflow. Once you're
+in, orchestrate freely; just spend deliberately:
 
-- **Gate the fleet on explicit opt-in.** Don't auto-orchestrate; the operator
-  turns it on for work that warrants it.
 - **Scale to risk.** "find any bugs" → a few lenses, single-vote verify.
   "thoroughly audit this RED-tier crypto" → a full lens panel + multi-vote
   adversarial attackers + a critic.
@@ -256,6 +286,9 @@ the context window.
 - Keep the **shape**: parallel lenses → real in-sandbox attackers → completeness
   critic → structured findings → red-first remediation → re-Gauntlet → green CI →
   human merge.
+- Keep the **mandate (§0)**: the Gauntlet runs at least once per PR before merge,
+  and multi-agent orchestration is the authorized default. Those two are what make
+  the whole thing trustworthy when you carry it to a new repo.
 
 ---
 

--- a/docs/process/machine-reviewed-red-tier-development.md
+++ b/docs/process/machine-reviewed-red-tier-development.md
@@ -2,7 +2,9 @@
 
 A portable process for building high-assurance code with one human and a fleet of
 AI agents. Distilled from a federation/crypto build, but the method is
-stack-agnostic — swap the examples for your domain.
+stack-agnostic — swap the examples for your domain. Companion:
+[Adversarial Design & Planning](./adversarial-design-and-planning.md) governs the
+design phase that precedes this build phase.
 
 The premise: **a solo builder cannot deep-review crypto, concurrency, or
 data-integrity code alone, so the machine becomes the reviewer.** The human owns

--- a/docs/process/machine-reviewed-red-tier-development.md
+++ b/docs/process/machine-reviewed-red-tier-development.md
@@ -1,0 +1,282 @@
+# Machine-Reviewed RED-Tier Development
+
+A portable process for building high-assurance code with one human and a fleet of
+AI agents. Distilled from a federation/crypto build, but the method is
+stack-agnostic — swap the examples for your domain.
+
+The premise: **a solo builder cannot deep-review crypto, concurrency, or
+data-integrity code alone, so the machine becomes the reviewer.** The human owns
+product judgment, go/no-go, and merges; the agents own the exhaustive adversarial
+review the human can't personally perform. Everything below exists to make that
+trade safe.
+
+---
+
+## 1. Roles
+
+- **Operator (human):** product sign-off, scope/go-no-go decisions, and the final
+  merge. Does *not* line-by-line review RED-tier internals — that's the machine's job.
+- **Builder (main agent):** decomposes work, writes code TDD-first, orchestrates
+  the review workflows, triages findings, remediates.
+- **Reviewers (sub-agents in workflows):** independent adversarial perspectives —
+  review lenses, red-team attackers, completeness critics. Their findings are
+  *acted on*, not just filed.
+
+The rule that makes it honest: **the machine review is a merge gate, not a
+formality.** A confirmed breach or unremediated high-severity finding blocks the
+merge exactly like a failing test.
+
+---
+
+## 2. RED-tier classification
+
+Not all code earns the full treatment — that would be wasteful. Tag modules
+**RED-tier** when a defect is (a) hard for a human to catch by reading and (b)
+high-blast-radius:
+
+- cryptography / signing / hashing / canonicalization
+- concurrency / locking / ordering / idempotency
+- data integrity / migrations / canonical-write paths
+- money or cost amplification (anything that can run up a bill)
+- security boundaries / untrusted-input parsers / auth
+
+Everything else is ordinary-tier: normal TDD + the standard gates. RED-tier adds
+the Gauntlet, the conformance machinery, and the per-file floors below.
+
+Write the RED-tier list into your project's governing doc (constitution / CONTRIBUTING)
+so it's binding, not folklore.
+
+---
+
+## 3. The core loop: TDD, red-first, reviewed between units
+
+1. **RED** — write the test that encodes the desired behavior; **run it and watch
+   it fail.** A test you never saw fail proves nothing.
+2. **GREEN** — minimum code to pass.
+3. **REFACTOR** — clean up with tests green.
+4. **Review between units** — don't batch ten changes then review once. Each
+   cohesive unit (a PR-sized task) gets its own review pass.
+
+Prefer a **fresh agent/context per task** (subagent-driven development). A new
+context doesn't inherit the builder's blind spots; one-context-iterated work
+accumulates them.
+
+---
+
+## 4. The Gauntlet
+
+The centerpiece: a **multi-agent adversarial review** run as a deterministic
+workflow against a finished, green PR. Three phases.
+
+### 4.1 Phase 1 — Review lenses (parallel)
+
+N independent agents, each owning **one correctness dimension** of the change
+(e.g. "crypto correctness", "concurrency/append", "schema/storage byte-identity",
+"API/endpoint", "kill-switch + wiring + isolation", "integration round-trip").
+Each lens *adversarially re-reads* its dimension and emits structured findings.
+Diversity is the point — a single reviewer (human or agent) shares one set of
+assumptions; six lenses with disjoint mandates do not.
+
+### 4.2 Phase 2 — Red-team attackers (parallel)
+
+N agents whose job is to **break it for real, in a sandbox** — not to reason about
+whether it's breakable, but to *construct the exploit and run it*: forge a
+signature, race the lock to produce a gap, bypass the kill switch, get a parser to
+accept a malformed input, make a hook abort its caller. Each reports
+`succeeded: true|false` with the actual command output. **Any `succeeded: true` is
+a blocking breach.**
+
+"You MUST actually attempt the construction and report the real outcome; do not
+merely reason" — put that in the attacker prompt. Reasoned-but-unrun attacks are
+worthless.
+
+### 4.3 Phase 3 — Completeness critic
+
+One agent that assumes the lenses and attackers missed something: runs the
+**executable truth** (full suite + the conformance vectors + the concurrency test;
+report the count), then asks *what is not covered* — an untested guard branch, an
+integration seam, an error path, a deferred item that must stay tracked. What it
+finds becomes the next round of work.
+
+### 4.4 Structured output
+
+Force machine-parseable results so triage is mechanical, not prose-diving:
+
+```jsonc
+// finding (review lens + critic)
+{ "severity": "critical|high|medium|low|info",
+  "title": "...", "location": "file:line", "claim": "...",
+  "evidence": "...", "exploitable": true|false, "recommended_action": "..." }
+
+// attack (red-team)
+{ "attack": "...", "attempted": "...", "succeeded": true|false,
+  "severity": "...", "evidence": "<real command output>", "recommended_action": "..." }
+```
+
+### 4.5 Triage rules
+
+- **`succeeded: true` breach** → blocking. Fix before merge.
+- **critical / high** → blocking.
+- **medium** → fix if cheap and in-scope; else defer *with a tracked issue*.
+- **low / info** → fix-if-trivial or record as a decision (see §8: rejected-on-record).
+- A finding tagged `regression: true` (introduced by your own remediation) is
+  treated one tier hotter.
+
+### 4.6 Remediate red-first → re-Gauntlet → converge
+
+Fix each real finding **red-first** (write the failing test that reproduces the
+defect, then fix). When a fix is structural or a critical, **re-run the Gauntlet**
+to confirm it's closed *and that the fix introduced no new defect* — remediation is
+where regressions are born. Iterate until the Gauntlet returns only documented
+minor/deferred items.
+
+> Real example: a Gauntlet caught a publish hook whose `commit()` ran inside a
+> batch job's open savepoint — it would have aborted production runs after one
+> iteration. The fix (collect-and-replay after the outer commit) was itself
+> re-Gauntleted, which confirmed the savepoint now survives and no new path
+> folded the transaction.
+
+---
+
+## 5. Machinery, not memory
+
+The hardest-won principle: **a quality rule that lives only in prose gets skipped.
+Encode it as an executable gate.** A doctrine an agent has to *remember* to follow
+fails the first time an agent doesn't read that doc.
+
+Concrete gates that transfer to any project:
+
+- **Conformance vectors over self-derived oracles.** When you implement a published
+  standard (RFC / W3C / spec), test against the *standard's own* vectors / reference
+  / conformance suite — vendored into the repo with pinned source URL + commit +
+  license. A test you wrote alongside the implementation shares the
+  implementation's blind spot. (A real canonicalization bug shipped green against a
+  self-derived "official-looking" test and was caught only by the spec author's
+  actual suite.)
+- **Byte-identity / round-trip invariants** at every serialization or storage
+  boundary: assert `serialize(x) == stored_bytes == reserialize(read_back(x))`.
+  This is the class of "ships green because nothing asserts the bytes are stable."
+- **Per-file coverage floors in CI** for RED-tier modules — a global average hides
+  one module decaying from 95% to 46%. Floor each RED-tier file; fail CI on a drop;
+  add a no-vacuous-pass guard (a module silently dropping out of the report must
+  fail, not pass).
+- **Kill-switch / feature-flag no-op proofs:** if a flag is meant to make a
+  subsystem inert, *prove it* — a test asserting zero side effects (no write, no
+  network, no signature) when the flag is off, on *every* entry point (the leak is
+  always the one entry point nobody added the guard to).
+- **A conformance registry** (`tests/<area>/vendor/REGISTRY.md`): one row per
+  implemented standard → has-official-vectors? → vendored-path-or-justified-absence,
+  plus a CI grep gate that fails if code references a standard not in the registry.
+  This makes "did you check for official vectors?" un-missable.
+- **Make the doctrine binding:** write all of the above into the governing doc
+  (constitution), with a version bump, so a future contributor (human or agent)
+  who obeys "follow the constitution" actually inherits the obligation.
+
+If a rule matters, it has a failing build behind it. If it only has a paragraph,
+assume it will be violated.
+
+---
+
+## 6. The PR gate (end to end)
+
+```
+decompose → per task: [RED test → GREEN → refactor] → review between tasks
+   → PR is green locally (full suite + all standard gates)
+   → GAUNTLET (review lenses ‖ attackers ‖ critic)
+   → triage; remediate red-first; RE-GAUNTLET on critical/structural fixes
+   → push; CI green (the authoritative gate)
+   → operator reviews + merges
+```
+
+Keep each PR a single well-scoped unit. Resolve base-branch conflicts before the
+final gate (a conflicted PR can't even produce a meaningful CI signal). Merge only
+on green; if a branch-protection ruleset requires a review the author can't supply,
+that's the operator's call — surface it, don't quietly force it.
+
+---
+
+## 7. Cost discipline
+
+A workflow can spawn dozens of agents; that is real money. So:
+
+- **Gate the fleet on explicit opt-in.** Don't auto-orchestrate; the operator
+  turns it on for work that warrants it.
+- **Scale to risk.** "find any bugs" → a few lenses, single-vote verify.
+  "thoroughly audit this RED-tier crypto" → a full lens panel + multi-vote
+  adversarial attackers + a critic.
+- **Reject ceremony, on the record.** A gate that adds CI minutes or flakiness for
+  a defect class that *cannot occur here* is a net negative. When you decline a
+  proposed gate, write down *why* (see §8) so it reads as a decision, not an
+  oversight.
+
+---
+
+## 8. Decisions on the record
+
+Every audit/Gauntlet produces a "considered and rejected" set — gates and tests
+deliberately *not* added. **Record them with the reason.** A future reviewer
+finding no schema-drift gate should see "rejected: the table is created by SQL only;
+the ORM name never materializes; the defect class can't trigger" — not wonder if it
+was forgotten. Rejections are first-class output.
+
+Likewise, deferred work (P2/later-phase hardening, archive paths, follow-on
+gates) gets a tracked issue immediately, quoted from the finding, so it survives
+the context window.
+
+---
+
+## 9. Anti-patterns this prevents
+
+- **Self-graded crypto.** An implementation + a same-author test pass each other
+  while both misread the spec. → conformance vectors (§5).
+- **Ships-green serialization bugs.** No test asserts the stored bytes equal the
+  signed bytes; an extreme value diverges silently. → byte-identity invariants (§5).
+- **The one unguarded entry point.** The kill switch covers `append` but not the
+  *other* thing that signs. → no-op proofs on every entry (§5).
+- **Remediation regressions.** A fix for finding A introduces finding B. →
+  re-Gauntlet after structural/critical fixes (§4.6).
+- **Doctrine drift.** A great quality rule lives in a doc nobody re-reads. → make
+  it an executable gate (§5).
+- **Coverage-average masking.** One file rots inside a healthy aggregate. →
+  per-file floors (§5).
+- **Transaction folding / fail-soft poisoning.** A "side" hook commits or aborts
+  the caller's transaction. → run side effects after the resource commit; on
+  failure, roll back so the caller's session survives; prove it with a test (§4.6).
+
+---
+
+## 10. Adapting to your stack
+
+- Swap the **review lenses** for your risk dimensions (e.g. for a payments system:
+  idempotency, money-rounding, reconciliation, webhook-replay, PII).
+- Swap the **attackers** for your threat model (replay, double-spend, injection,
+  privilege escalation).
+- Swap the **conformance vectors** for whatever standards you implement (or, if
+  none, drop that gate and say so on the record).
+- Keep the **shape**: parallel lenses → real in-sandbox attackers → completeness
+  critic → structured findings → red-first remediation → re-Gauntlet → green CI →
+  human merge.
+
+---
+
+## Appendix — Gauntlet workflow skeleton (pseudocode)
+
+```js
+// Phase 1: parallel review lenses, each adversarial on one dimension
+const reviews = await parallel(LENSES.map(l => () =>
+  agent(CTX + lensPrompt(l), { phase: 'Review', schema: FINDING_SCHEMA })))
+
+// Phase 2: parallel attackers — MUST run the exploit in a sandbox
+const attacks = await parallel(ATTACKS.map(a => () =>
+  agent(CTX + attackPrompt(a) + ' Actually attempt it in-container; report the real outcome.',
+        { phase: 'RedTeam', schema: ATTACK_SCHEMA })))
+const breaches = attacks.filter(a => a.succeeded)   // any => blocking
+
+// Phase 3: completeness critic — runs the executable truth, finds the gaps
+const critic = await agent(CTX + criticPrompt, { phase: 'Critic', schema: FINDING_SCHEMA })
+
+return { reviews, attacks, breaches, critic }
+```
+
+Findings flow back to the builder, who fixes red-first and re-runs until clean.
+The human reads the synthesis, not the file dumps — and decides the merge.


### PR DESCRIPTION
## What

Two **stack-agnostic** process docs under `docs/process/`, written to be lifted into **other epics and other projects** — capturing how this project designs and builds high-assurance code with one operator + a fleet of review agents.

1. **`adversarial-design-and-planning.md`** — how a hard system is *designed* before it's built: design-of-record + living plan + versioned amendment log; the **design Gauntlet** (multi-lens adversarial passes + a steelman pass + ecosystem research); de-risk-the-riskiest-assumption spikes; conformance-first byte pinning; cost as a first-class constraint; killable phasing. Centerpiece: **owner decision points** — the human is asked questions *throughout* but **never expected to understand the implementation**, so questions are framed in approachable, outcome-level terms (judgment to the human, mechanism to the machine).

2. **`machine-reviewed-red-tier-development.md`** — how it's *built*: RED-tier classification, red-first TDD, the three-phase **Gauntlet** (parallel review lenses ‖ in-sandbox red-team attackers ‖ completeness critic) with structured findings + red-first remediation + re-Gauntlet, the **"machinery not memory"** gates (conformance vectors, byte-identity invariants, per-file CI floors, kill-switch no-op proofs, conformance registry), the PR gate flow, cost discipline, and the anti-patterns it prevents.

## The two non-negotiables (§0 of the build doc)

- **The Gauntlet runs at least once per PR before merge** — the floor, not the target; re-run after critical/structural fixes; green CI is necessary but **not sufficient** (the Gauntlet is a required, independent gate on the final state).
- **Multi-agent orchestration ("ultracode") is authorized-by-default and preferred** for substantive work — optimize for exhaustive correctness over speed/cost.

## Scope

Docs only — two new files, no code. On its own branch, separate from the in-flight federation feature PRs. **Spend on design/review now to save effort later; review constantly, never once.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)