### PR TITLE
feat(federation): HSDS-FX RFC-6962 consistency-proof anchored area (Slice 8), machine-reviewed

### DIFF
--- a/conformance/hsdsfx/generate.py
+++ b/conformance/hsdsfx/generate.py
@@ -552,6 +552,98 @@ def _gen_merkle_inclusion() -> dict:
     }
 
 
+# --- consistency_proof area (Slice 8) -------------------------------------------
+# GENUINELY ANCHORED (mirrors merkle_inclusion): RFC-6962 consistency proofs read
+# VERBATIM from the vendored transparency-dev suite. This anchors the "the new log
+# head is an APPEND-ONLY extension of the one I last saw" check (§6.2b) — the
+# property that makes a rewritten / forked / truncated history PROVABLE, not merely
+# alleged. Carries the root-equality teeth (wrong-second-root, tampered-proof).
+
+
+def _gen_consistency_proof() -> dict:
+    suite = json.loads(
+        (_VENDOR / "rfc6962_transparency_dev" / "vectors.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    proofs = suite["consistency_proofs"]
+    vectors = []
+    for k, cp in enumerate(proofs, start=1):
+        vectors.append(
+            {
+                "id": f"consistency-{k:03d}",
+                "op": "verify_consistency",
+                "description": (
+                    f"ANCHORED (RFC-6962, transparency-dev {cp['source']}): the "
+                    f"size-{cp['second_size']} tree is a proven append-only extension "
+                    f"of the size-{cp['first_size']} tree. Proof/root bytes are "
+                    "vendored verbatim — a genuinely external anchor."
+                ),
+                "input": {
+                    "first_size": cp["first_size"],
+                    "second_size": cp["second_size"],
+                    "proof_hex": cp["proof_hex"],
+                    "first_root_hex": cp["first_root_hex"],
+                    "second_root_hex": cp["second_root_hex"],
+                },
+                "expected": True,
+                "must_reject": False,
+                "interop_pending": False,
+            }
+        )
+    good = proofs[0]
+    # (a) a valid proof checked against a DIFFERENT second root MUST fail — the
+    #     load-bearing equality (a forked/rewritten head reconstructs a different root).
+    vectors.append(
+        {
+            "id": "consistency-wrong-second-root-001",
+            "op": "verify_consistency",
+            "description": (
+                "A valid vendored consistency proof checked against a DIFFERENT "
+                "(empty-tree) second root MUST fail — a rewritten/forked head cannot "
+                "reconstruct the claimed root."
+            ),
+            "input": {
+                "first_size": good["first_size"],
+                "second_size": good["second_size"],
+                "proof_hex": good["proof_hex"],
+                "first_root_hex": good["first_root_hex"],
+                "second_root_hex": suite["empty_root_hex"],
+            },
+            "must_reject": True,
+        }
+    )
+    # (b) a proof with one hash byte flipped MUST fail — proof integrity.
+    tampered = list(good["proof_hex"])
+    tampered[0] = _flip_hex(tampered[0])
+    vectors.append(
+        {
+            "id": "consistency-tampered-proof-001",
+            "op": "verify_consistency",
+            "description": (
+                "A vendored consistency proof with a single flipped nibble in its "
+                "first hash MUST fail (proof integrity)."
+            ),
+            "input": {
+                "first_size": good["first_size"],
+                "second_size": good["second_size"],
+                "proof_hex": tampered,
+                "first_root_hex": good["first_root_hex"],
+                "second_root_hex": good["second_root_hex"],
+            },
+            "must_reject": True,
+        }
+    )
+    return {
+        "area": "consistency_proof",
+        "spec": "HSDS-FX/§6.2b (RFC-6962 consistency)",
+        "reference_impl": "app/federation/merkle.py:verify_consistency",
+        "interop_status": "anchored",
+        "derives_from": "vendor/rfc6962_transparency_dev (consistency proofs, verbatim)",
+        "vectors": vectors,
+    }
+
+
 # --- federation_id grammar area (Slice 4) ---------------------------------------
 # INTEROP_PENDING: the federation_id = <host> ":" <internal-id> composition is a
 # PPR-native canonical reading (design §135) with no upstream conformance suite —
@@ -1030,6 +1122,7 @@ _AREAS = {
     "checkpoint.json": _gen_checkpoint,
     "export_wire.json": _gen_export_wire,
     "merkle_inclusion.json": _gen_merkle_inclusion,
+    "consistency_proof.json": _gen_consistency_proof,
     "federation_id.json": _gen_federation_id,
     "jcs.json": _gen_jcs,
     "activity_verbs.json": _gen_activity_verbs,

--- a/conformance/hsdsfx/vectors/consistency_proof.json
+++ b/conformance/hsdsfx/vectors/consistency_proof.json
@@ -1,0 +1,118 @@
+{
+  "area": "consistency_proof",
+  "spec": "HSDS-FX/§6.2b (RFC-6962 consistency)",
+  "reference_impl": "app/federation/merkle.py:verify_consistency",
+  "interop_status": "anchored",
+  "derives_from": "vendor/rfc6962_transparency_dev (consistency proofs, verbatim)",
+  "vectors": [
+    {
+      "id": "consistency-001",
+      "op": "verify_consistency",
+      "description": "ANCHORED (RFC-6962, transparency-dev testdata/consistency/1/happy-path.json): the size-8 tree is a proven append-only extension of the size-1 tree. Proof/root bytes are vendored verbatim — a genuinely external anchor.",
+      "input": {
+        "first_size": 1,
+        "second_size": 8,
+        "proof_hex": [
+          "96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7",
+          "5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+          "6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"
+        ],
+        "first_root_hex": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "second_root_hex": "5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"
+      },
+      "expected": true,
+      "must_reject": false,
+      "interop_pending": false
+    },
+    {
+      "id": "consistency-002",
+      "op": "verify_consistency",
+      "description": "ANCHORED (RFC-6962, transparency-dev testdata/consistency/2/happy-path.json): the size-8 tree is a proven append-only extension of the size-6 tree. Proof/root bytes are vendored verbatim — a genuinely external anchor.",
+      "input": {
+        "first_size": 6,
+        "second_size": 8,
+        "proof_hex": [
+          "0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a",
+          "ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0",
+          "d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"
+        ],
+        "first_root_hex": "76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef",
+        "second_root_hex": "5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"
+      },
+      "expected": true,
+      "must_reject": false,
+      "interop_pending": false
+    },
+    {
+      "id": "consistency-003",
+      "op": "verify_consistency",
+      "description": "ANCHORED (RFC-6962, transparency-dev testdata/consistency/3/happy-path.json): the size-5 tree is a proven append-only extension of the size-2 tree. Proof/root bytes are vendored verbatim — a genuinely external anchor.",
+      "input": {
+        "first_size": 2,
+        "second_size": 5,
+        "proof_hex": [
+          "5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+          "bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"
+        ],
+        "first_root_hex": "fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125",
+        "second_root_hex": "4e3bbb1f7b478dcfe71fb631631519a3bca12c9aefca1612bfce4c13a86264d4"
+      },
+      "expected": true,
+      "must_reject": false,
+      "interop_pending": false
+    },
+    {
+      "id": "consistency-004",
+      "op": "verify_consistency",
+      "description": "ANCHORED (RFC-6962, transparency-dev testdata/consistency/4/happy-path.json): the size-7 tree is a proven append-only extension of the size-6 tree. Proof/root bytes are vendored verbatim — a genuinely external anchor.",
+      "input": {
+        "first_size": 6,
+        "second_size": 7,
+        "proof_hex": [
+          "0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a",
+          "b08693ec2e721597130641e8211e7eedccb4c26413963eee6c1e2ed16ffb1a5f",
+          "d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"
+        ],
+        "first_root_hex": "76e67dadbcdf1e10e1b74ddc608abd2f98dfb16fbce75277b5232a127f2087ef",
+        "second_root_hex": "ddb89be403809e325750d3d263cd78929c2942b7942a34b77e122c9594a74c8c"
+      },
+      "expected": true,
+      "must_reject": false,
+      "interop_pending": false
+    },
+    {
+      "id": "consistency-wrong-second-root-001",
+      "op": "verify_consistency",
+      "description": "A valid vendored consistency proof checked against a DIFFERENT (empty-tree) second root MUST fail — a rewritten/forked head cannot reconstruct the claimed root.",
+      "input": {
+        "first_size": 1,
+        "second_size": 8,
+        "proof_hex": [
+          "96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7",
+          "5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+          "6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"
+        ],
+        "first_root_hex": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "second_root_hex": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "must_reject": true
+    },
+    {
+      "id": "consistency-tampered-proof-001",
+      "op": "verify_consistency",
+      "description": "A vendored consistency proof with a single flipped nibble in its first hash MUST fail (proof integrity).",
+      "input": {
+        "first_size": 1,
+        "second_size": 8,
+        "proof_hex": [
+          "06a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7",
+          "5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
+          "6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"
+        ],
+        "first_root_hex": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "second_root_hex": "5dc9da79a70659a9ad559cb701ded9a2ab9d823aad2f4960cfe370eff4604328"
+      },
+      "must_reject": true
+    }
+  ]
+}

--- a/tests/test_federation/conformance/adapter.py
+++ b/tests/test_federation/conformance/adapter.py
@@ -93,6 +93,20 @@ class HsdsFxAdapter(Protocol):
         is load-bearing — RFC-6962 leaf = sha256(0x00 ‖ data)."""
         ...
 
+    def verify_consistency(
+        self,
+        first_size: int,
+        second_size: int,
+        proof_hex: list[str],
+        first_root_hex: str,
+        second_root_hex: str,
+    ) -> bool:
+        """True iff ``proof_hex`` shows the size-``second_size`` tree is an
+        APPEND-ONLY extension of the size-``first_size`` tree (RFC-6962 §2.1.2): a
+        rewritten / forked / truncated history cannot satisfy it. Roots/proof are
+        hex of the 32-byte node hashes."""
+        ...
+
     # --- federation_id grammar (§8.x / design §135) ---------------------------
 
     def normalize_federation_id(self, value: str) -> str:
@@ -227,6 +241,24 @@ class RefAdapter:
             n,
             [bytes.fromhex(h) for h in proof_hex],
             bytes.fromhex(root_hex),
+        )
+
+    def verify_consistency(
+        self,
+        first_size: int,
+        second_size: int,
+        proof_hex: list[str],
+        first_root_hex: str,
+        second_root_hex: str,
+    ) -> bool:
+        from app.federation.merkle import verify_consistency
+
+        return verify_consistency(
+            first_size,
+            second_size,
+            [bytes.fromhex(h) for h in proof_hex],
+            bytes.fromhex(first_root_hex),
+            bytes.fromhex(second_root_hex),
         )
 
     def normalize_federation_id(self, value: str) -> str:

--- a/tests/test_federation/conformance/runner.py
+++ b/tests/test_federation/conformance/runner.py
@@ -148,6 +148,16 @@ def _op_verify_inclusion(a: HsdsFxAdapter, i: dict) -> Any:
     )
 
 
+def _op_verify_consistency(a: HsdsFxAdapter, i: dict) -> Any:
+    return a.verify_consistency(
+        i["first_size"],
+        i["second_size"],
+        i["proof_hex"],
+        i["first_root_hex"],
+        i["second_root_hex"],
+    )
+
+
 def _op_normalize_federation_id(a: HsdsFxAdapter, i: dict) -> Any:
     return a.normalize_federation_id(i["federation_id"])
 
@@ -167,6 +177,7 @@ _OPS: dict[str, Callable[[HsdsFxAdapter, dict], Any]] = {
     "verify_note": _op_verify_note,
     "parse_checkpoint": _op_parse_checkpoint,
     "verify_inclusion": _op_verify_inclusion,
+    "verify_consistency": _op_verify_consistency,
     "normalize_federation_id": _op_normalize_federation_id,
     "validate_activity": _op_validate_activity,
 }
@@ -174,7 +185,13 @@ _OPS: dict[str, Callable[[HsdsFxAdapter, dict], Any]] = {
 #: Ops whose normal return value already signals rejection (False), so a
 #: ``must_reject`` vector passes on False as well as on a raise.
 _BOOLEAN_OPS = frozenset(
-    {"verify_envelope", "verify_note", "verify_inclusion", "validate_activity"}
+    {
+        "verify_envelope",
+        "verify_note",
+        "verify_inclusion",
+        "verify_consistency",
+        "validate_activity",
+    }
 )
 
 

--- a/tests/test_federation/test_hsdsfx_level1.py
+++ b/tests/test_federation/test_hsdsfx_level1.py
@@ -377,3 +377,39 @@ def test_merkle_inclusion_vectors_match_vendored_proof_tuples():
         assert (
             tup in vendored
         ), f"merkle accept {v['id']} is not a complete vendored inclusion-proof tuple"
+
+
+def test_consistency_proof_vectors_match_vendored_proof_tuples():
+    """The consistency_proof anchor (mirrors merkle_inclusion): each ACCEPT vector
+    must be a COMPLETE vendored RFC-6962 consistency-proof tuple (first_size,
+    second_size, proof, first_root, second_root), not vendored fragments reassembled."""
+    suite = json.loads(
+        (_VENDOR / "rfc6962_transparency_dev" / "vectors.json").read_text("utf-8")
+    )
+    vendored = {
+        (
+            cp["first_size"],
+            cp["second_size"],
+            tuple(h.lower() for h in cp["proof_hex"]),
+            cp["first_root_hex"].lower(),
+            cp["second_root_hex"].lower(),
+        )
+        for cp in suite["consistency_proofs"]
+    }
+    area = next(
+        m for _p, m in runner.iter_manifests() if m["area"] == "consistency_proof"
+    )
+    accepts = [v for v in area["vectors"] if not v["must_reject"]]
+    assert accepts, "consistency_proof has no accept vectors"
+    for v in accepts:
+        i = v["input"]
+        tup = (
+            i["first_size"],
+            i["second_size"],
+            tuple(h.lower() for h in i["proof_hex"]),
+            i["first_root_hex"].lower(),
+            i["second_root_hex"].lower(),
+        )
+        assert (
+            tup in vendored
+        ), f"consistency accept {v['id']} is not a complete vendored consistency-proof tuple"

--- a/tests/test_federation/test_hsdsfx_portability.py
+++ b/tests/test_federation/test_hsdsfx_portability.py
@@ -140,6 +140,7 @@ def test_runner_executes_in_a_ppr_free_tree(tmp_path):
                 def verify_note(self, note, pubkey_hex, key_name): return False
                 def parse_checkpoint(self, note): return {}
                 def verify_inclusion(self, *a, **k): return False
+                def verify_consistency(self, *a, **k): return False
                 def normalize_federation_id(self, value): return ""
                 def validate_activity(self, envelope): return False
             """


### PR DESCRIPTION
## What this delivers (plain language)

Slice 8 adds conformance coverage for the **"no rewriting history" check** — the cryptographic proof that a peer's latest log is an *append-only extension* of the version you last saw, so a peer that quietly rewrites, forks, or truncates its published records is **provably** caught, not just suspected. This is the second half of the verifiable-log story (the first, "this record is genuinely in the log," shipped earlier as the inclusion-proof area).

It mirrors the already-merged Merkle-inclusion area: it's a **genuinely anchored** area whose test vectors are copied verbatim from Google/transparency-dev's published RFC-6962 vectors, so it's externally validated, not self-graded.

## Why you can trust it

A RED-tier Gauntlet specifically tried to make the check *fail at its job* — it built forked, truncated, and wrong-root histories and confirmed the verifier **rejects every one** (and accepts every honest one), cross-checked against an independent clean-room implementation over 20,000 fuzz trials with zero disagreements. The conformance area also has real teeth (a cheating implementation fails it), and the change is surgical — it didn't touch the existing crypto or the honesty machinery (both re-confirmed byte-identical). **0 findings.**

## Gates (all green locally)
Full suite **1085 passed / 8 skipped**; drift gate (10 areas now), conformance L1/L2/portability, black, ruff, mypy, vulture, federation ≥95% coverage floor (`merkle.py` 100%). Anchored (externally-validated) vector count is now 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)