### PR TITLE
HSDS G2 — Profile truth-up

### DIFF
--- a/profiles/hsds-ppr/README.md
+++ b/profiles/hsds-ppr/README.md
@@ -17,6 +17,8 @@ Files in this Profile:
 
 - `location.json` — merge patch over the HSDS `location` schema.
 - `service.json` — merge patch over the HSDS `service` schema.
+- `organization.json` — merge patch over the HSDS `organization` schema.
+- `service_at_location.json` — merge patch over the HSDS `service_at_location` schema.
 - `openapi.json` — merge patch over the HSDS API specification.
 
 ## Permitted modifications only
@@ -27,18 +29,73 @@ property to a schema's `required` array, does not override or remove any core
 property, and the added terms do not overlap semantically with existing HSDS
 terms.
 
-The added optional properties on both `location` and `service` are:
+### Uniform PPR extension surface
+
+`location.json`, `service.json`, `organization.json`, and
+`service_at_location.json` all declare the same core extension surface
+(`confidence_score`, `verified_by`, `sources`, `source_count`).
+`location.json` additionally declares `distance`, which is location- and
+search-specific.
 
 | Property           | Type             | Notes                                                                                  |
 | ------------------ | ---------------- | -------------------------------------------------------------------------------------- |
-| `confidence_score` | integer (0–100)  | PPR data-quality confidence. Scraped data capped at 90; 91–100 are human corrections.  |
-| `verified_by`      | string enum      | `auto` / `admin` / `source` / `claimed` / `network` — provenance of the verification.  |
-| `sources`          | array of strings | Scraper / network identifiers that corroborated the record (multi-source corroboration). |
+| `confidence_score` | integer (0–100)  | PPR data-quality confidence. Scraped data capped at 90; 91–100 are human corrections. **Reserved / not currently served at the entity level**: NOT emitted by current HSDS read responses or the federation export as a top-level field for any of the four entities — it is surfaced today only per-source inside each `sources[]` item (`LocationResponse.sources[].confidence_score`). An entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). |
+| `verified_by`      | string enum      | `auto` / `admin` / `source` / `claimed` / `network` — provenance of the verification. `network` denotes federation-corroborated provenance, operational with P2 Slice 3 / I1. **Reserved / not currently served**: not surfaced by any current HSDS read response for any of the four entities; reserved for the federation/provenance surface. |
+| `sources`          | array of objects | Per-source corroboration details (multi-source). Each item mirrors `app.models.hsds.response.SourceInfo`: `scraper`, `name`, `phone`, `email`, `website`, `address` (strings), `confidence_score` (integer 0-100), `last_updated`, `first_seen` (strings). All item properties are optional. **Currently served only for `location`** (`LocationResponse.sources`, and the federation Location aggregate); for `service`, `organization`, and `service_at_location` this declaration is forward-looking and not yet emitted by any read endpoint. |
+| `source_count`     | integer (>= 0)   | Count of distinct corroborating sources (scraper/network identifiers). **Currently served only for `location`** — see "source_count: two definitions" below. For `service`, `organization`, and `service_at_location`, NOT currently emitted by the read API; reserved for the federation export surface, where it is the distinct-scraper count (`app/federation/aggregate.py`). |
+| `distance`         | string           | **`location.json` only.** Great-circle distance from the search origin. Appears ONLY on radius/proximity search responses — it is search-result metadata, not a stored property of the location. |
 
-These mirror fields PPR already emits. The `openapi.json` patch documents the
-forthcoming `/api/v1/federation/*` endpoints (`/export`, `/actor`, `/inbox`,
-`/history`); those operations land fully in later federation phases (P1/P3) — the
-Profile documents them now as new optional API endpoints.
+Of the four entities, **only `location` currently emits `sources` and
+`source_count`** via `LocationResponse` (and the federation Location
+aggregate). `confidence_score` and `verified_by` are not emitted at the
+entity level for ANY of the four entities today — `confidence_score` is
+visible only per-source inside `sources[]`. The `service.json`,
+`organization.json`, and `service_at_location.json` patches declare the same
+uniform extension surface as `location.json` as **forward declarations**: a
+deliberately uniform shape that unblocks a future federation export carrying
+org/SAL/service provenance without requiring a second Profile revision to add
+the fields then. Declaring an optional property that the implementation does
+not yet populate is conformant (HSDS Profiles "Permitted Modifications");
+this README and the per-field descriptions in each schema patch say plainly
+which fields are served today versus reserved.
+
+#### `sources` is an array of objects (not strings)
+
+Earlier revisions of this Profile declared `sources` as `array of strings`
+(scraper identifiers only). The read API actually serves `sources` as an array
+of `SourceInfo` objects (`app/models/hsds/response.py`). This Profile now
+declares the object shape to match what is actually served; a machinery test
+(`tests/test_federation/test_profile_merge.py::test_location_sources_items_match_source_info_model`)
+pins the declared `sources[].items.properties` keys to `SourceInfo`'s field set
+so the two cannot silently drift again.
+
+#### `source_count`: two definitions (documented, not yet unified)
+
+The canonical definition of `source_count` is **the count of distinct
+corroborating sources (scraper/network identifiers)** for the record — this
+matches the corroboration-bonus semantics (`app/reconciler/location_commit.py`)
+and the federation Location aggregate (`app/federation/aggregate.py`, which
+computes `len({s.scraper for s in sources})`). The read API
+(`app/models/hsds/response.py::LocationResponse.source_count`) currently sets
+this field to `len(sources)`, which is equivalent **when `sources` is already
+de-duplicated by source identifier** (the normal case). Unifying the two
+code paths onto one definition is tracked for a later slice; this Profile
+documents the canonical definition now so a federation peer's expectation is
+set correctly even before that unification lands.
+
+The `openapi.json` patch documents the `/api/v1/federation/*` endpoints
+(`/export`, `/actor`, `/inbox`, `/history`); those operations land fully in
+later federation phases (P1/P3). It also documents the additive PPR read
+endpoints `/api/v1/locations`, `/api/v1/locations/{location_id}`,
+`/api/v1/locations/search`, `/api/v1/organizations/search`, and
+`/api/v1/services/search` — these are not part of the core HSDS OpenAPI
+specification (which has no `/locations` or `/search` paths) but are existing,
+shipped PPR API surface that the Profile now documents as optional additive
+endpoints. Only the `/locations*` endpoints currently emit any PPR profile
+extension fields (`sources`, `source_count`, and — on `/locations/search`
+radius results — `distance`); `/organizations/search` and `/services/search`
+return the core HSDS `Organization`/`Service` shape with no PPR extension
+fields today.
 
 ## HSDS baseline: 3.1.1 (honest)
 

--- a/profiles/hsds-ppr/location.json
+++ b/profiles/hsds-ppr/location.json
@@ -4,7 +4,7 @@
       "name": "confidence_score",
       "type": "integer",
       "title": "Confidence Score",
-      "description": "Pantry Pirate Radio data-quality confidence for this location, 0-100. Scraped data is capped at 90; values 91-100 are reserved for human corrections. Optional profile extension.",
+      "description": "Pantry Pirate Radio data-quality confidence for this location, 0-100 (scraped data capped at 90; 91-100 reserved for human corrections). NOT emitted by current HSDS read responses or the federation export at the entity level — it is surfaced per-source inside each `sources[]` item today; an entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). Optional profile extension.",
       "minimum": 0,
       "maximum": 100,
       "core": "N"
@@ -13,7 +13,7 @@
       "name": "verified_by",
       "type": "string",
       "title": "Verified By",
-      "description": "Provenance of the most authoritative verification for this location. Optional profile extension.",
+      "description": "Provenance of the most authoritative verification for this location: auto (scraped), admin/source/claimed (human-corrected), or network (federation-corroborated provenance, operational with P2 Slice 3 / I1). Not currently surfaced by HSDS read responses; reserved for the federation/provenance surface. Optional profile extension.",
       "enum": ["auto", "admin", "source", "claimed", "network"],
       "core": "N"
     },
@@ -21,10 +21,83 @@
       "name": "sources",
       "type": "array",
       "title": "Sources",
-      "description": "Identifiers of the scrapers or networks that corroborated this location. Optional profile extension supporting multi-source corroboration.",
+      "description": "Per-source corroboration details for this location: one entry per scraper or network identifier that contributed data, supporting multi-source corroboration. Optional profile extension.",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "scraper": {
+            "name": "scraper",
+            "type": "string",
+            "title": "Scraper",
+            "description": "Scraper or network identifier for this source."
+          },
+          "name": {
+            "name": "name",
+            "type": "string",
+            "title": "Name",
+            "description": "Location name as reported by this source."
+          },
+          "phone": {
+            "name": "phone",
+            "type": "string",
+            "title": "Phone",
+            "description": "Phone number as reported by this source."
+          },
+          "email": {
+            "name": "email",
+            "type": "string",
+            "title": "Email",
+            "description": "Email address as reported by this source."
+          },
+          "website": {
+            "name": "website",
+            "type": "string",
+            "title": "Website",
+            "description": "Website as reported by this source."
+          },
+          "address": {
+            "name": "address",
+            "type": "string",
+            "title": "Address",
+            "description": "Address as reported by this source."
+          },
+          "confidence_score": {
+            "name": "confidence_score",
+            "type": "integer",
+            "title": "Confidence Score",
+            "description": "Per-source confidence score, 0-100.",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "last_updated": {
+            "name": "last_updated",
+            "type": "string",
+            "title": "Last Updated",
+            "description": "Timestamp this source last updated its contribution."
+          },
+          "first_seen": {
+            "name": "first_seen",
+            "type": "string",
+            "title": "First Seen",
+            "description": "Timestamp this source was first observed."
+          }
+        }
       },
+      "core": "N"
+    },
+    "source_count": {
+      "name": "source_count",
+      "type": "integer",
+      "title": "Source Count",
+      "description": "Count of distinct corroborating sources (scraper/network identifiers) for this location. The read API currently sets this to len(sources), which is equivalent when sources are de-duplicated by source identifier; code-level unification of the two definitions is tracked for a later slice. Optional profile extension.",
+      "minimum": 0,
+      "core": "N"
+    },
+    "distance": {
+      "name": "distance",
+      "type": "string",
+      "title": "Distance",
+      "description": "Great-circle distance from the search origin to this location. Appears ONLY on radius/proximity search responses; it is search-result metadata, not a stored property of the location. Optional profile extension.",
       "core": "N"
     }
   }

--- a/profiles/hsds-ppr/openapi.json
+++ b/profiles/hsds-ppr/openapi.json
@@ -1,5 +1,70 @@
 {
   "paths": {
+    "/api/v1/locations": {
+      "get": {
+        "summary": "List locations",
+        "description": "Returns a paginated list of HSDS Location records, including the PPR profile extension fields `sources` and `source_count`. Optional profile endpoint additive to the core HSDS API.",
+        "operationId": "listLocations",
+        "tags": ["locations"],
+        "responses": {
+          "200": {
+            "description": "A page of HSDS Location records."
+          }
+        }
+      }
+    },
+    "/api/v1/locations/{location_id}": {
+      "get": {
+        "summary": "Get a location by id",
+        "description": "Returns a single HSDS Location record, including the PPR profile extension fields `sources` and `source_count`. Optional profile endpoint additive to the core HSDS API.",
+        "operationId": "getLocation",
+        "tags": ["locations"],
+        "responses": {
+          "200": {
+            "description": "The requested HSDS Location record."
+          }
+        }
+      }
+    },
+    "/api/v1/locations/search": {
+      "get": {
+        "summary": "Search locations",
+        "description": "Returns HSDS Location records matching search and/or radius criteria, including the PPR profile extension fields `sources` and `source_count`. Radius/proximity search results additionally carry the PPR profile extension field `distance`. Optional profile endpoint additive to the core HSDS API.",
+        "operationId": "searchLocations",
+        "tags": ["locations"],
+        "responses": {
+          "200": {
+            "description": "A page of matching HSDS Location records."
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/search": {
+      "get": {
+        "summary": "Search organizations",
+        "description": "Returns HSDS Organization records matching search criteria. Optional PPR-additive search endpoint over the core HSDS Organization shape; no PPR profile extension fields are currently emitted for this entity. Optional profile endpoint additive to the core HSDS API.",
+        "operationId": "searchOrganizations",
+        "tags": ["organizations"],
+        "responses": {
+          "200": {
+            "description": "A page of matching HSDS Organization records."
+          }
+        }
+      }
+    },
+    "/api/v1/services/search": {
+      "get": {
+        "summary": "Search services",
+        "description": "Returns HSDS Service records matching search criteria. Optional PPR-additive search endpoint over the core HSDS Service shape; no PPR profile extension fields are currently emitted for this entity. Optional profile endpoint additive to the core HSDS API.",
+        "operationId": "searchServices",
+        "tags": ["services"],
+        "responses": {
+          "200": {
+            "description": "A page of matching HSDS Service records."
+          }
+        }
+      }
+    },
     "/api/v1/federation/export": {
       "get": {
         "summary": "Export HSDS records for federation peers",

--- a/profiles/hsds-ppr/organization.json
+++ b/profiles/hsds-ppr/organization.json
@@ -4,7 +4,7 @@
       "name": "confidence_score",
       "type": "integer",
       "title": "Confidence Score",
-      "description": "Pantry Pirate Radio data-quality confidence for this service, 0-100 (scraped data capped at 90; 91-100 reserved for human corrections). NOT emitted by current HSDS read responses or the federation export at the entity level — it is surfaced per-source inside each `sources[]` item today; an entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). Optional profile extension.",
+      "description": "Pantry Pirate Radio data-quality confidence for this organization, 0-100 (scraped data capped at 90; 91-100 reserved for human corrections). NOT emitted by current HSDS read responses or the federation export at the entity level — it is surfaced per-source inside each `sources[]` item today; an entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). Optional profile extension.",
       "minimum": 0,
       "maximum": 100,
       "core": "N"
@@ -13,7 +13,7 @@
       "name": "verified_by",
       "type": "string",
       "title": "Verified By",
-      "description": "Provenance of the most authoritative verification for this service: auto (scraped), admin/source/claimed (human-corrected), or network (federation-corroborated provenance, operational with P2 Slice 3 / I1). Not currently surfaced by HSDS read responses; reserved for the federation/provenance surface. Optional profile extension.",
+      "description": "Provenance of the most authoritative verification for this organization: auto (scraped), admin/source/claimed (human-corrected), or network (federation-corroborated provenance, operational with P2 Slice 3 / I1). Not currently surfaced by HSDS read responses; reserved for the federation/provenance surface. Optional profile extension.",
       "enum": ["auto", "admin", "source", "claimed", "network"],
       "core": "N"
     },
@@ -21,7 +21,7 @@
       "name": "sources",
       "type": "array",
       "title": "Sources",
-      "description": "Per-source corroboration details for this service: one entry per scraper or network identifier that contributed data, supporting multi-source corroboration. Optional profile extension.",
+      "description": "Per-source corroboration details for this organization: one entry per scraper or network identifier that contributed data, supporting multi-source corroboration. Optional profile extension.",
       "items": {
         "type": "object",
         "properties": {
@@ -35,7 +35,7 @@
             "name": "name",
             "type": "string",
             "title": "Name",
-            "description": "Service name as reported by this source."
+            "description": "Organization name as reported by this source."
           },
           "phone": {
             "name": "phone",

--- a/profiles/hsds-ppr/service_at_location.json
+++ b/profiles/hsds-ppr/service_at_location.json
@@ -4,7 +4,7 @@
       "name": "confidence_score",
       "type": "integer",
       "title": "Confidence Score",
-      "description": "Pantry Pirate Radio data-quality confidence for this service, 0-100 (scraped data capped at 90; 91-100 reserved for human corrections). NOT emitted by current HSDS read responses or the federation export at the entity level — it is surfaced per-source inside each `sources[]` item today; an entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). Optional profile extension.",
+      "description": "Pantry Pirate Radio data-quality confidence for this service-at-location entry, 0-100 (scraped data capped at 90; 91-100 reserved for human corrections). NOT emitted by current HSDS read responses or the federation export at the entity level — it is surfaced per-source inside each `sources[]` item today; an entity-level value is reserved for the forthcoming federation export surface (epic slices X1/X2). Optional profile extension.",
       "minimum": 0,
       "maximum": 100,
       "core": "N"
@@ -13,7 +13,7 @@
       "name": "verified_by",
       "type": "string",
       "title": "Verified By",
-      "description": "Provenance of the most authoritative verification for this service: auto (scraped), admin/source/claimed (human-corrected), or network (federation-corroborated provenance, operational with P2 Slice 3 / I1). Not currently surfaced by HSDS read responses; reserved for the federation/provenance surface. Optional profile extension.",
+      "description": "Provenance of the most authoritative verification for this service-at-location entry: auto (scraped), admin/source/claimed (human-corrected), or network (federation-corroborated provenance, operational with P2 Slice 3 / I1). Not currently surfaced by HSDS read responses; reserved for the federation/provenance surface. Optional profile extension.",
       "enum": ["auto", "admin", "source", "claimed", "network"],
       "core": "N"
     },
@@ -21,7 +21,7 @@
       "name": "sources",
       "type": "array",
       "title": "Sources",
-      "description": "Per-source corroboration details for this service: one entry per scraper or network identifier that contributed data, supporting multi-source corroboration. Optional profile extension.",
+      "description": "Per-source corroboration details for this service-at-location entry: one entry per scraper or network identifier that contributed data, supporting multi-source corroboration. Optional profile extension.",
       "items": {
         "type": "object",
         "properties": {
@@ -35,7 +35,7 @@
             "name": "name",
             "type": "string",
             "title": "Name",
-            "description": "Service name as reported by this source."
+            "description": "Name as reported by this source."
           },
           "phone": {
             "name": "phone",

--- a/tests/test_federation/test_profile.py
+++ b/tests/test_federation/test_profile.py
@@ -32,7 +32,16 @@ def test_api_root_version_unchanged():
     assert r.json()["version"] == "3.1.1"
 
 
-@pytest.mark.parametrize("name", ["location.json", "service.json", "openapi.json"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "location.json",
+        "service.json",
+        "organization.json",
+        "service_at_location.json",
+        "openapi.json",
+    ],
+)
 def test_profile_patch_is_valid_json(name):
     data = json.loads((_PROFILES / name).read_text())
     assert isinstance(data, dict)
@@ -44,6 +53,7 @@ def test_location_profile_adds_only_optional_props():
     assert "required" not in data or data.get("required") in (None, [], {})
     props = data.get("properties", {})
     assert "confidence_score" in props and "verified_by" in props and "sources" in props
+    assert "source_count" in props and "distance" in props
 
 
 def test_service_profile_adds_only_optional_props():
@@ -51,6 +61,23 @@ def test_service_profile_adds_only_optional_props():
     assert "required" not in data or data.get("required") in (None, [], {})
     props = data.get("properties", {})
     assert "confidence_score" in props and "verified_by" in props and "sources" in props
+    assert "source_count" in props
+
+
+def test_organization_profile_adds_only_optional_props():
+    data = json.loads((_PROFILES / "organization.json").read_text())
+    assert "required" not in data or data.get("required") in (None, [], {})
+    props = data.get("properties", {})
+    assert "confidence_score" in props and "verified_by" in props and "sources" in props
+    assert "source_count" in props
+
+
+def test_service_at_location_profile_adds_only_optional_props():
+    data = json.loads((_PROFILES / "service_at_location.json").read_text())
+    assert "required" not in data or data.get("required") in (None, [], {})
+    props = data.get("properties", {})
+    assert "confidence_score" in props and "verified_by" in props and "sources" in props
+    assert "source_count" in props
 
 
 def test_openapi_patch_documents_federation_paths():
@@ -58,3 +85,13 @@ def test_openapi_patch_documents_federation_paths():
     paths = data.get("paths", {})
     assert "/api/v1/federation/export" in paths
     assert "/api/v1/federation/inbox" in paths
+
+
+def test_openapi_patch_documents_additive_locations_and_search_paths():
+    data = json.loads((_PROFILES / "openapi.json").read_text())
+    paths = data.get("paths", {})
+    assert "/api/v1/locations" in paths
+    assert "/api/v1/locations/{location_id}" in paths
+    assert "/api/v1/locations/search" in paths
+    assert "/api/v1/organizations/search" in paths
+    assert "/api/v1/services/search" in paths

--- a/tests/test_federation/test_profile_merge.py
+++ b/tests/test_federation/test_profile_merge.py
@@ -9,7 +9,10 @@ null-deletion) or replaces rather than extends. This module:
 1. pins a local ``merge_patch`` implementation against the vendored RFC 7386
    Appendix A vectors (external truth — constitution v1.7.0), then
 2. merges each real Profile patch over its base schema and asserts the merge
-   ADDS only the three profile fields and removes nothing.
+   ADDS only the expected PPR profile extension fields and removes nothing.
+3. cross-checks the declared ``sources[]`` item shape against the
+   ``SourceInfo`` Pydantic model so the Profile's declared shape can't drift
+   from what the read API actually serves.
 """
 
 import json
@@ -22,7 +25,17 @@ _CASES = json.loads((_VENDOR / "vectors.json").read_text(encoding="utf-8"))["cas
 
 _BASE = Path(__file__).resolve().parents[2] / "docs" / "HSDS" / "schema"
 _PROFILE = Path(__file__).resolve().parents[2] / "profiles" / "hsds-ppr"
-_PROFILE_FIELDS = {"confidence_score", "verified_by", "sources"}
+
+# Per-file expected sets of PPR profile extension properties. location.json
+# additionally carries `distance` (search-result metadata); the other three
+# entities share the uniform corroboration/provenance surface.
+_COMMON_PROFILE_FIELDS = {"confidence_score", "verified_by", "sources", "source_count"}
+_PROFILE_FIELDS_BY_FILE = {
+    "location.json": _COMMON_PROFILE_FIELDS | {"distance"},
+    "service.json": _COMMON_PROFILE_FIELDS,
+    "organization.json": _COMMON_PROFILE_FIELDS,
+    "service_at_location.json": _COMMON_PROFILE_FIELDS,
+}
 
 
 def merge_patch(target, patch):
@@ -64,6 +77,8 @@ def _has_none(obj) -> bool:
     [
         ("location.json", ["id", "location_type"]),
         ("service.json", ["id", "name", "status"]),
+        ("organization.json", ["id", "name", "description"]),
+        ("service_at_location.json", ["id"]),
     ],
 )
 def test_profile_patch_over_base_adds_only_profile_fields(name, base_required) -> None:
@@ -77,8 +92,9 @@ def test_profile_patch_over_base_adds_only_profile_fields(name, base_required) -
 
     # required is neither shrunk nor grown.
     assert merged.get("required") == base_required
-    # properties gain ONLY the three profile fields; none are removed.
-    assert set(merged["properties"]) == set(base["properties"]) | _PROFILE_FIELDS
+    # properties gain ONLY the expected profile fields for this entity; none removed.
+    expected_fields = _PROFILE_FIELDS_BY_FILE[name]
+    assert set(merged["properties"]) == set(base["properties"]) | expected_fields
     # every base property survives unchanged.
     for key, val in base["properties"].items():
         assert merged["properties"][key] == val
@@ -96,6 +112,38 @@ def test_openapi_patch_adds_only_federation_paths() -> None:
         "/api/v1/federation/inbox",
         "/api/v1/federation/history",
         "/api/v1/federation/actor",
+        "/api/v1/locations",
+        "/api/v1/locations/{location_id}",
+        "/api/v1/locations/search",
+        "/api/v1/organizations/search",
+        "/api/v1/services/search",
     }
     # No base path is dropped.
     assert set(base.get("paths", {})) <= set(merged.get("paths", {}))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "location.json",
+        "service.json",
+        "organization.json",
+        "service_at_location.json",
+    ],
+)
+def test_location_sources_items_match_source_info_model(name) -> None:
+    """The declared `sources[].items.properties` shape must equal the field set
+    of `app.models.hsds.response.SourceInfo` — the model the read API actually
+    uses to serialize `LocationResponse.sources`. This prevents the Profile's
+    declared shape from silently drifting from what is served (the original sin
+    of the array-of-strings `sources` this slice replaces). All four entity
+    files declare the same uniform `sources[]` shape, so this is pinned for
+    each of them."""
+    from app.models.hsds.response import SourceInfo
+
+    patch = json.loads((_PROFILE / name).read_text(encoding="utf-8"))
+    sources_schema = patch["properties"]["sources"]
+    assert sources_schema["type"] == "array"
+    item_props = set(sources_schema["items"]["properties"])
+
+    assert item_props == set(SourceInfo.model_fields)


### PR DESCRIPTION
Closes #595. Phase G of the HSDS full-compliance epic #584 (phase #585). Demo blocker. **Docs-only** (`profiles/hsds-ppr/` + its tests; no `app/` code).

## What
Make the PPR HSDS Profile (RFC 7386 merge patches over `docs/HSDS/schema/<entity>.json`) honestly declare every PPR extension key so a federating peer pinning export bytes (and the later X1/X2 leak tests) sees only **core-or-declared** keys.

- **`location.json`**: `sources` string→object (mirrors `SourceInfo`); +`source_count`; +`distance` (radius-search metadata).
- **`service.json`**: `sources`→object; +`source_count`.
- **`organization.json` + `service_at_location.json` (NEW)**: uniform `{confidence_score, verified_by, sources(object), source_count}` surface, forward-declared to unblock **X2** (org-graph export carries, not strips, org provenance).
- **`openapi.json`**: additive PPR endpoints not in HSDS core (`/api/v1/locations`, `/locations/{location_id}`, `/locations/search`, `/organizations/search`, `/services/search`).
- **`verified_by`**: `'network'` annotated as federation-corroborated provenance (operational with P2 Slice 3 / I1).
- **tests**: per-file expected-field sets, org/SAL merge cases, openapi allowlist, and a `SourceInfo`-shape drift guard parametrized over all 4 entity files.

## Honesty
Every declaration is true to the code. Fields not yet served (entity-level `confidence_score`/`verified_by`; `source_count` on org/service/SAL) are explicitly marked **"reserved / not currently served"** — they're forward-declared for the federation export surface (X1/X2), not claimed as emitted today. RFC 7386 invariants hold: optional-only, no `required` additions, no base property removed, no null deletion tokens.

## Decision on record
Kept the uniform forward-declared surface (**Reading 1** — entity extension surface) rather than trimming to served-only (**Reading 2**), because the owner-approved plan explicitly wants the org/SAL patches created now to unblock X2. Reversible (docs-only) if Reading 2 is later preferred.

## Machine review
Opus Gauntlet: Profile-honesty lens ∥ RFC-7386/merge+wiring lens ∥ full CI gate set. Merge/wiring lens clean; honesty lens found **2 HIGH + 1 MEDIUM** descriptions asserting served behavior the code lacks — all fixed red-first. Full pytest **5264 passed**; black/ruff/mypy clean; profile suite **37 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)