### PR TITLE
HSDS L1 — location core scalars (url + organization_id)

### DIFF
--- a/app/api/v1/locations.py
+++ b/app/api/v1/locations.py
@@ -248,6 +248,10 @@ async def list_locations(
                 "name": location.name,
                 "alternate_name": location.alternate_name,
                 "description": location.description,
+                "url": location.url,
+                "organization_id": (
+                    str(location.organization_id) if location.organization_id else None
+                ),
                 "latitude": float(location.latitude) if location.latitude else None,
                 "longitude": float(location.longitude) if location.longitude else None,
                 "transportation": location.transportation,
@@ -443,6 +447,10 @@ async def search_locations(
                 "name": location.name,
                 "alternate_name": location.alternate_name,
                 "description": location.description,
+                "url": location.url,
+                "organization_id": (
+                    str(location.organization_id) if location.organization_id else None
+                ),
                 "latitude": float(location.latitude) if location.latitude else None,
                 "longitude": float(location.longitude) if location.longitude else None,
                 "transportation": location.transportation,
@@ -551,6 +559,10 @@ async def get_location(
             "name": location.name,
             "alternate_name": location.alternate_name,
             "description": location.description,
+            "url": location.url,
+            "organization_id": (
+                str(location.organization_id) if location.organization_id else None
+            ),
             "latitude": float(location.latitude) if location.latitude else None,
             "longitude": float(location.longitude) if location.longitude else None,
             "transportation": location.transportation,

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -96,6 +96,7 @@ class LocationModel(Base):
         ForeignKey("organization.id"),
         nullable=True,
     )
+    url = Column(Text, nullable=True)
     name = Column(Text, nullable=True)
     alternate_name = Column(Text, nullable=True)
     description = Column(Text, nullable=True)

--- a/app/models/hsds/response.py
+++ b/app/models/hsds/response.py
@@ -254,9 +254,16 @@ class OrganizationResponse(BaseResponse):
 class LocationResponse(BaseResponse):
     """Response model for Location endpoints."""
 
+    organization_id: UUID | None = None
     name: str | None = None
     alternate_name: str | None = None
     description: str | None = None
+    # Plain string, NOT HttpUrl: HttpUrl normalizes "http://example.com" to
+    # "http://example.com/" (trailing slash), which would mutate served values
+    # and break the Tier-B byte round-trip. HSDS location.url is a plain URL
+    # string ("If location_type is virtual, then this field represents the URL
+    # of a virtual location.").
+    url: str | None = None
     latitude: float | None = None
     longitude: float | None = None
     transportation: str | None = None

--- a/tests/test_api/test_hsds_endpoints_integration.py
+++ b/tests/test_api/test_hsds_endpoints_integration.py
@@ -72,12 +72,12 @@ async def hsds_graph(db_session: AsyncSession):
         text(
             """
             INSERT INTO location (
-                id, organization_id, name, description,
+                id, organization_id, name, description, url,
                 latitude, longitude, location_type,
                 validation_status, confidence_score, is_canonical
             )
             VALUES (
-                :id, :org_id, :name, :desc,
+                :id, :org_id, :name, :desc, :url,
                 40.7128, -74.0060, 'physical',
                 'verified', 75, true
             )
@@ -88,6 +88,7 @@ async def hsds_graph(db_session: AsyncSession):
             "org_id": org_id,
             "name": "Manhattan Pantry",
             "desc": "Pantry location",
+            "url": "https://example.org/manhattan-pantry",
         },
     )
 
@@ -233,6 +234,64 @@ async def test_get_location_with_services(hsds_graph, db_session: AsyncSession):
     assert result.services is not None
     assert len(result.services) >= 1
     assert any(s.name == "Food Pantry" for s in result.services)
+
+
+@pytest.mark.asyncio
+async def test_get_location_includes_url_and_organization_id(
+    hsds_graph, db_session: AsyncSession
+):
+    """L1 (issue #597): LocationResponse must surface the HSDS-core `url` and
+    `organization_id` scalars that the DB already stores on `location`."""
+    from app.api.v1.locations import get_location
+
+    result = await get_location(
+        location_id=hsds_graph["location_id"],
+        include_services=False,
+        session=db_session,
+    )
+
+    assert result.url == "https://example.org/manhattan-pantry"
+    assert result.organization_id == hsds_graph["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_locations_includes_url_and_organization_id(
+    hsds_graph, db_session: AsyncSession
+):
+    """Same as above, but via the list endpoint's loc_dict fallback path."""
+    from fastapi import Request
+    from app.api.v1.locations import list_locations
+
+    class _StubURL:
+        def __init__(self, url: str):
+            self._url = url
+
+        def __str__(self) -> str:
+            return self._url
+
+        def include_query_params(self, **kwargs):
+            return self
+
+        def remove_query_params(self, key):
+            return self
+
+    class _StubRequest:
+        url = _StubURL("http://test/api/v1/locations")
+
+    page = await list_locations(
+        request=_StubRequest(),  # type: ignore[arg-type]
+        page=1,
+        per_page=10,
+        organization_id=None,
+        include_services=False,
+        session=db_session,
+    )
+
+    target = next(
+        loc for loc in page.data if str(loc.id) == str(hsds_graph["location_id"])
+    )
+    assert target.url == "https://example.org/manhattan-pantry"
+    assert target.organization_id == hsds_graph["org_id"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_federation/test_aggregate.py
+++ b/tests/test_federation/test_aggregate.py
@@ -250,6 +250,22 @@ def test_object_excludes_envelope_identity_fields(db_session) -> None:
         assert forbidden not in obj, f"{forbidden} leaked into the object"
 
 
+def test_object_excludes_url_and_organization_id(db_session) -> None:
+    """L1 (issue #597) added `url`/`organization_id` to LocationResponse, but
+    ``_LOCATION_SQL`` and the explicit ``LocationResponse(...)`` construction in
+    ``build_location_aggregate`` deliberately omit both — they stay None and are
+    dropped by ``exclude_none``, so the curated export object (and its signed
+    bytes) are UNCHANGED by L1. organization_id is set on the row to prove the
+    omission is deliberate (not merely "never set")."""
+    org_id = _insert_organization(db_session)
+    loc_id = _insert_location(db_session, organization_id=org_id)
+    obj = build_location_aggregate(db_session, loc_id)
+    assert "url" not in obj, "url leaked into the federation export object"
+    assert (
+        "organization_id" not in obj
+    ), "organization_id leaked into the federation export object"
+
+
 def test_two_distinct_schedules_not_collapsed(db_session) -> None:
     """Two distinct schedule rows must yield two schedules (spike Proof 2)."""
     loc_id = _insert_location(db_session)

--- a/tests/test_hsds_response_models.py
+++ b/tests/test_hsds_response_models.py
@@ -142,6 +142,31 @@ def test_location_response():
     assert location.metadata.last_updated == "2024-02-06T20:46:26Z"
 
 
+def test_location_response_url_and_organization_id():
+    """L1 (issue #597): `url` and `organization_id` are optional HSDS-core
+    location scalars, default to None, and `url` stays a plain string (no
+    HttpUrl trailing-slash normalization that would mutate served values and
+    break the Tier-B byte round-trip)."""
+    location_id = uuid4()
+    org_id = uuid4()
+
+    # Defaults: both None when not supplied.
+    bare = LocationResponse(id=location_id, name="Bare Location")
+    assert bare.url is None
+    assert bare.organization_id is None
+
+    # Accepted when supplied, and url is NOT mutated (no trailing slash added).
+    location = LocationResponse(
+        id=location_id,
+        name="Downtown Food Pantry",
+        url="http://example.com",
+        organization_id=org_id,
+    )
+    assert location.url == "http://example.com"
+    assert isinstance(location.url, str)
+    assert location.organization_id == org_id
+
+
 def test_service_at_location_response():
     """Test ServiceAtLocationResponse model validation."""
     service_id = uuid4()


### PR DESCRIPTION
Closes #597. Phase L of the HSDS full-compliance epic #584 (phase #587). Demo blocker.

## What
Add the two HSDS-core `location` scalars the DB already has but the model/serve dropped: **`url`** and **`organization_id`** (both are core properties of `docs/HSDS/schema/location.json`).

- **ORM** `LocationModel`: +`url` column (`organization_id` already mapped).
- **Pydantic** `LocationResponse`: +`url: str | None` (deliberately `str`, not `HttpUrl` — HttpUrl appends a trailing slash, mutating values + breaking the Tier-B round-trip) +`organization_id: UUID | None`.
- **Serve** `app/api/v1/locations.py`: both added to the three explicit `loc_dict` builders; the `model_validate(location)` ORM paths auto-populate.

## Invariants held (proven, not assumed)
- **Signed federation export byte-UNCHANGED**: `build_location_aggregate` constructs `LocationResponse` from a curated field list that omits these two, so they stay `None` and `exclude_none` drops them. `aggregate.py` untouched; new exclusion test + `test_coldstart_parity` green.
- **G1 conformance ratchet intact**: `location.json` still Tier-A xfails (still missing top-level languages/addresses/contacts/accessibility/phones — L2/L3/L5); manifest + `BASELINE=22` unchanged.

## Machine review
Opus Gauntlet (correctness/export-stability lens + full CI gate set): no HIGH/CRITICAL. Two LOW decisions on record (non-blocking): SAL/services location-embed fallbacks stay thin (that embed is A1's); `organization_id: UUID` against the `varchar(250)` column mirrors the existing `id: UUID` precedent (org ids are uuid4-minted). Full pytest **5268 passed**; coverage **59.01%** (RED-tier floors met); black/ruff/mypy/bandit/vulture/xenon clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)