### PR TITLE
HSDS L2 — address vertical (structured addresses[] on location)

### DIFF
--- a/app/api/v1/locations.py
+++ b/app/api/v1/locations.py
@@ -13,6 +13,7 @@ from app.database.models import LocationModel
 from app.models.hsds.location import Location
 from app.models.hsds.query import GeoBoundingBox, GeoPoint
 from app.models.hsds.response import (
+    Address,
     LocationResponse,
     ServiceResponse,
     Page,
@@ -118,6 +119,65 @@ async def get_location_schedules(
         schedules.append(schedule)
 
     return schedules
+
+
+async def get_location_addresses(
+    location_id: str, session: AsyncSession
+) -> list[Address]:
+    """Get structured HSDS addresses for a location via direct SQL query.
+
+    Args:
+        location_id: Location ID
+        session: Database session
+
+    Returns:
+        List of structured Address models. The `address` table NOT-NULLs
+        address_1/city/state_province/postal_code/country/address_type
+        (init-scripts/01-hsds-schema.sql), so every row satisfies Address's
+        required fields.
+    """
+    address_query = """
+        SELECT
+            id,
+            location_id,
+            attention,
+            address_1,
+            address_2,
+            city,
+            region,
+            state_province,
+            postal_code,
+            country,
+            address_type
+        FROM address
+        WHERE location_id = :location_id
+        ORDER BY id
+    """
+
+    result = await session.execute(
+        text(address_query), {"location_id": str(location_id)}
+    )
+    rows = result.fetchall()
+
+    addresses = []
+    for row in rows:
+        addresses.append(
+            Address(
+                id=row.id,
+                location_id=row.location_id,
+                attention=row.attention,
+                address_1=row.address_1,
+                address_2=row.address_2,
+                city=row.city,
+                region=row.region,
+                state_province=row.state_province,
+                postal_code=row.postal_code,
+                country=row.country,
+                address_type=row.address_type,
+            )
+        )
+
+    return addresses
 
 
 async def get_location_sources(
@@ -278,6 +338,11 @@ async def list_locations(
         schedules = await get_location_schedules(str(location.id), session)
         if schedules:
             location_data.schedules = schedules[:5]  # Limit to 5 schedules per location
+
+        # Add structured addresses information via direct SQL query
+        addresses = await get_location_addresses(str(location.id), session)
+        if addresses:
+            location_data.addresses = addresses
 
         if include_services and location.services_at_location:
             location_data.services = [
@@ -478,6 +543,11 @@ async def search_locations(
         if schedules:
             location_data.schedules = schedules[:5]  # Limit to 5 schedules per location
 
+        # Add structured addresses information via direct SQL query
+        addresses = await get_location_addresses(str(location.id), session)
+        if addresses:
+            location_data.addresses = addresses
+
         # Add distance information for radius searches
         if (
             latitude is not None
@@ -589,6 +659,11 @@ async def get_location(
     schedules = await get_location_schedules(str(location.id), session)
     if schedules:
         location_response.schedules = schedules
+
+    # Add structured addresses information via direct SQL query
+    addresses = await get_location_addresses(str(location.id), session)
+    if addresses:
+        location_response.addresses = addresses
 
     if include_services:
         # Load services at this location. Build shallow dicts so Pydantic never

--- a/app/models/hsds/response.py
+++ b/app/models/hsds/response.py
@@ -251,6 +251,35 @@ class OrganizationResponse(BaseResponse):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
+class Address(HSDSBaseModel):
+    """Structured HSDS address, nested under a Location's ``addresses[]``.
+
+    Required fields mirror BOTH the HSDS ``address.json`` schema's
+    ``required`` list and the ``address`` table's NOT NULL columns
+    (``app/database/models.py::AddressModel``), so a row served from the DB
+    always satisfies this model. ``attributes``/``metadata`` are out of scope
+    (T2).
+    """
+
+    address_1: str = Field(..., description="Address line 1")
+    city: str = Field(..., description="City")
+    state_province: str = Field(..., description="State or province")
+    postal_code: str = Field(..., description="Postal code")
+    country: str = Field(..., description="Country (ISO 3166-1 alpha-2)")
+    address_type: str = Field(
+        ..., description="Address type (physical, postal, or virtual)"
+    )
+
+    attention: str | None = Field(None, description="Attention line")
+    address_2: str | None = Field(None, description="Address line 2")
+    region: str | None = Field(None, description="Region")
+    location_id: UUID | None = Field(
+        None, description="Identifier of the location this address belongs to"
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class LocationResponse(BaseResponse):
     """Response model for Location endpoints."""
 
@@ -275,6 +304,7 @@ class LocationResponse(BaseResponse):
     sources: list[SourceInfo] | None = None  # Source-specific data
     source_count: int = Field(1, description="Number of sources for this location")
     schedules: list[ScheduleInfo] | None = None  # Schedule information
+    addresses: list[Address] | None = None  # Structured HSDS addresses
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/test_api/test_hsds_endpoints_integration.py
+++ b/tests/test_api/test_hsds_endpoints_integration.py
@@ -107,6 +107,35 @@ async def hsds_graph(db_session: AsyncSession):
         },
     )
 
+    address_id = str(uuid.uuid4())
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO address (
+                id, location_id, attention, address_1, address_2, city,
+                region, state_province, postal_code, country, address_type
+            )
+            VALUES (
+                :id, :loc, :attention, :address_1, :address_2, :city,
+                :region, :state_province, :postal_code, :country, :address_type
+            )
+            """
+        ),
+        {
+            "id": address_id,
+            "loc": location_id,
+            "attention": "Front Desk",
+            "address_1": "123 Main St",
+            "address_2": "Suite 100",
+            "city": "New York",
+            "region": "Manhattan",
+            "state_province": "NY",
+            "postal_code": "10001",
+            "country": "US",
+            "address_type": "physical",
+        },
+    )
+
     await db_session.flush()
 
     return {
@@ -114,6 +143,7 @@ async def hsds_graph(db_session: AsyncSession):
         "service_id": uuid.UUID(service_id),
         "location_id": uuid.UUID(location_id),
         "sal_id": uuid.UUID(sal_id),
+        "address_id": uuid.UUID(address_id),
     }
 
 
@@ -292,6 +322,72 @@ async def test_list_locations_includes_url_and_organization_id(
     )
     assert target.url == "https://example.org/manhattan-pantry"
     assert target.organization_id == hsds_graph["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_location_includes_addresses(hsds_graph, db_session: AsyncSession):
+    """L2 (issue #599): GET /locations/{id} must nest the structured
+    `addresses[]` from the `address` table."""
+    from app.api.v1.locations import get_location
+
+    result = await get_location(
+        location_id=hsds_graph["location_id"],
+        include_services=False,
+        session=db_session,
+    )
+
+    assert result.addresses is not None
+    assert len(result.addresses) == 1
+    address = result.addresses[0]
+    assert address.id == hsds_graph["address_id"]
+    assert address.attention == "Front Desk"
+    assert address.address_1 == "123 Main St"
+    assert address.address_2 == "Suite 100"
+    assert address.city == "New York"
+    assert address.region == "Manhattan"
+    assert address.state_province == "NY"
+    assert address.postal_code == "10001"
+    assert address.country == "US"
+    assert address.address_type == "physical"
+
+
+@pytest.mark.asyncio
+async def test_list_locations_includes_addresses(hsds_graph, db_session: AsyncSession):
+    """Same as above, but via the list endpoint."""
+    from fastapi import Request
+    from app.api.v1.locations import list_locations
+
+    class _StubURL:
+        def __init__(self, url: str):
+            self._url = url
+
+        def __str__(self) -> str:
+            return self._url
+
+        def include_query_params(self, **kwargs):
+            return self
+
+        def remove_query_params(self, key):
+            return self
+
+    class _StubRequest:
+        url = _StubURL("http://test/api/v1/locations")
+
+    page = await list_locations(
+        request=_StubRequest(),  # type: ignore[arg-type]
+        page=1,
+        per_page=10,
+        organization_id=None,
+        include_services=False,
+        session=db_session,
+    )
+
+    target = next(
+        loc for loc in page.data if str(loc.id) == str(hsds_graph["location_id"])
+    )
+    assert target.addresses is not None
+    assert len(target.addresses) == 1
+    assert target.addresses[0].address_1 == "123 Main St"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_integration_simple.py
+++ b/tests/test_api_integration_simple.py
@@ -170,6 +170,7 @@ class TestOrganizationsAPI:
 class TestLocationsAPI:
     """Test locations API endpoints."""
 
+    @patch("app.api.v1.locations.get_location_addresses")
     @patch("app.api.v1.locations.get_location_schedules")
     @patch("app.api.v1.locations.get_location_sources")
     @patch("app.api.v1.locations.LocationRepository")
@@ -178,6 +179,7 @@ class TestLocationsAPI:
         mock_repo_class,
         mock_get_sources,
         mock_get_schedules,
+        mock_get_addresses,
         client,
         mock_location,
     ):
@@ -191,6 +193,7 @@ class TestLocationsAPI:
         # Mock helper functions to return empty lists
         mock_get_sources.return_value = []
         mock_get_schedules.return_value = []
+        mock_get_addresses.return_value = []
 
         response = client.get("/api/v1/locations/")
 
@@ -199,6 +202,7 @@ class TestLocationsAPI:
         assert "data" in data
         assert "count" in data
 
+    @patch("app.api.v1.locations.get_location_addresses")
     @patch("app.api.v1.locations.get_location_schedules")
     @patch("app.api.v1.locations.get_location_sources")
     @patch("app.api.v1.locations.LocationRepository")
@@ -207,6 +211,7 @@ class TestLocationsAPI:
         mock_repo_class,
         mock_get_sources,
         mock_get_schedules,
+        mock_get_addresses,
         client,
         mock_location,
     ):
@@ -220,12 +225,14 @@ class TestLocationsAPI:
         # Mock helper functions to return empty lists
         mock_get_sources.return_value = []
         mock_get_schedules.return_value = []
+        mock_get_addresses.return_value = []
 
         org_id = str(uuid.uuid4())
         response = client.get(f"/api/v1/locations/?organization_id={org_id}")
 
         assert response.status_code == 200
 
+    @patch("app.api.v1.locations.get_location_addresses")
     @patch("app.api.v1.locations.get_location_schedules")
     @patch("app.api.v1.locations.get_location_sources")
     @patch("app.api.v1.locations.LocationRepository")
@@ -234,6 +241,7 @@ class TestLocationsAPI:
         mock_repo_class,
         mock_get_sources,
         mock_get_schedules,
+        mock_get_addresses,
         client,
         mock_location,
     ):
@@ -247,6 +255,7 @@ class TestLocationsAPI:
         # Mock helper functions to return empty lists
         mock_get_sources.return_value = []
         mock_get_schedules.return_value = []
+        mock_get_addresses.return_value = []
 
         response = client.get(
             "/api/v1/locations/search?latitude=40.7128&longitude=-74.0060&radius_miles=10"
@@ -254,6 +263,7 @@ class TestLocationsAPI:
 
         assert response.status_code == 200
 
+    @patch("app.api.v1.locations.get_location_addresses")
     @patch("app.api.v1.locations.get_location_schedules")
     @patch("app.api.v1.locations.get_location_sources")
     @patch("app.api.v1.locations.LocationRepository")
@@ -262,6 +272,7 @@ class TestLocationsAPI:
         mock_repo_class,
         mock_get_sources,
         mock_get_schedules,
+        mock_get_addresses,
         client,
         mock_location,
     ):
@@ -275,6 +286,7 @@ class TestLocationsAPI:
         # Mock helper functions to return empty lists
         mock_get_sources.return_value = []
         mock_get_schedules.return_value = []
+        mock_get_addresses.return_value = []
 
         response = client.get(
             "/api/v1/locations/search?min_latitude=40.7&max_latitude=40.8&min_longitude=-74.1&max_longitude=-74.0"
@@ -282,6 +294,7 @@ class TestLocationsAPI:
 
         assert response.status_code == 200
 
+    @patch("app.api.v1.locations.get_location_addresses")
     @patch("app.api.v1.locations.get_location_schedules")
     @patch("app.api.v1.locations.get_location_sources")
     @patch("app.api.v1.locations.LocationRepository")
@@ -290,6 +303,7 @@ class TestLocationsAPI:
         mock_repo_class,
         mock_get_sources,
         mock_get_schedules,
+        mock_get_addresses,
         client,
         mock_location,
     ):
@@ -302,6 +316,7 @@ class TestLocationsAPI:
         # Mock helper functions to return empty lists
         mock_get_sources.return_value = []
         mock_get_schedules.return_value = []
+        mock_get_addresses.return_value = []
 
         location_id = str(mock_location.id)
         response = client.get(f"/api/v1/locations/{location_id}")

--- a/tests/test_federation/test_aggregate.py
+++ b/tests/test_federation/test_aggregate.py
@@ -266,6 +266,20 @@ def test_object_excludes_url_and_organization_id(db_session) -> None:
     ), "organization_id leaked into the federation export object"
 
 
+def test_object_excludes_addresses(db_session) -> None:
+    """L2 (issue #599) added a structured `addresses[]` field to
+    LocationResponse, but ``_LOCATION_SQL`` and the explicit
+    ``LocationResponse(...)`` construction in ``build_location_aggregate``
+    deliberately omit it — it stays None and is dropped by ``exclude_none``,
+    so the curated export object (and its signed bytes) are UNCHANGED by L2.
+    An `address` row is inserted to prove the omission is deliberate (not
+    merely "never set")."""
+    loc_id = _insert_location(db_session)
+    _insert_address(db_session, loc_id, address_1="100 Main St")
+    obj = build_location_aggregate(db_session, loc_id)
+    assert "addresses" not in obj, "addresses leaked into the federation export object"
+
+
 def test_two_distinct_schedules_not_collapsed(db_session) -> None:
     """Two distinct schedule rows must yield two schedules (spike Proof 2)."""
     loc_id = _insert_location(db_session)

--- a/tests/test_hsds_response_models.py
+++ b/tests/test_hsds_response_models.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from app.models.hsds.response import (
+    Address,
     LocationResponse,
     MetadataResponse,
     OrganizationResponse,
@@ -165,6 +166,153 @@ def test_location_response_url_and_organization_id():
     assert location.url == "http://example.com"
     assert isinstance(location.url, str)
     assert location.organization_id == org_id
+
+
+def test_address_model_required_fields():
+    """L2 (issue #599): `Address` enforces the HSDS-required scalars
+    (address_1, city, state_province, postal_code, country, address_type)."""
+    address_id = uuid4()
+
+    address = Address(
+        id=address_id,
+        address_1="123 Main St",
+        city="Anytown",
+        state_province="NY",
+        postal_code="10001",
+        country="US",
+        address_type="physical",
+    )
+    assert address.id == address_id
+    assert address.address_1 == "123 Main St"
+    assert address.city == "Anytown"
+    assert address.state_province == "NY"
+    assert address.postal_code == "10001"
+    assert address.country == "US"
+    assert address.address_type == "physical"
+
+    # Optional fields default to None when not supplied.
+    assert address.attention is None
+    assert address.address_2 is None
+    assert address.region is None
+    assert address.location_id is None
+
+    # Missing a required field (address_1) raises.
+    with pytest.raises(ValidationError):
+        Address(
+            id=uuid4(),
+            city="Anytown",
+            state_province="NY",
+            postal_code="10001",
+            country="US",
+            address_type="physical",
+        )
+
+
+def test_address_model_optional_fields():
+    """Optional Address fields (attention, address_2, region, location_id) are
+    accepted when supplied."""
+    address_id = uuid4()
+    location_id = uuid4()
+
+    address = Address(
+        id=address_id,
+        location_id=location_id,
+        attention="A. Persona",
+        address_1="1-30 Main Street",
+        address_2="MyVillage",
+        city="MyCity",
+        region="MyRegion",
+        state_province="MyState",
+        postal_code="ABC 1234",
+        country="US",
+        address_type="postal",
+    )
+    assert address.location_id == location_id
+    assert address.attention == "A. Persona"
+    assert address.address_2 == "MyVillage"
+    assert address.region == "MyRegion"
+
+
+def test_address_model_validates_official_example():
+    """The official HSDS `location.json` example's `addresses[0]` dict
+    (no `location_id`, no `attributes`/`metadata`) must `model_validate`
+    cleanly against `Address` (Tier-A progress on the address sub-shape)."""
+    example_address = {
+        "id": "74706e55-df26-4b84-80fe-ecc30b5befb4",
+        "attention": "A. Persona",
+        "address_1": "1-30 Main Street",
+        "address_2": "MyVillage",
+        "city": "MyCity",
+        "region": "MyRegion",
+        "state_province": "MyState",
+        "postal_code": "ABC 1234",
+        "country": "US",
+        "address_type": "postal",
+    }
+    address = Address.model_validate(example_address)
+    assert str(address.id) == example_address["id"]
+    assert address.attention == "A. Persona"
+    assert address.address_1 == "1-30 Main Street"
+    assert address.address_2 == "MyVillage"
+    assert address.city == "MyCity"
+    assert address.region == "MyRegion"
+    assert address.state_province == "MyState"
+    assert address.postal_code == "ABC 1234"
+    assert address.country == "US"
+    assert address.address_type == "postal"
+
+
+def test_address_model_jcs_round_trip_with_official_example():
+    """`Address` validated from the official example round-trips byte-equal
+    via `app.federation.canonical.jcs_bytes` after `model_dump(mode="json",
+    exclude_none=True)` (no location_id/attributes/metadata leak in)."""
+    from app.federation.canonical import jcs_bytes
+
+    example_address = {
+        "id": "74706e55-df26-4b84-80fe-ecc30b5befb4",
+        "attention": "A. Persona",
+        "address_1": "1-30 Main Street",
+        "address_2": "MyVillage",
+        "city": "MyCity",
+        "region": "MyRegion",
+        "state_province": "MyState",
+        "postal_code": "ABC 1234",
+        "country": "US",
+        "address_type": "postal",
+    }
+    address = Address.model_validate(example_address)
+    dumped = address.model_dump(mode="json", exclude_none=True)
+    assert dumped == example_address
+    # Byte-for-byte round trip: re-canonicalizing the dump is idempotent.
+    assert jcs_bytes(dumped) == jcs_bytes(example_address)
+
+
+def test_location_response_addresses_field():
+    """L2 (issue #599): `LocationResponse.addresses` defaults to None and
+    accepts a list of `Address` models."""
+    location_id = uuid4()
+
+    bare = LocationResponse(id=location_id, name="Bare Location")
+    assert bare.addresses is None
+
+    address = Address(
+        id=uuid4(),
+        location_id=location_id,
+        address_1="123 Main St",
+        city="Anytown",
+        state_province="NY",
+        postal_code="10001",
+        country="US",
+        address_type="physical",
+    )
+    location = LocationResponse(
+        id=location_id,
+        name="Downtown Food Pantry",
+        addresses=[address],
+    )
+    assert location.addresses is not None
+    assert len(location.addresses) == 1
+    assert location.addresses[0].address_1 == "123 Main St"
 
 
 def test_service_at_location_response():

--- a/tests/test_locations_direct_coverage.py
+++ b/tests/test_locations_direct_coverage.py
@@ -34,7 +34,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -52,6 +54,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {
@@ -122,7 +125,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -141,6 +146,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {
@@ -206,7 +212,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -224,6 +232,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {
@@ -292,7 +301,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -308,6 +319,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {
@@ -366,7 +378,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -383,6 +397,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {
@@ -453,7 +468,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -468,6 +485,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock session
             mock_session = AsyncMock()
@@ -529,7 +547,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repositories
             mock_repo = AsyncMock()
@@ -545,6 +565,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock service at location. The handler now builds a shallow dict
             # from the ORM (no nested relationship traversal) before validating,
@@ -609,7 +630,9 @@ class TestLocationsDirectExecution:
             "app.api.v1.locations.get_location_sources"
         ) as mock_get_sources, patch(
             "app.api.v1.locations.get_location_schedules"
-        ) as mock_get_schedules:
+        ) as mock_get_schedules, patch(
+            "app.api.v1.locations.get_location_addresses"
+        ) as mock_get_addresses:
 
             # Mock repository
             mock_repo = AsyncMock()
@@ -628,6 +651,7 @@ class TestLocationsDirectExecution:
             # Mock async helper functions to return empty lists
             mock_get_sources.return_value = []
             mock_get_schedules.return_value = []
+            mock_get_addresses.return_value = []
 
             # Mock utilities
             mock_calc_meta.return_value = {


### PR DESCRIPTION
Closes #599. Phase L of the HSDS full-compliance epic #584 (phase #587). Demo blocker. "Most user-visible gap" — no structured address appeared in any HSDS location response before.

## What
- **Pydantic `Address`** (full HSDS 3.1.1 scalar set): required `[address_1, city, state_province, postal_code, country, address_type]` (= the DB NOT-NULL set, so no 500 risk), optional `attention/address_2/region/location_id`. No `attributes`/`metadata` (T2).
- **`LocationResponse.addresses: list[Address] | None`** nested.
- **Serve**: new `get_location_addresses` helper (param-bound SQL, deterministic order; mirrors `get_location_sources`) wired into all three location paths.

## Invariants held (proven)
- **Federation export byte-UNCHANGED**: `build_location_aggregate` constructs `LocationResponse` without `addresses` → None → `exclude_none` drops it (structured addresses enter the signed export at X1). `aggregate.py` untouched; exclusion test + coldstart parity green.
- **G1 conformance ratchet intact**: `location.json` still Tier-A xfails (still missing top-level languages/contacts/accessibility/phones — L3/L5/L6); manifest + `BASELINE=22` unchanged. New tests prove the `Address` model validates + JCS-round-trips the official `addresses[0]`.

## Test-mock remediation
L2's new query broke 13 mock-based location-handler tests (`test_locations_direct_coverage.py` ×8, `test_api_integration_simple.py` ×5) that patched the sibling helpers but not the new one — **app code is correct**; the tests now patch `get_location_addresses`. Caught by the full-suite completeness run, not the narrower lens (the "Gauntlet must run the whole CI gate set" lesson).

## Machine review
Opus Gauntlet (correctness/export-stability lens + full CI gate set): no HIGH/CRITICAL. Two LOW on record (non-blocking): per-row sources/schedules/addresses loads are an existing N+1 (project-wide batch refactor is a future follow-up); SAL/services location embed stays thin (A1-owned). Full pytest **5276 passed**; coverage **59.03%** (RED-tier floors met); black/ruff/mypy/bandit/vulture/xenon clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)